### PR TITLE
Report timeout as failure in MemoryToolRunner even with partial output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ### Fixed
 
+- **A memory-inspection tool run that times out is now reported as a failure
+  even when it printed partial output:** `MemoryToolRunner` runs one of Apple's
+  signed tools (`footprint`, `heap`, `leaks`, `sample`) under a hard timeout and
+  kills the child process when it expires. When the child had already written
+  some stdout before being killed, the runner returned `.success` carrying that
+  partial text, so the inspector treated an incomplete run as if it had
+  finished and displayed truncated data. The timeout now wins regardless of
+  captured output: a timed-out run returns `.failure(.timedOut)`, so callers
+  surface an error instead of presenting a partial result as complete.
 - **Quiet the notification spam during a sustained memory crisis:** real memory
   pressure can bounce between critical and normal while the kernel compresses,
   swaps, and throttles, and every bounce re-armed the alert so the next critical

--- a/Sources/MacPerfMonitorCore/System/MemoryToolRunner.swift
+++ b/Sources/MacPerfMonitorCore/System/MemoryToolRunner.swift
@@ -126,12 +126,27 @@ public enum MemoryToolRunner {
                 )
             }
 
-            let text = String(decoding: data, as: UTF8.self)
-            if text.isEmpty {
-                return timedOut ? .failure(.timedOut) : .failure(.noOutput)
-            }
-            return .success(text)
+            return Self.resolveResult(timedOut: timedOut, data: data)
         }
+    }
+
+    /// Turn the captured bytes into the final result. A timeout wins regardless
+    /// of any partial output: when the child is killed for exceeding the hard
+    /// limit it was stopped mid-run, so whatever it printed is neither complete
+    /// nor trustworthy and must never be reported as success. Only a run that
+    /// finished in time and produced output is a success; an in-time run that
+    /// printed nothing is a distinct no-output failure.
+    ///
+    /// Pulled out of `run` so the precedence (timeout over partial output) is
+    /// unit-testable without spawning a real Apple tool, which could not
+    /// reproduce a timeout-with-output case deterministically.
+    static func resolveResult(
+        timedOut: Bool, data: Data
+    ) -> Result<String, RunError> {
+        if timedOut { return .failure(.timedOut) }
+        let text = String(decoding: data, as: UTF8.self)
+        if text.isEmpty { return .failure(.noOutput) }
+        return .success(text)
     }
 
     /// Stop a runaway child: ask politely, then force-kill if it lingers.

--- a/Tests/MacPerfMonitorCoreTests/MemoryToolRunnerTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/MemoryToolRunnerTests.swift
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+/// Tests for `MemoryToolRunner`'s captured-output resolution. The real `run`
+/// spawns a signed Apple tool and cannot reproduce a timeout-with-output case
+/// deterministically, so these exercise the pure decision it delegates to
+/// (`resolveResult`): the rule under test is that a timeout must win over any
+/// partial stdout the child managed to print before being killed.
+final class MemoryToolRunnerTests: XCTestCase {
+
+    // The reported bug: a tool run that emits some stdout and THEN exceeds the
+    // hard timeout was returned as `.success` with that partial text. A timed-
+    // out run is incomplete by definition, so it must be `.failure(.timedOut)`
+    // regardless of what was captured.
+    func testTimeoutWithPartialOutputIsFailureNotSuccess() {
+        let partial = Data("Footprint: 195 MB\n[truncated, child killed]\n".utf8)
+        let result = MemoryToolRunner.resolveResult(timedOut: true, data: partial)
+        XCTAssertEqual(result, .failure(.timedOut))
+    }
+
+    // Control: a timeout that captured nothing is also `.failure(.timedOut)`.
+    // This case already worked before the fix (the empty-output branch consulted
+    // the flag); it is kept as a regression guard for the timeout path.
+    func testTimeoutWithNoOutputIsFailure() {
+        let result = MemoryToolRunner.resolveResult(timedOut: true, data: Data())
+        XCTAssertEqual(result, .failure(.timedOut))
+    }
+
+    // Control: a run that finished in time and produced output is `.success`
+    // carrying that text. Guards the happy path so the timeout fix does not
+    // regress the normal success return.
+    func testSuccessfulRunReturnsText() {
+        let output = Data("All zones: 202503 nodes (47995927 bytes)\n".utf8)
+        let result = MemoryToolRunner.resolveResult(timedOut: false, data: output)
+        XCTAssertEqual(result, .success("All zones: 202503 nodes (47995927 bytes)\n"))
+    }
+
+    // Control: a run that finished in time but printed nothing is the distinct
+    // `.noOutput` failure, not a timeout. Guards against the timeout check
+    // shadowing the no-output case.
+    func testInTimeRunWithNoOutputIsNoOutputFailure() {
+        let result = MemoryToolRunner.resolveResult(timedOut: false, data: Data())
+        XCTAssertEqual(result, .failure(.noOutput))
+    }
+}


### PR DESCRIPTION
## Summary

`MemoryToolRunner.run` captures the combined stdout/stderr of one of Apple's signed memory tools (`footprint`, `heap`, `leaks`, `sample`) and kills the child when it exceeds a hard timeout. When the child had already printed some output before being killed, the result was assembled as `.success(text)` without checking the `timedOut` flag, which was consulted only on the empty-output path. A timed-out run is incomplete by definition, so it must never be reported as success.

The captured-output decision is now a pure internal helper, `resolveResult(timedOut:data:)`, that returns `.failure(.timedOut)` first whenever the flag is set, before any `.success`. The in-time success and in-time no-output paths are unchanged, and `.noOutput` stays reachable. Callers (`HelperService`, `ProcessDeepDiveModel`, `MemoryInspectorModel`) all funnel a failure through their existing error path, so a timed-out run now surfaces an error instead of presenting truncated data: the helper replies `nil` and logs the failure, and the two view models turn a failure into `nil` via `try?`.

The helper is pulled out of `run` so the timeout precedence is unit-testable without spawning a real Apple tool, which could not reproduce a timeout-with-output case deterministically. This touches only the result decision; the tool invocation, process spawn, and argument building are unchanged.

## Related issue

No open issue tracked for this. (Closes none.)

## How verified

- New `Tests/MacPerfMonitorCoreTests/MemoryToolRunnerTests.swift` (XCTest, matching the rest of the Core suite) covers the full `(timedOut x empty/non-empty)` decision table: timeout with partial output, timeout with no output, in-time success, and in-time no-output.
- RED/GREEN proven: with the helper reverted to the prior logic, `testTimeoutWithPartialOutputIsFailureNotSuccess` fails (`success(...)` is not equal to `failure(.timedOut)`) while the three controls pass; with the fix restored, all four pass.
- `swift test`: 345 tests, 0 failures.
- `swift format lint --strict --recursive Sources Tests Package.swift`: clean.

## Checklist

- [x] `swift test` passes
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` passes
- [x] `CHANGELOG.md` updated under "Unreleased" for any user-visible change
- [x] No telemetry or network calls introduced
- [x] Data-layer changes keep `MacPerfMonitorCore` free of SwiftUI
