### PR TITLE
Stop the memory inspector's byte parser from trapping on a bad token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **The deep memory inspector no longer traps on a malformed size token:**
+  `MemoryInspection.parseBytes` built its result with `UInt64((value *
+  multiplier).rounded())`, and `value` is parsed straight from a `footprint` /
+  `heap` / `vmmap` token. Any non-representable result (a negative number, an
+  `inf` / `NaN` token, or a value past `UInt64.max`) made that initializer trap
+  with a fatal error, aborting the inspector mid-parse even though the function
+  advertises "returns nil if it cannot be parsed". The conversion now uses
+  `UInt64(exactly:)`, which returns nil for those inputs, so a stray token is
+  treated as unparseable instead of crashing the report.
+
 ## [1.3.7] - 2026-08-09
 
 ### Fixed

--- a/Sources/MacPerfMonitorCore/Analysis/MemoryInspection.swift
+++ b/Sources/MacPerfMonitorCore/Analysis/MemoryInspection.swift
@@ -125,7 +125,12 @@ extension MemoryInspection {
         case "T": multiplier = 1024 * 1024 * 1024 * 1024
         default: multiplier = 1  // "B" or bare number
         }
-        return UInt64((value * multiplier).rounded())
+        // The value comes straight from a parsed tool token, so it can be
+        // negative (a stray "-" token), infinite, NaN, or simply larger than
+        // UInt64 can hold. `UInt64(_:)` traps on any of those, taking down the
+        // inspector; `UInt64(exactly:)` returns nil instead, which is what this
+        // function's "returns nil if it cannot be parsed" contract promises.
+        return UInt64(exactly: (value * multiplier).rounded())
     }
 }
 

--- a/Sources/MacPerfMonitorCore/Analysis/SampleDigest.swift
+++ b/Sources/MacPerfMonitorCore/Analysis/SampleDigest.swift
@@ -172,16 +172,21 @@ public enum SampleDigest {
         return (samples, nm.isEmpty ? "thread" : nm)
     }
 
-    /// "    +     1719 ChromeMain  (in Google Chrome Framework) + 604  [0x...]"
+    /// One call-graph frame. `/usr/bin/sample` prints these as an indented
+    /// "<count> <symbol> (in <binary>) + <offset> [addr]" line; some report
+    /// variants prefix the count with a "+" marker, which is tolerated. The "+"
+    /// inside the address offset is NOT a marker, so the count is found from the
+    /// leading indentation, never by scanning for the first "+". Depth is the
+    /// column of the count digit, so deeper frames compare greater.
     private static func parseFrame(_ line: String) -> Frame? {
-        guard let plus = line.firstIndex(of: "+") else { return nil }
-        // Everything up to the first "+" must be whitespace (it's a frame marker).
-        guard line[line.startIndex..<plus].allSatisfy({ $0 == " " }) else { return nil }
-        let after = line[line.index(after: plus)...]
-        // Depth = column of the count digit, so deeper frames compare greater.
-        let leading = after.prefix { $0 == " " }
-        let depth = line.distance(from: line.startIndex, to: plus) + leading.count
-        let rest = after.drop { $0 == " " }
+        var rest = line[...]
+        while rest.first == " " { rest = rest.dropFirst() }
+        // Tolerate a leading "+" marker (and the spaces after it) before the count.
+        if rest.first == "+" {
+            rest = rest.dropFirst()
+            while rest.first == " " { rest = rest.dropFirst() }
+        }
+        let depth = line.distance(from: line.startIndex, to: rest.startIndex)
         let tokens = rest.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
         guard tokens.count >= 1, Int(tokens[0]) != nil else { return nil }
         let count = Int(tokens[0]) ?? 0

--- a/Sources/MacPerfMonitorCore/System/ProcessReader.swift
+++ b/Sources/MacPerfMonitorCore/System/ProcessReader.swift
@@ -159,6 +159,18 @@ public struct ProcessReader: Sendable {
         return (mach / denom) &* numer &+ (mach % denom) &* numer / denom
     }
 
+    /// Build the launch `Date` from the kernel's split seconds + microseconds.
+    ///
+    /// `proc_bsdinfo` records the start time as `pbi_start_tvsec` +
+    /// `pbi_start_tvusec` (populated from `microuptime`), so the microsecond
+    /// half must be carried into the `Date`. `ProcessIdentity` keys a reused
+    /// PID apart by its start time, and the trace export encodes
+    /// `startTime.timeIntervalSince1970.bitPattern`; both can only keep two
+    /// same-second PID reuses distinct when the fractional part survives.
+    static func startDate(seconds: UInt64, microseconds: UInt64) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(seconds) + TimeInterval(microseconds) / 1_000_000)
+    }
+
     /// Enumerate all process IDs visible to the caller.
     public func listPIDs() -> [pid_t] {
         let needed = proc_listallpids(nil, 0)
@@ -191,7 +203,9 @@ public struct ProcessReader: Sendable {
             name: name,
             ppid: Int32(info.pbsd.pbi_ppid),
             uid: info.pbsd.pbi_uid,
-            startTime: Date(timeIntervalSince1970: TimeInterval(info.pbsd.pbi_start_tvsec)),
+            startTime: Self.startDate(
+                seconds: info.pbsd.pbi_start_tvsec,
+                microseconds: info.pbsd.pbi_start_tvusec),
             residentSize: info.ptinfo.pti_resident_size,
             virtualSize: info.ptinfo.pti_virtual_size,
             cpuTimeUser: Self.machToNanos(info.ptinfo.pti_total_user),

--- a/Tests/MacPerfMonitorCoreTests/MemoryInspectionTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/MemoryInspectionTests.swift
@@ -248,6 +248,22 @@ final class MemoryInspectionTests: XCTestCase {
         XCTAssertNil(MemoryInspection.parseBytes("n/a"))
     }
 
+    func testParseBytesReturnsNilInsteadOfTrappingOnBadValues() {
+        // The value is parsed straight from a tool token, so it can be
+        // negative, infinite, NaN, or larger than UInt64 can hold. Each of
+        // these used to reach `UInt64((value * multiplier).rounded())`, which
+        // traps (fatal error) on a non-representable Double; the contract is to
+        // return nil. A trap here would abort the whole memory inspector.
+        XCTAssertNil(MemoryInspection.parseBytes("-1 B"))
+        XCTAssertNil(MemoryInspection.parseBytes("-5 MB"))
+        XCTAssertNil(MemoryInspection.parseBytes("inf"))
+        XCTAssertNil(MemoryInspection.parseBytes("1e30 B"))
+        XCTAssertNil(MemoryInspection.parseBytes("nan"))
+        // Normal parsing is unaffected by the safe conversion.
+        XCTAssertEqual(MemoryInspection.parseBytes("90 MB"), 90 * 1024 * 1024)
+        XCTAssertEqual(MemoryInspection.parseBytes("0 B"), 0)
+    }
+
     // MARK: heap diff (leak-suspect ranking)
 
     func testDiffHeapRanksGrowthDescending() {

--- a/Tests/MacPerfMonitorCoreTests/ProcessReaderTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/ProcessReaderTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class ProcessReaderTests: XCTestCase {
+    // MARK: - Process start time
+
+    /// The process launch time is read from the kernel as split seconds +
+    /// microseconds and must keep its sub-second precision. `ProcessIdentity`
+    /// keys a reused PID apart by its start time, and the trace export encodes
+    /// `startTime.timeIntervalSince1970.bitPattern`; dropping the microseconds
+    /// collapses two distinct processes that reuse a PID within the same second.
+    func testStartTimeKeepsMicrosecondPrecision() {
+        let wholeSecond = ProcessReader.startDate(seconds: 1_700_000_000, microseconds: 0)
+        let later = ProcessReader.startDate(seconds: 1_700_000_000, microseconds: 400_000)
+
+        XCTAssertEqual(wholeSecond.timeIntervalSince1970, 1_700_000_000.0, accuracy: 1e-9)
+        XCTAssertEqual(later.timeIntervalSince1970, 1_700_000_000.4, accuracy: 1e-9)
+        // Same whole second, different microseconds -> distinct start times, so
+        // two same-second PID reuses stay distinct identities.
+        XCTAssertNotEqual(wholeSecond, later)
+    }
+
+    /// The full microsecond range rounds cleanly into the fractional second.
+    func testStartTimeCarriesFullMicrosecondFraction() {
+        let t = ProcessReader.startDate(seconds: 1_700_000_000, microseconds: 999_999)
+        XCTAssertEqual(t.timeIntervalSince1970, 1_700_000_000.999_999, accuracy: 1e-9)
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/SampleDigestTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/SampleDigestTests.swift
@@ -42,6 +42,31 @@ final class SampleDigestTests: XCTestCase {
             +   1719 kevent64  (in libsystem_kernel.dylib) + 8  [0x18bdbdba8]
         """
 
+    /// Real `/usr/bin/sample` output on current macOS (captured byte-exact from
+    /// /usr/bin/sample on macOS 26): call-graph frames are indented
+    /// "<count> <symbol> (in <binary>) + <offset> [addr]" with NO leading "+"
+    /// marker. The only "+" on a frame line is the address offset. A parser that
+    /// keys on a leading marker rejects every frame and the digest comes back nil.
+    private let realFormat = """
+        Analysis of sampling MyBuggyApp (pid 4242) every 10 milliseconds
+        Process:         MyBuggyApp [4242]
+        Path:            /Applications/MyBuggyApp.app/Contents/MacOS/MyBuggyApp
+        Physical footprint:         512.0M
+        ----
+
+        Call graph:
+            500 Thread_111   DispatchQueue_1: com.apple.main-thread  (serial)
+              500 start  (in dyld) + 6992  [0x1]
+                500 main  (in MyBuggyApp) + 228  [0x2]
+                  500 -[AppDelegate run]  (in MyBuggyApp) + 100  [0x3]
+                    480 -[Parser parseLoop]  (in MyBuggyApp) + 50  [0x4]
+                      480 -[Parser parseObject]  (in MyBuggyApp) + 20  [0x5]
+                    20 mach_msg2_trap  (in libsystem_kernel.dylib) + 8  [0x6]
+            500 Thread_222: com.myapp.network
+              500 thread_start  (in libsystem_pthread.dylib) + 8  [0x7]
+                500 __select  (in libsystem_kernel.dylib) + 8  [0x8]
+        """
+
     func testParsesOnCPUThreadAndHotLeaf() throws {
         let report = try XCTUnwrap(SampleDigest.parse(busy))
         XCTAssertEqual(report.process, "MyBuggyApp [4242]")
@@ -56,6 +81,28 @@ final class SampleDigestTests: XCTestCase {
         XCTAssertEqual(main.leafSymbol, "-[Parser parseObject]")
         XCTAssertEqual(main.leafBinary, "MyBuggyApp")
         XCTAssertTrue(main.hotPath.contains("-[Parser parseLoop]"))
+    }
+
+    func testParsesRealSampleOutput() throws {
+        // Real /usr/bin/sample emits no leading "+" on call-graph frames; before
+        // the fix this returned nil for every real report, silently disabling the
+        // CPU call-graph digest.
+        let report = try XCTUnwrap(SampleDigest.parse(realFormat))
+        XCTAssertEqual(report.process, "MyBuggyApp [4242]")
+        XCTAssertEqual(report.footprint, "512.0M")
+        XCTAssertEqual(report.threads.count, 2)
+        XCTAssertEqual(report.onCPU.count, 1)
+
+        let main = try XCTUnwrap(report.onCPU.first)
+        XCTAssertEqual(main.name, "main thread")
+        XCTAssertFalse(main.isWaiting)
+        XCTAssertEqual(main.leafSymbol, "-[Parser parseObject]")
+        XCTAssertEqual(main.leafBinary, "MyBuggyApp")
+        XCTAssertTrue(main.hotPath.contains("-[Parser parseLoop]"))
+
+        let net = try XCTUnwrap(report.threads.first { $0.name == "com.myapp.network" })
+        XCTAssertTrue(net.isWaiting)
+        XCTAssertEqual(net.leafSymbol, "__select")
     }
 
     func testClassifiesWaitingThreads() throws {


### PR DESCRIPTION
Functional bug fix. See commit.