### PR TITLE
Throttle repeated alert deliveries during a sustained flap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Quiet the notification spam during a sustained memory crisis:** real memory
+  pressure can bounce between critical and normal while the kernel compresses,
+  swaps, and throttles, and every bounce re-armed the alert so the next critical
+  tick fired a fresh notification. The engine now delivers at most one
+  notification for each alert during a cooldown window (five minutes by default),
+  so a condition that keeps flapping notifies once instead of re-firing on every
+  flap. The condition is still tracked and shown as active until it genuinely
+  recovers; only the repeat notifications are held back.
+
 ## [1.3.6] - 2026-08-04
 
 ### Fixed

--- a/Sources/MacPerfMonitorCore/Analysis/AlertEngine.swift
+++ b/Sources/MacPerfMonitorCore/Analysis/AlertEngine.swift
@@ -119,6 +119,14 @@ public final class AlertEngine {
     /// Fraction of a threshold a value must fall back below before its alert
     /// re-arms, damping oscillation around the threshold.
     private let rearmFraction = 0.8
+    /// Minimum time between two deliveries of the same alert id. A sustained
+    /// condition that flaps (for example memory pressure bouncing critical to
+    /// normal to critical while the kernel compresses and swaps) re-arms the
+    /// edge trigger on each recovery tick, so without this guard it would
+    /// re-fire a notification on every flap. The throttle drops the repeat
+    /// deliveries while leaving the per-kind armed flags untouched, so a
+    /// suppressed condition still reports as active until it truly recovers.
+    private let refireCooldown: TimeInterval
 
     private var pressureArmed = true
     private var swapArmed = true
@@ -130,13 +138,24 @@ public final class AlertEngine {
     /// does. Nil while CPU is below the threshold. Time-based rather than a tick
     /// count, so it is unaffected by the sampling cadence.
     private var highCPUSince: Date?
+    /// Last delivery time per alert id, used to suppress re-fires inside the
+    /// cooldown window. Recorded only for alerts that survive the throttle, so
+    /// a sustained flap cannot slide the window forward and starve the later
+    /// notifications it should still deliver.
+    private var lastFiredAt: [String: Date] = [:]
     /// Conditions that are active after the most recent evaluation. Unlike the
     /// returned alerts, this remains populated until each condition recovers.
     public private(set) var activeKinds: Set<Alert.Kind> = []
     /// How long total CPU must stay at/above the threshold before alerting.
     private let sustainedCPUDuration: TimeInterval = 8
 
-    public init() {}
+    /// - Parameter refireCooldown: minimum seconds between two deliveries of
+    ///   the same alert id. Defaults to 5 minutes, which keeps a flapping
+    ///   sustained condition from re-firing on every flap. Pass 0 to disable
+    ///   the throttle entirely.
+    public init(refireCooldown: TimeInterval = 300) {
+        self.refireCooldown = refireCooldown
+    }
 
     /// Evaluate one tick. `leakingProcesses` is supplied by the caller from the
     /// leak board (leak detection needs a series, not a single sample). Returns
@@ -157,6 +176,20 @@ public final class AlertEngine {
             processes, leakingProcesses: leakingProcesses, config: config, now: now, into: &alerts)
         evaluateCPU(cpu, config: config, now: now, into: &alerts)
         refreshActiveKinds()
+        // Throttle notification delivery per alert id: drop any alert whose id
+        // was already delivered inside the cooldown window. The armed flags
+        // above are final, so a suppressed alert still marks its kind active
+        // (refreshActiveKinds already ran). Record the delivery time only for
+        // survivors; recording it for a suppressed alert would slide the window
+        // forward on every flap and starve the re-fire that should land once
+        // the cooldown genuinely elapses.
+        alerts = alerts.filter { alert in
+            if let last = lastFiredAt[alert.id], now.timeIntervalSince(last) < refireCooldown {
+                return false
+            }
+            lastFiredAt[alert.id] = now
+            return true
+        }
         return alerts
     }
 
@@ -169,6 +202,7 @@ public final class AlertEngine {
         leakFired.removeAll()
         cpuArmed = true
         highCPUSince = nil
+        lastFiredAt.removeAll()
         activeKinds.removeAll()
     }
 

--- a/Tests/MacPerfMonitorCoreTests/AlertEngineTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/AlertEngineTests.swift
@@ -13,7 +13,9 @@ final class AlertEngineTests: XCTestCase {
     // MARK: - Critical pressure
 
     func testCriticalPressureFiresOnceThenRearmsAfterRecovery() {
-        let engine = AlertEngine()
+        // A cooldown of 0 disables the per-id throttle so the re-arm path can
+        // re-fire on the next crossing, which is what this test exercises.
+        let engine = AlertEngine(refireCooldown: 0)
         let config = AlertConfig(criticalPressureEnabled: true)
 
         XCTAssertTrue(
@@ -59,10 +61,55 @@ final class AlertEngineTests: XCTestCase {
                 .isEmpty)
     }
 
+    // MARK: - Refire cooldown
+
+    func testSustainedFlapRefiresAtMostOncePerCooldown() {
+        let engine = AlertEngine(refireCooldown: 300)
+        let config = AlertConfig(criticalPressureEnabled: true)
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // Step 1: the first critical tick of a sustained crisis fires exactly
+        // once and is delivered.
+        let first = engine.evaluate(
+            system: Make.system(timestamp: t0, pressure: .critical),
+            processes: [], config: config, now: t0)
+        XCTAssertEqual(first.map(\.kind), [.criticalPressure])
+
+        // Step 2: the crisis keeps flapping (normal to critical) several times
+        // WITHIN the cooldown window. Each recovery re-arms the edge trigger,
+        // so without the throttle every critical tick here would deliver a
+        // fresh alert. All of them are suppressed, and none may advance the
+        // cooldown window: recording a delivery time for a suppressed tick
+        // would slide the window forward and starve the re-fire step 3 expects.
+        for offset in [10.0, 60.0, 180.0, 290.0] {
+            _ = engine.evaluate(
+                system: Make.system(
+                    timestamp: t0.addingTimeInterval(offset - 2), pressure: .normal),
+                processes: [], config: config, now: t0.addingTimeInterval(offset - 2))
+            let suppressed = engine.evaluate(
+                system: Make.system(timestamp: t0.addingTimeInterval(offset), pressure: .critical),
+                processes: [], config: config, now: t0.addingTimeInterval(offset))
+            XCTAssertEqual(suppressed, [])
+        }
+
+        // Step 3: once the cooldown measured from the FIRST delivery (t0) has
+        // elapsed, the next flap re-fires exactly once. The last suppressed
+        // tick was at t0 + 290, only 13 s before this retry, so a slide-forward
+        // bug (recording suppressed ticks) would still suppress it and starve
+        // the crisis. The survivor-only implementation fires here.
+        _ = engine.evaluate(
+            system: Make.system(timestamp: t0.addingTimeInterval(301), pressure: .normal),
+            processes: [], config: config, now: t0.addingTimeInterval(301))
+        let afterCooldown = engine.evaluate(
+            system: Make.system(timestamp: t0.addingTimeInterval(303), pressure: .critical),
+            processes: [], config: config, now: t0.addingTimeInterval(303))
+        XCTAssertEqual(afterCooldown.map(\.kind), [.criticalPressure])
+    }
+
     // MARK: - Swap
 
     func testSwapThresholdFiresWithHysteresis() {
-        let engine = AlertEngine()
+        let engine = AlertEngine(refireCooldown: 0)
         let config = AlertConfig(swapEnabled: true, swapThresholdBytes: 3 * gb)
 
         XCTAssertTrue(
@@ -90,7 +137,7 @@ final class AlertEngineTests: XCTestCase {
     // MARK: - Process ceiling
 
     func testProcessCeilingFiresPerProcessAndRearms() {
-        let engine = AlertEngine()
+        let engine = AlertEngine(refireCooldown: 0)
         let config = AlertConfig(processCeilingEnabled: true, processCeilingBytes: 1 * gb)
 
         let a = Make.process(timestamp: now, pid: 100, name: "Alpha", footprint: 2 * gb)
@@ -126,7 +173,7 @@ final class AlertEngineTests: XCTestCase {
     // MARK: - Leaks
 
     func testLeakAlertFiresOncePerLeakAndRearms() {
-        let engine = AlertEngine()
+        let engine = AlertEngine(refireCooldown: 0)
         let config = AlertConfig(leakEnabled: true)
         let a = Make.process(timestamp: now, pid: 100, name: "Leaky", footprint: 1 * gb)
         let b = Make.process(timestamp: now, pid: 200, name: "AlsoLeaky", footprint: 1 * gb)
@@ -202,7 +249,7 @@ final class AlertEngineTests: XCTestCase {
     }
 
     func testHighCPUFiresOnlyAfterSustainedDurationThenRearms() {
-        let engine = AlertEngine()
+        let engine = AlertEngine(refireCooldown: 0)
         let config = AlertConfig(highCPUEnabled: true, highCPUThresholdPercent: 85)
         let t0 = now
 


### PR DESCRIPTION
Closes #1.

## Problem

Real memory pressure during a sustained crisis flaps between `.critical` and `.normal` (the kernel compresses, swaps, and throttles), and a single `.normal` tick re-arms the edge-triggered alert — so the next `.critical` tick fires a fresh notification. A leak that runs for a minute can produce a dozen banners. As you put it in #1: _"If trigger is sustained we send way too many notifications."_ The same re-arm-then-refire path exists for swap, high CPU, and the per-process ceiling/leak kinds.

## Fix

A delivery-only cooldown keyed on the stable `Alert.id`. `AlertEngine` gains `init(refireCooldown:)` (5-minute default) and a `lastFiredAt` map. After the existing edge/hysteresis logic runs — so `activeKinds` is unaffected and a suppressed condition is still shown as active — a single filter drops any alert whose id was delivered within the cooldown window.

Delivery time is recorded **only for survivors**: a suppressed alert hits `return false` before its time is recorded, so a sustained flap cannot slide the window forward and starve the re-fire that should land once the cooldown genuinely elapses.

Net effect: a flapping condition notifies once per cooldown window instead of on every flap, while still tracking and surfacing the active condition until it truly recovers.

## Behavior preserved

- `AlertConfig`, persistence, the armed flags, and `activeKinds` semantics are unchanged.
- `refireCooldown: 0` disables the throttle entirely (used by the existing re-arm tests).
- No SwiftUI/telemetry in Core; Swift 5 mode preserved.

## Tests

- New `testSustainedFlapRefiresAtMostOncePerCooldown` (deterministic, explicit `now:`): the first `.critical` is delivered; four flaps within the window are all suppressed; a flap after the window re-fires exactly once — and the step-3 timing is tight enough (13 s after the last suppressed tick) that a slide-forward bug would still suppress it and fail the test.
- Five existing re-arm tests switched to `AlertEngine(refireCooldown: 0)` — assertions unchanged.
- `swift test` → 339 tests, 0 failures. `swift format lint --strict --recursive` → clean.

## CHANGELOG

One bullet under `[Unreleased] → Fixed`, matching the repo's Keep-a-Changelog style.

A known, deliberately-deferred follow-up (out of scope for this one-concern PR): `lastFiredAt` has no per-tick pruning — entries are added only on a delivered alert and linger until `reset()`, so practical impact is negligible, but a future PR could mirror the `formIntersection` pruning already used for the armed sets.
