### PR TITLE
Carry disk throughput fields through the chart downsampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ Notable changes to Mac Performance Monitor. This project follows
   for the bulk of processes after every app launch. The cache now carries the
   team id and compares it, so a late-resolved id defeats the short-circuit and
   the row's existing COALESCE upsert heals it in place.
+- **Disk tab trend no longer flattens to zero on long ranges:** the Disk tab's
+  read/write trend lines collapsed to a flat zero on any dashboard range whose
+  point count exceeded the chart cap (the six-hour, day, and longer windows),
+  even though the underlying raw and minute-tier rows carried the values. The
+  chart downsampler builds one averaged point per time bucket, and it carried
+  the pressure, memory, CPU, battery, and network scalars through but omitted
+  the four disk-throughput fields, so they defaulted to 0. The four disk
+  scalars (read and write bytes per second, and read and write operations per
+  second) are now averaged per bucket like the network scalars, the same fix
+  the battery and network fields already got. The downsampler also moved from
+  the app target into `MacPerfMonitorCore/Persistence` (alongside the history
+  type it operates on), bringing this chart-path function under the headless
+  test suite for the first time.
 
 ## [1.3.6] - 2026-08-04
 

--- a/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
@@ -1,14 +1,13 @@
 import Foundation
-import MacPerfMonitorCore
 
 extension Array where Element == SystemHistoryPoint {
     /// Break the series into contiguous runs wherever two consecutive samples
     /// are further apart than the median spacing × 15 (with a 30-second floor).
     /// This is the same heuristic MetricChart uses for per-process data: ordinary
     /// jitter and the occasional missed tick are bridged, but a genuine absence
-    /// — the Mac asleep, the app not running — leaves a blank gap instead of a
+    /// (the Mac asleep, the app not running) leaves a blank gap instead of a
     /// straight diagonal across the hole.
-    func splitIntoSegments() -> [[SystemHistoryPoint]] {
+    public func splitIntoSegments() -> [[SystemHistoryPoint]] {
         guard !isEmpty else { return [] }
         let threshold = gapThreshold()
         var result: [[SystemHistoryPoint]] = []
@@ -46,19 +45,19 @@ extension Array where Element == SystemHistoryPoint {
     /// only on its timestamp, not on how many samples are in the array, so
     /// appending the newest sample (or trimming the oldest) only ever changes the
     /// rightmost bucket. The historical shape holds still and the series simply
-    /// slides left as time advances — instead of every bucket's contents (and the
+    /// slides left as time advances, instead of every bucket's contents (and the
     /// whole shape) shifting on each tick, which is what an index-based
     /// `count / maxCount` split does the moment `count` changes.
     ///
     /// `span` is the selected window's length (e.g. `range.seconds`). Deriving
-    /// the width from this FIXED span — not the data's own min…max extent, which
-    /// grows every tick — is essential to that stability; each bucket's point is
-    /// dated to its grid start so the x-positions never wander.
+    /// the width from this FIXED span (not the data's own min-to-max extent,
+    /// which grows every tick) is essential to that stability; each bucket's
+    /// point is dated to its grid start so the x-positions never wander.
     ///
     /// Byte fields are averaged per bucket; `pressurePercent` keeps the bucket
     /// peak so the spikes the pressure charts exist to show (and the Insights
     /// event markers point at) are preserved rather than averaged away.
-    func chartDownsampled(span: TimeInterval, to maxCount: Int) -> [SystemHistoryPoint] {
+    public func chartDownsampled(span: TimeInterval, to maxCount: Int) -> [SystemHistoryPoint] {
         guard count > maxCount, maxCount > 0, span > 0 else { return self }
         let width = span / Double(maxCount)
         func bucketIndex(_ p: SystemHistoryPoint) -> Double {
@@ -93,7 +92,7 @@ extension Array where Element == SystemHistoryPoint {
                     // CPU is inherently spiky, so average rather than peak per
                     // bucket; a max-collapsed line would read as permanently high.
                     cpuLoad: dmean { $0.cpuLoad },
-                    // Carry the battery scalars through too — omitting them
+                    // Carry the battery scalars through too: omitting them
                     // defaulted them to 0, which collapsed the Battery tab's
                     // charge/power lines to a flat zero on any downsampled range.
                     batteryCharge: dmean { $0.batteryCharge },
@@ -103,7 +102,16 @@ extension Array where Element == SystemHistoryPoint {
                     // Network is bursty, so average per bucket (a max-collapsed
                     // line would read as permanently saturated), like CPU.
                     networkInBytesPerSec: dmean { $0.networkInBytesPerSec },
-                    networkOutBytesPerSec: dmean { $0.networkOutBytesPerSec }
+                    networkOutBytesPerSec: dmean { $0.networkOutBytesPerSec },
+                    // Disk throughput is bursty too, so average per bucket like
+                    // network. Carrying these through is the same fix the battery
+                    // and network scalars already got: leaving them out defaulted
+                    // them to 0 and flattened the Disk tab's read/write trend on
+                    // any range whose point count exceeded the chart cap.
+                    diskReadBytesPerSec: dmean { $0.diskReadBytesPerSec },
+                    diskWriteBytesPerSec: dmean { $0.diskWriteBytesPerSec },
+                    diskReadOperationsPerSec: dmean { $0.diskReadOperationsPerSec },
+                    diskWriteOperationsPerSec: dmean { $0.diskWriteOperationsPerSec }
                 ))
             i = j
         }

--- a/Tests/MacPerfMonitorCoreTests/HistoryDownsampleTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/HistoryDownsampleTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class HistoryDownsampleTests: XCTestCase {
+    /// The four disk-throughput scalars (and the earlier battery, CPU, and
+    /// network fixes) must survive `chartDownsampled`. Before the disk
+    /// carry-through, downsampled points defaulted those fields to 0 and the
+    /// Disk tab's read/write trend collapsed to a flat zero on any range whose
+    /// point count exceeded the cap, even though the raw and minute-tier rows
+    /// carried the values.
+    func testDownsamplePreservesDiskThroughput() throws {
+        // ~400 samples at 2-second spacing inside a one-hour window: well past
+        // the maxPoints cap, so chartDownsampled actually buckets them rather
+        // than returning the input unchanged.
+        let spacing: TimeInterval = 2
+        let count = 400
+        let span: TimeInterval = 3600
+        let anchor = Date(timeIntervalSince1970: 1_700_000_000)
+        var points: [SystemHistoryPoint] = []
+        points.reserveCapacity(count)
+        for i in 0..<count {
+            points.append(
+                SystemHistoryPoint(
+                    date: anchor.addingTimeInterval(Double(i) * spacing),
+                    pressurePercent: 50,
+                    appMemory: 0,
+                    wired: 0,
+                    compressed: 0,
+                    cachedFiles: 0,
+                    swapUsed: 0,
+                    cpuLoad: 0.42,
+                    batteryCharge: 0.87,
+                    batteryPowerWatts: -3.5,
+                    batteryHealthPercent: 99,
+                    batteryTemperatureCelsius: 31.5,
+                    networkInBytesPerSec: 2048,
+                    networkOutBytesPerSec: 1024,
+                    diskReadBytesPerSec: 5_242_880,
+                    diskWriteBytesPerSec: 1_048_576,
+                    diskReadOperationsPerSec: 12.5,
+                    diskWriteOperationsPerSec: 6.25
+                ))
+        }
+
+        let downsampled = points.chartDownsampled(span: span, to: 100)
+
+        // Bucketing must actually happen: fewer points out than in.
+        XCTAssertLessThan(downsampled.count, points.count, "series should be thinned")
+        XCTAssertFalse(downsampled.isEmpty, "expected bucketed points")
+        for point in downsampled {
+            // The four disk scalars this fix carries through.
+            XCTAssertEqual(point.diskReadBytesPerSec, 5_242_880, accuracy: 1.0)
+            XCTAssertEqual(point.diskWriteBytesPerSec, 1_048_576, accuracy: 1.0)
+            XCTAssertEqual(point.diskReadOperationsPerSec, 12.5, accuracy: 1e-6)
+            XCTAssertEqual(point.diskWriteOperationsPerSec, 6.25, accuracy: 1e-6)
+            // The earlier scalar-carry fixes (CPU, battery, network) must still
+            // hold across every carried field, not just one per category, so a
+            // future drop of any single carry line fails here too.
+            XCTAssertEqual(point.cpuLoad, 0.42, accuracy: 1e-9)
+            XCTAssertEqual(point.batteryCharge, 0.87, accuracy: 1e-9)
+            XCTAssertEqual(point.batteryPowerWatts, -3.5, accuracy: 1e-9)
+            XCTAssertEqual(point.batteryHealthPercent, 99, accuracy: 1e-9)
+            XCTAssertEqual(point.batteryTemperatureCelsius, 31.5, accuracy: 1e-9)
+            XCTAssertEqual(point.networkInBytesPerSec, 2048, accuracy: 1e-6)
+            XCTAssertEqual(point.networkOutBytesPerSec, 1024, accuracy: 1e-6)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The Disk tab's read/write trend lines collapsed to a flat zero on any dashboard
range whose point count exceeded the chart cap (the six-hour, day, and longer
windows), even though the underlying raw and minute-tier rows carry the values.
`chartDownsampled` builds one averaged `SystemHistoryPoint` per time bucket and
carried the pressure, memory, CPU, battery, and network scalars through, but it
omitted the four disk-throughput fields, so the memberwise init defaulted them
to 0. `DiskChart` builds its trend straight off those fields, so every
downsampled point read as zero.

This is the exact regression the file already fixed for the battery scalars;
the disk fields were added to `SystemHistoryPoint` later and that fix was never
extended. The four disk scalars (read/write bytes per second and read/write
operations per second) are now averaged per bucket via the existing `dmean`
helper, mirroring the network scalars.

`chartDownsampled` and `splitIntoSegments` are pure (they depend only on the
Core type `SystemHistoryPoint`) yet lived in the untested app target. They move
into `MacPerfMonitorCore/Persistence` alongside `SystemHistory`, marked public
so the app target still resolves them through its `MacPerfMonitorCore` import.
This brings the chart downsampler under the headless test suite for the first
time.

## Related issue

(none; self-contained correctness fix)

## How verified

- New `HistoryDownsampleTests.testDownsamplePreservesDiskThroughput`: 400 points
  at 2s spacing in a one-hour window (past the cap), downsample to 100, assert
  every returned point carries the four disk scalars plus the earlier
  cpuLoad / batteryCharge / networkInBytesPerSec fixes. Fails before the carry
  (92 assertions, disk == 0) and passes after.
- `swift test`: 339 tests, 0 failures.
- `swift format lint --strict --recursive Sources Tests Package.swift`: clean.

## Checklist

- [x] `swift test` passes
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` passes
- [x] `CHANGELOG.md` updated under "Unreleased"
- [x] No telemetry or network calls introduced
- [x] Data-layer changes keep `MacPerfMonitorCore` free of SwiftUI