### PR TITLE
Persist a process team id that resolves after first sight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Vendor grouping works for processes whose team id resolves late:** the
+  recording cache short-circuited the per-process upsert on (name, path,
+  bundle id) without checking the team id, so a process first seen with
+  team_id nil (the common case, since codesign lookups are expensive and the
+  sampler resolves a team id for only ~30 of ~800 processes per tick) and
+  later resolved to a real team id never had that id written, leaving the row
+  NULL forever. Grouping by vendor, which keys on team_id, therefore broke
+  for the bulk of processes after every app launch. The cache now carries the
+  team id and compares it, so a late-resolved id defeats the short-circuit and
+  the row's existing COALESCE upsert heals it in place.
+
 ## [1.3.6] - 2026-08-04
 
 ### Fixed

--- a/Sources/MacPerfMonitorCore/Persistence/SampleStore.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/SampleStore.swift
@@ -10,17 +10,24 @@ public final class SampleStore {
 
     /// A cached dimension-row id together with the identity fields it was
     /// written with. The fields are compared on every insert so a process whose
-    /// name, path, or bundle changes after first sight gets its row re-upserted
-    /// rather than freezing the first glimpse for the whole session. That
-    /// matters for app launches: launchd spawns an `xpcproxy` trampoline that
-    /// execs the real binary under the same pid and start time, and a sample
-    /// tick can straddle the exec, recording the trampoline's name against the
-    /// app's path forever (a Word session whose history row said "xpcproxy").
+    /// name, path, bundle, or team id changes after first sight gets its row
+    /// re-upserted rather than freezing the first glimpse for the whole session.
+    /// That matters for app launches: launchd spawns an `xpcproxy` trampoline
+    /// that execs the real binary under the same pid and start time, and a
+    /// sample tick can straddle the exec, recording the trampoline's name
+    /// against the app's path forever (a Word session whose history row said
+    /// "xpcproxy"). It matters for team id too: the sampler resolves a team id
+    /// via codesign for only a few dozen processes per tick while hundreds run,
+    /// so a process is usually first seen with team_id nil and only gains a
+    /// real id on a later tick. Without comparing team_id the cache would
+    /// short-circuit that later upsert and leave the row NULL forever, breaking
+    /// vendor grouping.
     private struct CachedProcessRow {
         var id: Int64
         var name: String
         var executablePath: String?
         var bundleID: String?
+        var teamID: String?
     }
     private var processIDCache: [ProcessIdentity: CachedProcessRow] = [:]
 
@@ -292,7 +299,8 @@ public final class SampleStore {
         if let cached = processIDCache[s.id],
             cached.name == s.name,
             cached.executablePath == s.executablePath,
-            cached.bundleID == s.bundleID
+            cached.bundleID == s.bundleID,
+            cached.teamID == s.teamID
         {
             return cached.id
         }
@@ -320,7 +328,8 @@ public final class SampleStore {
             ])
         guard let id else { throw DatabaseError(message: "failed to upsert process row") }
         processIDCache[s.id] = CachedProcessRow(
-            id: id, name: s.name, executablePath: s.executablePath, bundleID: s.bundleID)
+            id: id, name: s.name, executablePath: s.executablePath, bundleID: s.bundleID,
+            teamID: s.teamID)
         return id
     }
 

--- a/Tests/MacPerfMonitorCoreTests/PersistenceTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/PersistenceTests.swift
@@ -24,14 +24,15 @@ final class PersistenceTests: XCTestCase {
     private func insertTick(
         _ timestamp: Date, footprint: UInt64, pid: Int32 = 1000,
         startTime: Date = Date(timeIntervalSince1970: 1_000_000),
-        name: String = "TestProc"
+        name: String = "TestProc",
+        teamID: String? = nil
     ) throws {
         let snapshot = Sampler.Snapshot(
             system: Make.system(timestamp: timestamp, pressurePercent: 10),
             processes: [
                 Make.process(
                     timestamp: timestamp, pid: pid, startTime: startTime, name: name,
-                    footprint: footprint)
+                    teamID: teamID, footprint: footprint)
             ],
             unreadableProcessCount: 3
         )
@@ -182,6 +183,31 @@ final class PersistenceTests: XCTestCase {
             try Double.fetchOne(db, sql: "SELECT last_seen FROM processes")!
         }
         XCTAssertEqual(lastSeen, t0.addingTimeInterval(2).timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    func testTeamIDPersistsWhenResolvedAfterFirstSight() throws {
+        // The sampler resolves a team id via codesign for only ~30 processes
+        // per tick while ~800 run, so a process is usually first seen with
+        // teamID nil and only gains a real id on a later tick. The id cache
+        // must not short-circuit that later upsert (the identity fields name,
+        // path, and bundle are unchanged), or the processes row keeps team_id
+        // NULL forever and vendor grouping, which keys on team_id, silently
+        // breaks for the bulk of processes after every app launch.
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+        try insertTick(t0, footprint: 100 * 1024 * 1024)  // first sight: teamID nil
+        try insertTick(
+            t0.addingTimeInterval(2), footprint: 100 * 1024 * 1024, teamID: "ABCDE12345")
+
+        let rows = try store.databasePool.read { db in
+            try Row.fetchAll(db, sql: "SELECT team_id, name, bundle_id FROM processes")
+        }
+        // Same identity healed in place, not duplicated.
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0]["team_id"] as String?, "ABCDE12345")
+        // The COALESCE upsert refreshed only team_id; the other dimensions are
+        // carried over from the first sight unchanged.
+        XCTAssertEqual(rows[0]["name"] as String, "TestProc")
+        XCTAssertEqual(rows[0]["bundle_id"] as String?, "com.test.TestProc")
     }
 
     func testRetentionRollsRawIntoMinuteAndTrims() throws {


### PR DESCRIPTION
## Summary

`SampleStore` caches each process's dimension row id in memory so a process that has not
changed is upserted at most once per session. The cache short-circuit compared only
(name, executable path, bundle id) and skipped the team id. The sampler resolves a team
id via codesign for only ~30 processes per tick (the lookups are expensive) while ~800
run, so most processes are first seen with team_id nil and only gain a real team id on a
later tick. Because that later upsert was cache-skipped, the row's team_id stayed NULL
for the whole session, and grouping by vendor, which keys on team_id, silently broke for
the bulk of processes after every app launch. The cache now carries the team id and
compares it, so a late-resolved id defeats the short-circuit and the row's existing
COALESCE upsert heals it in place.

## Related issue

No matching open issue found. The effect is that vendor grouping now works for the bulk
of processes on first launch instead of only for the ~30 per tick whose team id happened
to resolve on the first sighting.

## How verified

`swift test` -> 339 tests passed (baseline ~338, plus the new test
`testTeamIDPersistsWhenResolvedAfterFirstSight`); `swift format lint --strict --recursive
Sources Tests Package.swift` -> clean (exit 0). The new test was confirmed red before
green: with only the fix reverted it fails with `XCTAssertEqual failed: ("nil") is not
equal to ("Optional("ABCDE12345")")`, and passes once the fix is restored.

## Checklist

- [x] `swift test` passes
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` passes
- [x] `CHANGELOG.md` updated under "Unreleased" for any user-visible change
- [x] No telemetry or network calls introduced
- [x] Data-layer changes keep `MacPerfMonitorCore` free of SwiftUI
