### PR TITLE
Report timeout as failure in MemoryToolRunner even with partial output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ### Fixed
 
+- **A timed-out memory inspection no longer masquerades as success:** the deep
+  memory inspector shells out to Apple's tools (`footprint`, `heap`, `leaks`,
+  `sample`) under a hard timeout, and a wedged target that printed a few lines
+  before hanging was killed on time, but its partial text was then returned as a
+  complete `.success` instead of `.failure(.timedOut)`. The decision checked the
+  captured text before the timeout flag, so any output at all, however truncated,
+  hid that the run had been cut short. The timeout now wins regardless of output:
+  a run killed for exceeding the limit reports `.timedOut` even when it managed
+  to write partial stdout first, so an incomplete report is shown as a failure
+  rather than presented as the tool's full answer.
 - **Quiet the notification spam during a sustained memory crisis:** real memory
   pressure can bounce between critical and normal while the kernel compresses,
   swaps, and throttles, and every bounce re-armed the alert so the next critical

--- a/Sources/MacPerfMonitorCore/System/MemoryToolRunner.swift
+++ b/Sources/MacPerfMonitorCore/System/MemoryToolRunner.swift
@@ -40,16 +40,39 @@ public enum MemoryToolRunner {
         maxBytes: Int = 8 * 1024 * 1024
     ) -> Result<String, RunError> {
         guard pid > 1 else { return .failure(.invalidPID) }
+        return capture(
+            executablePath: tool.executablePath,
+            arguments: tool.arguments(pid: pid),
+            label: tool.label,
+            pid: pid,
+            timeout: timeout,
+            maxBytes: maxBytes)
+    }
 
+    /// Spawn `executablePath` with `arguments`, drain its combined stdout/stderr
+    /// up to `maxBytes`, and kill it on `timeout`. Split out from `run` so tests
+    /// can drive it with a stub executable (a real Apple tool cannot be made to
+    /// hang on cue); the behaviour is identical to the public `run`.
+    ///
+    /// `label` is only the tag stamped into log lines so a stub run logs with the
+    /// same context a real tool run would.
+    internal static func capture(
+        executablePath: String,
+        arguments: [String],
+        label: String,
+        pid: Int32,
+        timeout: TimeInterval,
+        maxBytes: Int
+    ) -> Result<String, RunError> {
         // Spawn inside an autoreleasepool so the Process/Pipe/FileHandle file
         // descriptors are reclaimed when this returns rather than at the calling
-        // context's next pool drain — the same descriptor-leak guard the per-tick
+        // context's next pool drain, the same descriptor-leak guard the per-tick
         // spawners use (see NetworkProcessReader.runOneShot). Belt-and-braces here
         // (this is user-action only, not a hot loop), but keeps the pattern uniform.
         return autoreleasepool {
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: tool.executablePath)
-            process.arguments = tool.arguments(pid: pid)
+            process.executableURL = URL(fileURLWithPath: executablePath)
+            process.arguments = arguments
 
             // Combine stdout and stderr: the tools print their data to stdout and
             // their privilege/usage errors to stderr, and the caller wants to see
@@ -66,7 +89,7 @@ public enum MemoryToolRunner {
                 try process.run()
             } catch {
                 log.error(
-                    "launch \(tool.label, privacy: .public) failed: \(error.localizedDescription, privacy: .public)"
+                    "launch \(label, privacy: .public) failed: \(error.localizedDescription, privacy: .public)"
                 )
                 return .failure(.launchFailed(error.localizedDescription))
             }
@@ -104,7 +127,7 @@ public enum MemoryToolRunner {
             if exited.wait(timeout: .now() + timeout) == .timedOut {
                 timedOut = true
                 log.error(
-                    "\(tool.label, privacy: .public) on pid \(pid, privacy: .public) timed out after \(timeout, privacy: .public)s"
+                    "\(label, privacy: .public) on pid \(pid, privacy: .public) timed out after \(timeout, privacy: .public)s"
                 )
                 terminateHard(process)
             }
@@ -122,13 +145,20 @@ public enum MemoryToolRunner {
 
             if capped {
                 log.notice(
-                    "\(tool.label, privacy: .public) on pid \(pid, privacy: .public) output capped at \(maxBytes, privacy: .public) bytes"
+                    "\(label, privacy: .public) on pid \(pid, privacy: .public) output capped at \(maxBytes, privacy: .public) bytes"
                 )
             }
 
             let text = String(decoding: data, as: UTF8.self)
+            // A timeout must win regardless of any partial output the child wrote
+            // before it was killed. Checking this before the success return keeps a
+            // wedged run that managed to print a few lines from being misreported
+            // as a complete, successful result.
+            if timedOut {
+                return .failure(.timedOut)
+            }
             if text.isEmpty {
-                return timedOut ? .failure(.timedOut) : .failure(.noOutput)
+                return .failure(.noOutput)
             }
             return .success(text)
         }

--- a/Tests/MacPerfMonitorCoreTests/MemoryToolRunnerTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/MemoryToolRunnerTests.swift
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+/// `MemoryToolRunner` is the one place the project execs a subprocess, so its
+/// timeout/output decision is safety-relevant: a run that is killed for exceeding
+/// the hard timeout must report failure even if the child managed to write some
+/// stdout before it died, otherwise a wedged run is misreported as a complete,
+/// successful result. The public `run` resolves a fixed Apple tool path, which
+/// cannot be made to hang on cue, so these tests drive the internal `capture`
+/// seam with a `/bin/sh -c` stub script: the same Process machinery, just a
+/// program we control.
+final class MemoryToolRunnerTests: XCTestCase {
+
+    /// Small enough that the timeout cases finish in a couple of seconds while
+    /// still exercising the real wait/kill path.
+    private let timeoutSeconds: TimeInterval = 2
+
+    private func capture(script: String) -> Result<String, MemoryToolRunner.RunError> {
+        MemoryToolRunner.capture(
+            executablePath: "/bin/sh",
+            arguments: ["-c", script],
+            label: "stub",
+            pid: 99_999,
+            timeout: timeoutSeconds,
+            maxBytes: 8 * 1024 * 1024)
+    }
+
+    func testTimeoutWithPartialOutputIsFailureNotSuccess() {
+        // Prints one line, then outlives the timeout. The child was killed for
+        // timing out, so the result must be .timedOut even though it captured
+        // partial stdout before it died.
+        let result = capture(script: "printf 'partial output line one\\n'; sleep 30")
+
+        switch result {
+        case .failure(.timedOut):
+            break
+        case .failure(let error):
+            XCTFail("expected .failure(.timedOut), got .failure(\(error))")
+        case .success(let text):
+            XCTFail("expected .failure(.timedOut), got .success(\"\(text)\")")
+        }
+    }
+
+    func testFastSuccessfulRunReturnsCapturedOutput() {
+        // Finishes well within the timeout, so it is a genuine success that
+        // carries everything the child printed.
+        let result = capture(script: "printf 'full output\\n'")
+
+        switch result {
+        case .success(let text):
+            XCTAssertEqual(text, "full output\n")
+        case .failure(let error):
+            XCTFail("expected .success, got .failure(\(error))")
+        }
+    }
+
+    func testTimeoutWithNoOutputIsFailure() {
+        // Hangs without printing anything. The empty-output timeout path must
+        // keep returning .timedOut (regression guard for the empty-output branch).
+        let result = capture(script: "sleep 30")
+
+        switch result {
+        case .failure(.timedOut):
+            break
+        case .failure(let error):
+            XCTFail("expected .failure(.timedOut), got .failure(\(error))")
+        case .success(let text):
+            XCTFail("expected .failure(.timedOut), got .success(\"\(text)\")")
+        }
+    }
+
+    func testFastRunWithNoOutputIsNoOutputFailure() {
+        // Exits at once without printing anything (the `:` shell builtin is a
+        // no-op): a clean run that produced no output is .noOutput, distinct
+        // from a timeout. Guards that the timeout-precedence change did not
+        // swallow the genuine no-output failure.
+        let result = capture(script: ":")
+
+        switch result {
+        case .failure(.noOutput):
+            break
+        case .failure(let error):
+            XCTFail("expected .failure(.noOutput), got .failure(\(error))")
+        case .success(let text):
+            XCTFail("expected .failure(.noOutput), got .success(\"\(text)\")")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`MemoryToolRunner.run` misreported a timed-out inspection as success whenever the wedged target had written any partial stdout before it was killed.

The deep memory inspector runs `footprint`, `heap`, `leaks`, and `sample` under a hard wall-clock timeout so a pathological target cannot hang the daemon. When the timeout fired, the runner killed the child and then decided the result from whatever the child had written: it returned `.success` for any non-empty captured text and consulted the `timedOut` flag only on the empty-output branch. A target that printed a few lines and then hung (the real failure mode for a wedged run) therefore reported success with that truncated text, and the user saw an incomplete report presented as the tool's full answer instead of a failure.

The timeout now wins regardless of output. Right after assembling the captured text, a `timedOut` run returns `.failure(.timedOut)` before any `.success`, so a killed run is reported as a failure even when it managed to write partial stdout first. The genuine success path (a run that finished in time with output), the empty-output `.noOutput` path, and the process-spawn/argument-building logic are all unchanged; only the timeout precedence moved.

## Related issue

Self-found; no open issue. The defect is in the result-classification ordering, not in any single tool invocation.

## How verified

- New `MemoryToolRunnerTests` drives the spawn-and-drain body through an internal `capture(executablePath:arguments:label:pid:timeout:maxBytes:)` seam (extracted from `run`, behavior identical) using a `/bin/sh -c` stub script, since a real Apple tool cannot be made to hang on cue. It covers:
  - partial-output timeout (red before this change, green after),
  - fast success,
  - no-output timeout,
  - fast no-output run.
- `swift test --filter MemoryToolRunnerTests` passes.
- `swift format lint --strict --recursive Sources Tests Package.swift` is clean.

## Checklist

- [x] Code follows the project style (no em/en dashes; `MacPerfMonitorCore` stays SwiftUI-free).
- [x] New analysis/persistence logic ships with a test under `Tests/MacPerfMonitorCoreTests/`.
- [x] `swift test` and `swift format lint --strict` pass locally.
- [x] CHANGELOG entry added under `[Unreleased]`.
