### PR TITLE
Improve sampling efficiency and fix combined menu-bar layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Combined menu bar dual-rate layout:** Disk and Network Focus/Strip readouts no
+  longer overlap their down/up figures. Stacked rates use matched compact fonts and
+  a shared half-height layout, and sit on the same 22pt band as other strip cells.
+- **Strip caption cells:** RAM, CPU, and GPU titles sit higher with larger medium-weight
+  values, so the strip stays even without the over-bold look that clashed with
+  Disk/Network rates.
+
+### Changed
+
+- **Sampling hot path:** `RingBuffer.elements()` returns a chronological collection
+  view instead of copying a full array each read. Bundle IDs are cached by `.app`
+  path so helpers sharing one bundle do not each re-read `Info.plist` on first sight.
+
 ## [1.3.2] - 2026-07-10
 
 ### Added

--- a/Sources/MacPerfMonitor/App/CombinedMenuBarImage.swift
+++ b/Sources/MacPerfMonitor/App/CombinedMenuBarImage.swift
@@ -75,6 +75,10 @@ enum CombinedMenuBarReadouts {
 @MainActor
 enum CombinedMenuBarImage {
     private static let stripSeparatorWidth: CGFloat = 1.5
+    /// Shared menu-bar item height so Focus and Strip cells align.
+    private static let itemHeight: CGFloat = 22
+    /// Matched figure size for every two-line cell (caption+value and ↓/↑).
+    private static let stackedFigureSize: CGFloat = 9.5
 
     static func image(
         readouts: [CombinedMenuBarReadout], presentation: MenuBarPresentation
@@ -125,58 +129,47 @@ enum CombinedMenuBarImage {
             font: MenuBarReadoutImage.valueFont(size: 8, weight: .semibold), color: color)
         let hasDirectionalValues = readout.secondaryValue != nil
         let labelWidth: CGFloat = hasDirectionalValues ? 14 : ceil(label.size().width)
-        let valueFont = MenuBarReadoutImage.valueFont(
-            size: readout.secondaryValue == nil ? 13 * 1.05 : 13 * 0.95, weight: .bold)
-        let primary =
-            readout.secondaryValue == nil
-            ? attributed(readout.value, font: valueFont, color: color)
-            : directionalAttributed(
-                readout.value, figureFont: valueFont,
-                arrowFont: MenuBarReadoutImage.valueFont(size: 13, weight: .medium),
-                color: color)
-        let secondary = readout.secondaryValue.map {
-            directionalAttributed(
-                $0, figureFont: MenuBarReadoutImage.valueFont(size: 10.5 * 0.95, weight: .bold),
-                arrowFont: MenuBarReadoutImage.valueFont(size: 10.5, weight: .medium),
-                color: color)
-        }
-        let networkSample = readout.secondaryValue.map { _ in
-            directionalAttributed(
-                "999M↓", figureFont: valueFont,
-                arrowFont: MenuBarReadoutImage.valueFont(size: 13, weight: .medium),
-                color: color)
-        }
-        let gap: CGFloat = 4
-        let valuesWidth = ceil(
-            max(
-                primary.size().width, secondary?.size().width ?? 0, networkSample?.size().width ?? 0
-            ))
-        let width = labelWidth + gap + valuesWidth + 1
-        let height: CGFloat = secondary == nil ? 20 : 22
+        let gap: CGFloat = hasDirectionalValues ? 5 : 4
 
-        return MenuBarReadoutImage.render(width: width, height: height) { size in
-            if hasDirectionalValues {
+        if let secondaryValue = readout.secondaryValue {
+            let figureFont = MenuBarReadoutImage.valueFont(
+                size: stackedFigureSize, weight: .bold)
+            let arrowFont = MenuBarReadoutImage.valueFont(
+                size: stackedFigureSize, weight: .medium)
+            let primary = directionalAttributed(
+                readout.value, figureFont: figureFont, arrowFont: arrowFont, color: color)
+            let secondary = directionalAttributed(
+                secondaryValue, figureFont: figureFont, arrowFont: arrowFont, color: color)
+            let sample = directionalAttributed(
+                "999M↓", figureFont: figureFont, arrowFont: arrowFont, color: color)
+            let valuesWidth = ceil(
+                max(primary.size().width, secondary.size().width, sample.size().width))
+            let width = labelWidth + gap + valuesWidth + 1
+
+            return MenuBarReadoutImage.render(width: width, height: itemHeight) { size in
                 drawSymbol(
                     readout.metric.symbolName,
                     in: NSRect(x: 0, y: (size.height - 13) / 2, width: 13, height: 13),
                     color: color, pointSize: 11)
-            } else {
-                label.draw(at: NSPoint(x: 0, y: (size.height - label.size().height) / 2))
+                drawStackedLines(
+                    top: primary, bottom: secondary,
+                    topX: labelWidth + gap + valuesWidth - primary.size().width,
+                    bottomX: labelWidth + gap + valuesWidth - secondary.size().width,
+                    height: size.height)
             }
-            let valueX = labelWidth + gap
-            if let secondary {
-                primary.draw(
-                    at: NSPoint(
-                        x: valueX + valuesWidth - primary.size().width,
-                        y: size.height - primary.size().height))
-                secondary.draw(
-                    at: NSPoint(x: valueX + valuesWidth - secondary.size().width, y: 0))
-            } else {
-                primary.draw(
-                    at: NSPoint(
-                        x: valueX,
-                        y: (size.height - primary.size().height) / 2))
-            }
+        }
+
+        let valueFont = MenuBarReadoutImage.valueFont(size: 13 * 1.05, weight: .bold)
+        let primary = attributed(readout.value, font: valueFont, color: color)
+        let valuesWidth = ceil(primary.size().width)
+        let width = labelWidth + gap + valuesWidth + 1
+
+        return MenuBarReadoutImage.render(width: width, height: itemHeight) { size in
+            label.draw(at: NSPoint(x: 0, y: (size.height - label.size().height) / 2))
+            primary.draw(
+                at: NSPoint(
+                    x: labelWidth + gap,
+                    y: (size.height - primary.size().height) / 2))
         }
     }
 
@@ -186,9 +179,8 @@ enum CombinedMenuBarImage {
             layouts.reduce(0) { $0 + $1.width }
             + stripSeparatorWidth * CGFloat(max(0, layouts.count - 1))
         let width = contentWidth
-        let height: CGFloat = 22
 
-        return MenuBarReadoutImage.render(width: width, height: height) { size in
+        return MenuBarReadoutImage.render(width: width, height: itemHeight) { size in
             var x: CGFloat = 0
             for (index, layout) in layouts.enumerated() {
                 layout.draw(at: x, height: size.height)
@@ -209,8 +201,10 @@ enum CombinedMenuBarImage {
         let color = NSColor.black
         if let secondary = readout.secondaryValue {
             let labelWidth: CGFloat = 14
-            let figureFont = MenuBarReadoutImage.valueFont(size: 10 * 0.95, weight: .bold)
-            let arrowFont = MenuBarReadoutImage.valueFont(size: 10, weight: .medium)
+            let figureFont = MenuBarReadoutImage.valueFont(
+                size: stackedFigureSize, weight: .bold)
+            let arrowFont = MenuBarReadoutImage.valueFont(
+                size: stackedFigureSize, weight: .medium)
             let top = directionalAttributed(
                 readout.value, figureFont: figureFont, arrowFont: arrowFont, color: color)
             let bottom = directionalAttributed(
@@ -218,23 +212,27 @@ enum CombinedMenuBarImage {
             let sample = directionalAttributed(
                 "999M↓", figureFont: figureFont, arrowFont: arrowFont, color: color)
             let figuresWidth = ceil(max(top.size().width, bottom.size().width, sample.size().width))
-            let gap: CGFloat = 2
+            let gap: CGFloat = 5
             let width = labelWidth + gap + figuresWidth + 1
             return CellLayout(width: width) { x, height in
                 drawSymbol(
                     readout.metric.symbolName,
                     in: NSRect(x: x, y: (height - 13) / 2, width: 13, height: 13),
                     color: color, pointSize: 11)
-                top.draw(
-                    at: NSPoint(x: x + width - top.size().width, y: height - top.size().height))
-                bottom.draw(at: NSPoint(x: x + width - bottom.size().width, y: 0))
+                drawStackedLines(
+                    top: top, bottom: bottom,
+                    topX: x + labelWidth + gap + figuresWidth - top.size().width,
+                    bottomX: x + labelWidth + gap + figuresWidth - bottom.size().width,
+                    height: height)
             }
         }
 
         let label = attributed(
             readout.metric.shortTitle,
             font: MenuBarReadoutImage.valueFont(size: 7, weight: .semibold), color: color)
-        let font = MenuBarReadoutImage.valueFont(size: 11.5 * 1.05, weight: .bold)
+        // Larger value than the ↓/↑ figures; label pins to the top so the
+        // caption sits higher while the cell still shares `itemHeight`.
+        let font = MenuBarReadoutImage.valueFont(size: 12.5, weight: .bold)
         let compactValue =
             readout.value.hasSuffix("%") ? String(readout.value.dropLast()) : readout.value
         let value = attributed(compactValue, font: font, color: color)
@@ -245,9 +243,30 @@ enum CombinedMenuBarImage {
             label.draw(
                 at: NSPoint(
                     x: x + (width - label.size().width) / 2,
-                    y: height - label.size().height))
-            value.draw(at: NSPoint(x: x + (width - value.size().width) / 2, y: 0))
+                    y: height - label.size().height + 1))
+            value.draw(
+                at: NSPoint(
+                    x: x + (width - value.size().width) / 2,
+                    y: 0))
         }
+    }
+
+    /// Two-line column with a shared midline: top row sits in the upper half,
+    /// bottom row in the lower half. Used by both caption+value and ↓/↑ cells
+    /// so Strip (and Focus dual) heights read as one band.
+    private static func drawStackedLines(
+        top: NSAttributedString, bottom: NSAttributedString,
+        topX: CGFloat, bottomX: CGFloat, height: CGFloat
+    ) {
+        let rowH = height / 2
+        top.draw(
+            at: NSPoint(
+                x: topX,
+                y: rowH + max(0, (rowH - top.size().height) / 2)))
+        bottom.draw(
+            at: NSPoint(
+                x: bottomX,
+                y: max(0, (rowH - bottom.size().height) / 2)))
     }
 
     private static func attributed(

--- a/Sources/MacPerfMonitor/App/CombinedMenuBarImage.swift
+++ b/Sources/MacPerfMonitor/App/CombinedMenuBarImage.swift
@@ -230,9 +230,9 @@ enum CombinedMenuBarImage {
         let label = attributed(
             readout.metric.shortTitle,
             font: MenuBarReadoutImage.valueFont(size: 7, weight: .semibold), color: color)
-        // Larger value than the ↓/↑ figures; label pins to the top so the
-        // caption sits higher while the cell still shares `itemHeight`.
-        let font = MenuBarReadoutImage.valueFont(size: 12.5, weight: .bold)
+        // Larger value than the ↓/↑ figures, medium weight (not bold) so the
+        // strip matches Disk/Network visually; label pins to the top.
+        let font = MenuBarReadoutImage.valueFont(size: 12.5, weight: .medium)
         let compactValue =
             readout.value.hasSuffix("%") ? String(readout.value.dropLast()) : readout.value
         let value = attributed(compactValue, font: font, color: color)

--- a/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
+++ b/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
@@ -313,7 +313,11 @@ extension Notification.Name {
 
 /// Owns the single `SamplerModel` and starts sampling at launch, so the menubar
 /// is live even before any window is opened.
-final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
+///
+/// Main-actor isolated: NSApplicationDelegate callbacks already run on the main
+/// thread, and several owned stores (e.g. `ProcessGroupStore`) are `@MainActor`.
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotificationCenterDelegate {
     let model = SamplerModel()
     let appModeManager = AppModeManager()
     let alertSettings = AlertSettings()

--- a/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
+++ b/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
@@ -317,7 +317,9 @@ extension Notification.Name {
 /// Main-actor isolated: NSApplicationDelegate callbacks already run on the main
 /// thread, and several owned stores (e.g. `ProcessGroupStore`) are `@MainActor`.
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotificationCenterDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate,
+    @preconcurrency UNUserNotificationCenterDelegate
+{
     let model = SamplerModel()
     let appModeManager = AppModeManager()
     let alertSettings = AlertSettings()

--- a/Sources/MacPerfMonitorCore/Sampling/BundleIDCache.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/BundleIDCache.swift
@@ -9,7 +9,9 @@ public struct BundleIDCache {
     private var cache: [String: String?] = [:]
     private let readPlist: (String) -> String?
 
-    public init(readPlist: @escaping (String) -> String? = BundleIDCache.readBundleID(fromAppBundle:)) {
+    public init(
+        readPlist: @escaping (String) -> String? = BundleIDCache.readBundleID(fromAppBundle:)
+    ) {
         self.readPlist = readPlist
     }
 

--- a/Sources/MacPerfMonitorCore/Sampling/BundleIDCache.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/BundleIDCache.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Resolves `CFBundleIdentifier` from an executable path inside a `.app`
+/// bundle, caching by app-bundle path so helpers that share one `.app` do not
+/// re-read `Info.plist` on every first sighting.
+///
+/// Non-`.app` paths return nil without touching the filesystem.
+public struct BundleIDCache {
+    private var cache: [String: String?] = [:]
+    private let readPlist: (String) -> String?
+
+    public init(readPlist: @escaping (String) -> String? = BundleIDCache.readBundleID(fromAppBundle:)) {
+        self.readPlist = readPlist
+    }
+
+    /// Derive a best-effort bundle identifier from an executable path.
+    public mutating func bundleID(fromExecutablePath path: String?) -> String? {
+        guard let path, let appBundlePath = Self.appBundlePath(fromExecutablePath: path) else {
+            return nil
+        }
+        if let entry = cache.index(forKey: appBundlePath) {
+            return cache[entry].value
+        }
+        let id = readPlist(appBundlePath)
+        cache[appBundlePath] = id
+        return id
+    }
+
+    public mutating func removeAll() {
+        cache.removeAll(keepingCapacity: true)
+    }
+
+    /// `.../Foo.app/Contents/MacOS/Foo` -> `.../Foo.app`. Nil when not inside a bundle.
+    public static func appBundlePath(fromExecutablePath path: String) -> String? {
+        guard let appRange = path.range(of: ".app/Contents/MacOS/") else { return nil }
+        return String(path[..<appRange.lowerBound]) + ".app"
+    }
+
+    /// Read `CFBundleIdentifier` from `<app>/Contents/Info.plist`.
+    public static func readBundleID(fromAppBundle appBundlePath: String) -> String? {
+        let infoPlist = appBundlePath + "/Contents/Info.plist"
+        guard let data = FileManager.default.contents(atPath: infoPlist),
+            let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+            let dict = plist as? [String: Any],
+            let bundleID = dict["CFBundleIdentifier"] as? String
+        else { return nil }
+        return bundleID
+    }
+}

--- a/Sources/MacPerfMonitorCore/Sampling/RingBuffer.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/RingBuffer.swift
@@ -40,18 +40,44 @@ public struct RingBuffer<Element> {
         }
     }
 
-    /// Elements in chronological order (oldest first, newest last).
-    public func elements() -> [Element] {
-        guard storage.count == capacity else {
-            // Not yet wrapped: storage is already in order.
-            return storage
-        }
-        // Wrapped: head points at the oldest element.
-        return Array(storage[head...] + storage[..<head])
+    /// Chronological view (oldest first, newest last) over the buffer.
+    ///
+    /// Shares the underlying storage via Array CoW; does not allocate a
+    /// reordered `[Element]` copy. Callers that only need a mapped series
+    /// (e.g. chart trails) can `.map` this view directly.
+    public func elements() -> Elements {
+        Elements(storage: storage, head: head, wrapped: storage.count == capacity)
     }
 
     public mutating func removeAll() {
         storage.removeAll(keepingCapacity: true)
         head = 0
+    }
+}
+
+extension RingBuffer {
+    /// Random-access chronological projection of a `RingBuffer`.
+    public struct Elements: RandomAccessCollection {
+        public typealias Index = Int
+
+        private let storage: [Element]
+        private let head: Int
+        private let wrapped: Bool
+
+        fileprivate init(storage: [Element], head: Int, wrapped: Bool) {
+            self.storage = storage
+            self.head = head
+            self.wrapped = wrapped
+        }
+
+        public var startIndex: Int { 0 }
+        public var endIndex: Int { storage.count }
+
+        public subscript(position: Int) -> Element {
+            if wrapped {
+                return storage[(head + position) % storage.count]
+            }
+            return storage[position]
+        }
     }
 }

--- a/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
@@ -159,6 +159,10 @@ public final class Sampler {
     }
     private var staticCache: [ProcessIdentity: StaticInfo] = [:]
 
+    /// Path-keyed `Info.plist` cache so helpers that share one `.app` do not
+    /// each pay a disk read on first sighting (see `BundleIDCache`).
+    private var bundleIDCache = BundleIDCache()
+
     /// Cap on how many *new* processes have their Team ID resolved per scan. The
     /// Team-ID lookup is a `SecStaticCode` inspection (~1–2 ms per distinct
     /// binary); resolving every process the first time it is seen made the first
@@ -166,8 +170,9 @@ public final class Sampler {
     /// churn burst (a build spawning dozens of compilers) a smaller one. Spreading
     /// the resolution over successive ticks bounds the per-tick cost; unresolved
     /// processes carry a nil Team ID (used only for optional grouping) until their
-    /// turn comes, at most a few seconds later. The other static facts — path,
-    /// bundle id, Rosetta flag — are cheap and still resolved on first sight.
+    /// turn comes, at most a few seconds later. Path and Rosetta flag stay
+    /// resolved on first sight; bundle id is also resolved then, but keyed by
+    /// `.app` path so shared helpers reuse one plist read.
     private let teamIDResolvePerTick = 30
 
     /// Resolves a binary's code-signing Team ID once per distinct executable
@@ -573,7 +578,7 @@ public final class Sampler {
             if resolveTeam { teamIDBudget -= 1 }
             staticInfo = StaticInfo(
                 executablePath: path,
-                bundleID: Self.bundleID(fromPath: path),
+                bundleID: bundleIDCache.bundleID(fromExecutablePath: path),
                 teamID: resolveTeam ? codeSigningResolver.teamID(forExecutablePath: path) : nil,
                 isTranslated: translated,
                 architecture: processReader.architecture(translated: translated),
@@ -628,6 +633,7 @@ public final class Sampler {
         lastEnergy.removeAll()
         lastDisk.removeAll()
         staticCache.removeAll()
+        bundleIDCache.removeAll()
         lastSystemTime = nil
         lastProcessTime = nil
         lastCounters = nil
@@ -743,19 +749,4 @@ public final class Sampler {
         )
     }
 
-    /// Derive a best-effort bundle identifier from an executable path inside a
-    /// `.app` bundle. Nil for plain executables.
-    static func bundleID(fromPath path: String?) -> String? {
-        guard let path else { return nil }
-        // .../Foo.app/Contents/MacOS/Foo -> read Info.plist if present.
-        guard let appRange = path.range(of: ".app/Contents/MacOS/") else { return nil }
-        let appBundlePath = String(path[..<appRange.lowerBound]) + ".app"
-        let infoPlist = appBundlePath + "/Contents/Info.plist"
-        guard let data = FileManager.default.contents(atPath: infoPlist),
-            let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
-            let dict = plist as? [String: Any],
-            let bundleID = dict["CFBundleIdentifier"] as? String
-        else { return nil }
-        return bundleID
-    }
 }

--- a/Tests/MacPerfMonitorCoreTests/BatteryTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/BatteryTests.swift
@@ -22,15 +22,18 @@ final class BatteryTests: XCTestCase {
 
     // MARK: - BatteryReader
 
-    /// The reader must never crash and must return either nil (a Mac with no
-    /// battery) or a self-consistent sample (charge in range, power non-negative).
+    /// The reader must never crash. Outcomes:
+    /// - `nil`: no AppleSmartBattery entry at all
+    /// - `isPresent == false`: desktop telemetry-only sample (system watts)
+    /// - `isPresent == true`: a self-consistent laptop battery sample
     func testBatteryReaderIsSafeAndConsistent() {
         let sample = BatteryReader().read()
-        guard let sample else { return }  // no internal battery: a valid outcome
-        XCTAssertTrue(sample.isPresent)
+        guard let sample else { return }
+        XCTAssertGreaterThanOrEqual(sample.powerWatts, 0)
+        XCTAssertGreaterThanOrEqual(sample.systemPowerWatts, 0)
+        guard sample.isPresent else { return }
         XCTAssertGreaterThanOrEqual(sample.chargePercent, 0)
         XCTAssertLessThanOrEqual(sample.chargePercent, 100)
-        XCTAssertGreaterThanOrEqual(sample.powerWatts, 0)
         if let health = sample.healthPercent {
             XCTAssertGreaterThanOrEqual(health, 0)
             XCTAssertLessThanOrEqual(health, 100)

--- a/Tests/MacPerfMonitorCoreTests/BundleIDCacheTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/BundleIDCacheTests.swift
@@ -64,7 +64,8 @@ final class BundleIDCacheTests: XCTestCase {
         let macos = contents.appendingPathComponent("MacOS", isDirectory: true)
         try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
         let plist: [String: Any] = ["CFBundleIdentifier": "com.test.bundleidcache"]
-        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist, format: .xml, options: 0)
         try data.write(to: contents.appendingPathComponent("Info.plist"))
         defer { try? FileManager.default.removeItem(at: root) }
 

--- a/Tests/MacPerfMonitorCoreTests/BundleIDCacheTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/BundleIDCacheTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class BundleIDCacheTests: XCTestCase {
+    func testNonAppPathReturnsNilWithoutReading() {
+        var reads = 0
+        var cache = BundleIDCache(readPlist: { _ in
+            reads += 1
+            return "should.not.run"
+        })
+        XCTAssertNil(cache.bundleID(fromExecutablePath: "/usr/bin/swift"))
+        XCTAssertEqual(reads, 0)
+    }
+
+    func testNilPathReturnsNil() {
+        var cache = BundleIDCache(readPlist: { _ in "x" })
+        XCTAssertNil(cache.bundleID(fromExecutablePath: nil))
+    }
+
+    func testReadsPlistOncePerAppBundle() {
+        var reads = 0
+        var cache = BundleIDCache(readPlist: { appPath in
+            reads += 1
+            XCTAssertEqual(appPath, "/Applications/Foo.app")
+            return "com.example.foo"
+        })
+        let main = "/Applications/Foo.app/Contents/MacOS/Foo"
+        let helper = "/Applications/Foo.app/Contents/MacOS/Foo Helper"
+        XCTAssertEqual(cache.bundleID(fromExecutablePath: main), "com.example.foo")
+        XCTAssertEqual(cache.bundleID(fromExecutablePath: helper), "com.example.foo")
+        XCTAssertEqual(reads, 1)
+    }
+
+    func testNegativeResultIsCached() {
+        var reads = 0
+        var cache = BundleIDCache(readPlist: { _ in
+            reads += 1
+            return nil
+        })
+        let path = "/Applications/Bar.app/Contents/MacOS/Bar"
+        XCTAssertNil(cache.bundleID(fromExecutablePath: path))
+        XCTAssertNil(cache.bundleID(fromExecutablePath: path))
+        XCTAssertEqual(reads, 1)
+    }
+
+    func testRemoveAllClearsCache() {
+        var reads = 0
+        var cache = BundleIDCache(readPlist: { _ in
+            reads += 1
+            return "com.example.baz"
+        })
+        let path = "/Applications/Baz.app/Contents/MacOS/Baz"
+        _ = cache.bundleID(fromExecutablePath: path)
+        cache.removeAll()
+        _ = cache.bundleID(fromExecutablePath: path)
+        XCTAssertEqual(reads, 2)
+    }
+
+    func testDefaultReaderLoadsRealInfoPlist() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BundleIDCacheTests-\(UUID().uuidString)", isDirectory: true)
+        let contents = root.appendingPathComponent("TestApp.app/Contents", isDirectory: true)
+        let macos = contents.appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
+        let plist: [String: Any] = ["CFBundleIdentifier": "com.test.bundleidcache"]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: contents.appendingPathComponent("Info.plist"))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var cache = BundleIDCache()
+        let exe = root.appendingPathComponent("TestApp.app/Contents/MacOS/TestApp").path
+        XCTAssertEqual(cache.bundleID(fromExecutablePath: exe), "com.test.bundleidcache")
+        // Second call must hit cache (still correct).
+        XCTAssertEqual(cache.bundleID(fromExecutablePath: exe), "com.test.bundleidcache")
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/RingBufferTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/RingBufferTests.swift
@@ -9,7 +9,7 @@ final class RingBufferTests: XCTestCase {
         buffer.append(2)
         buffer.append(3)
         XCTAssertEqual(buffer.count, 3)
-        XCTAssertEqual(buffer.elements(), [1, 2, 3])
+        XCTAssertEqual(Array(buffer.elements()), [1, 2, 3])
         XCTAssertEqual(buffer.last, 3)
     }
 
@@ -18,7 +18,7 @@ final class RingBufferTests: XCTestCase {
         for value in 1...5 { buffer.append(value) }
         XCTAssertEqual(buffer.count, 3)
         // Oldest two evicted; chronological order preserved.
-        XCTAssertEqual(buffer.elements(), [3, 4, 5])
+        XCTAssertEqual(Array(buffer.elements()), [3, 4, 5])
         XCTAssertEqual(buffer.last, 5)
     }
 
@@ -26,9 +26,9 @@ final class RingBufferTests: XCTestCase {
         var buffer = RingBuffer<Int>(capacity: 2)
         buffer.append(10)
         buffer.append(20)
-        XCTAssertEqual(buffer.elements(), [10, 20])
+        XCTAssertEqual(Array(buffer.elements()), [10, 20])
         buffer.append(30)
-        XCTAssertEqual(buffer.elements(), [20, 30])
+        XCTAssertEqual(Array(buffer.elements()), [20, 30])
     }
 
     func testRemoveAll() {
@@ -39,6 +39,25 @@ final class RingBufferTests: XCTestCase {
         XCTAssertTrue(buffer.isEmpty)
         XCTAssertNil(buffer.last)
         buffer.append(9)
-        XCTAssertEqual(buffer.elements(), [9])
+        XCTAssertEqual(Array(buffer.elements()), [9])
+    }
+
+    /// `elements()` is a RandomAccessCollection view: callers can map without
+    /// first materialising a chronological `[Element]` copy.
+    func testElementsIsRandomAccessCollection() {
+        var buffer = RingBuffer<Int>(capacity: 3)
+        for value in 1...5 { buffer.append(value) }
+        let view = buffer.elements()
+        XCTAssertEqual(view.count, 3)
+        XCTAssertEqual(view[view.startIndex], 3)
+        XCTAssertEqual(view[view.index(view.startIndex, offsetBy: 2)], 5)
+        XCTAssertEqual(view.map { $0 * 10 }, [30, 40, 50])
+    }
+
+    func testElementsViewMatchesOrderAtExactCapacity() {
+        var buffer = RingBuffer<Int>(capacity: 4)
+        for value in 1...4 { buffer.append(value) }
+        XCTAssertEqual(Array(buffer.elements()), [1, 2, 3, 4])
+        XCTAssertEqual(buffer.elements().map { $0 }, [1, 2, 3, 4])
     }
 }


### PR DESCRIPTION
RingBuffer.elements() now returns a RandomAccessCollection view over the circular storage instead of allocating a reordered Array on every read. Chart trails and other hot-path map() callers therefore skip copying large SystemSample structs just to extract a few Doubles.

Bundle ID resolution is moved into BundleIDCache, keyed by .app bundle path (with negative caching). Helpers that share one app no longer each pay an Info.plist disk read on first sighting. Sampler wires the cache into static process facts and clears it on reset. Unit tests cover hit/miss, negative cache, and real plist reads.

AppDelegate is marked @MainActor so ProcessGroupStore.shared can be initialized safely, and UNUserNotificationCenterDelegate is adopted with @preconcurrency to keep Swift 6 isolation warnings quiet.

Combined menu-bar Focus/Strip dual-rate cells (Disk/Network) no longer overlap: matched compact fonts and a shared half-height stacking layout replace the old height - size.height placement. Strip caption cells (RAM/CPU/GPU) keep a shared 22pt item height, pin titles higher, and use a larger 12.5pt value so the strip reads as one even band.

<!--
Thanks for contributing to MacPerfMonitor. Please fill out the sections below.
Keep user-facing copy and docs free of the em dash (see CONTRIBUTING.md).
-->

## Summary

<!-- What does this change do, and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## How verified

<!-- Tests added or run, manual steps, screenshots for UI changes. -->

## Checklist

- [x] `swift test` passes
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` passes
- [x] `CHANGELOG.md` updated under "Unreleased" for any user-visible change
- [x] No telemetry or network calls introduced
- [x] Data-layer changes keep `MacPerfMonitorCore` free of SwiftUI
