### PR TITLE
Classify the whole IPv6 link-local range, not just fe80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ### Fixed
 
+- **The network scanner recognises the whole IPv6 link-local range:** the NDP
+  table parser and the per-interface address collector matched only an `fe80`
+  prefix, but RFC 4291 defines link-local unicast as `fe80::/10`, which spans
+  `fe80::` through `febf::`. Addresses in `fe90::` to `febf::` were sorted into
+  the global bucket of the NDP view and, on the Network page, were kept in the
+  global IPv6 list instead of being filtered out as link-local noise. A shared
+  `isIPv6LinkLocal` predicate now matches the full `fe80::/10` range, so every
+  link-local address lands in the right place.
+
 - **The deep memory inspector no longer traps on a malformed size token:**
   `MemoryInspection.parseBytes` built its result with `UInt64((value *
   multiplier).rounded())`, and `value` is parsed straight from a `footprint` /

--- a/Sources/MacPerfMonitorCore/System/NetworkInfoReader.swift
+++ b/Sources/MacPerfMonitorCore/System/NetworkInfoReader.swift
@@ -165,7 +165,7 @@ public final class NetworkInfoReader {
                 }
             case AF_INET6:
                 if let s = Self.addressString(addr, family: AF_INET6) {
-                    let linkLocal = s.hasPrefix("fe80")
+                    let linkLocal = NetworkScanner.isIPv6LinkLocal(s)
                     if !linkLocal { entry.ipv6.append(s) }
                     let prefix = ifa.ifa_netmask.flatMap { Self.prefixLength($0, family: AF_INET6) }
                     entry.addresses.append(

--- a/Sources/MacPerfMonitorCore/System/NetworkScanner.swift
+++ b/Sources/MacPerfMonitorCore/System/NetworkScanner.swift
@@ -553,6 +553,17 @@ public final class NetworkScanner: @unchecked Sendable {
         var global: Set<String> = []
     }
 
+    /// Whether an IPv6 address string is link-local (RFC 4291 section 2.5.6,
+    /// fe80::/10). The first byte is 0xFE and the second byte's top two bits are
+    /// 10, so its high nibble is 8-B; the full fe80:: through febf:: range is
+    /// link-local, not just the fe80::/64 addresses hosts usually generate.
+    static func isIPv6LinkLocal(_ address: String) -> Bool {
+        let a = address.lowercased()
+        guard a.count >= 3, a.hasPrefix("fe") else { return false }
+        let third = a[a.index(a.startIndex, offsetBy: 2)]
+        return third == "8" || third == "9" || third == "a" || third == "b"
+    }
+
     static func parseNDPTable(
         _ output: String, interfaceName: String
     ) -> [String: IPv6Addresses] {
@@ -565,7 +576,7 @@ public final class NetworkScanner: @unchecked Sendable {
             let address =
                 fields[0].split(separator: "%", maxSplits: 1).first.map(String.init) ?? fields[0]
             var addresses = result[mac] ?? IPv6Addresses()
-            if address.lowercased().hasPrefix("fe80:") {
+            if Self.isIPv6LinkLocal(address) {
                 addresses.local.insert(address)
             } else {
                 addresses.global.insert(address)

--- a/Tests/MacPerfMonitorCoreTests/NetworkTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/NetworkTests.swift
@@ -96,6 +96,40 @@ final class NetworkTests: XCTestCase {
         XCTAssertEqual(entries["00:11:32:98:C7:B2"]?.global, ["fd12::42"])
     }
 
+    func testNetworkScannerClassifiesFullLinkLocalRange() {
+        // RFC 4291 section 2.5.6: link-local is fe80::/10, so fe80 through febf
+        // all qualify, not just the fe80::/64 addresses macOS auto-generates.
+        // fec0::/10 is the deprecated site-local range, and not link-local.
+        let output = """
+            Neighbor Linklayer Address Netif Expire St Flgs Prbs
+            fe80::1%en0 0:11:32:98:c7:b2 en0 23h S
+            fe90::2%en0 0:11:32:98:c7:b2 en0 23h S
+            febf::3%en0 0:11:32:98:c7:b2 en0 23h S
+            fec0::4%en0 0:11:32:98:c7:b2 en0 23h S
+            2001:db8::5%en0 0:11:32:98:c7:b2 en0 23h S
+            """
+        let entries = NetworkScanner.parseNDPTable(output, interfaceName: "en0")
+        XCTAssertEqual(
+            entries["00:11:32:98:C7:B2"]?.local, ["fe80::1", "fe90::2", "febf::3"])
+        XCTAssertEqual(
+            entries["00:11:32:98:C7:B2"]?.global, ["fec0::4", "2001:db8::5"])
+    }
+
+    func testNetworkScannerLinkLocalPredicateMatchesRFCRange() {
+        // fe80::/10 covers fe80 through febf (second byte 0x80-0xBF).
+        XCTAssertTrue(NetworkScanner.isIPv6LinkLocal("fe80::1"))
+        XCTAssertTrue(NetworkScanner.isIPv6LinkLocal("fe90::1"))
+        XCTAssertTrue(NetworkScanner.isIPv6LinkLocal("fea0::1"))
+        XCTAssertTrue(NetworkScanner.isIPv6LinkLocal("febf::1"))
+        XCTAssertTrue(NetworkScanner.isIPv6LinkLocal("FE90::1"))
+        // Outside the range: deprecated site-local, ULA, multicast, global, loopback.
+        XCTAssertFalse(NetworkScanner.isIPv6LinkLocal("fec0::1"))
+        XCTAssertFalse(NetworkScanner.isIPv6LinkLocal("fd00::1"))
+        XCTAssertFalse(NetworkScanner.isIPv6LinkLocal("ff00::1"))
+        XCTAssertFalse(NetworkScanner.isIPv6LinkLocal("2001:db8::1"))
+        XCTAssertFalse(NetworkScanner.isIPv6LinkLocal("::1"))
+    }
+
     func testNetworkScannerParsesSMBIdentity() {
         let output = """
             NetBIOS Name Number Type Description


### PR DESCRIPTION
## Summary
The NDP table parser (`NetworkScanner.parseNDPTable`) and the per-interface address collector (`NetworkInfoReader.rawInterfaces`) both decided an IPv6 address was link-local by matching an `fe80` prefix. RFC 4291 section 2.5.6 defines link-local unicast as `fe80::/10`, a range that runs from `fe80::` through `febf::` (first byte `0xFE`, second byte's top two bits `10`, so its high nibble is 8 to B). Matching only `fe80` left `fe90::`, `fea0::`, and `febf::` addresses in the wrong bucket: they landed in the NDP view's global half, and on the Network page they were kept in the global IPv6 list instead of being filtered out as link-local noise.

The hosts a Mac actually talks to almost always generate `fe80::/64` link-locals, which is why the prefix check survived, but the parser was provably wrong on RFC-valid input. A shared `NetworkScanner.isIPv6LinkLocal` predicate now recognises the full `fe80::/10` range, and both call sites use it.

## Related issue
No linked issue.

## How verified
- `swift test` - 351/351 pass (2 new in `NetworkTests`: the full-range NDP classification, and the predicate pinned to `fe80`/`fe90`/`fea0`/`febf` in vs `fec0`/`fd00`/`ff00`/`2001:db8`/`::1` out).
- `swift format lint --strict --recursive Sources Tests Package.swift` - clean.

## Checklist
- [x] `swift test` passes
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` passes
- [x] `CHANGELOG.md` updated under "Unreleased" for any user-visible change
- [x] No telemetry or network calls introduced
- [x] Data-layer changes keep `MacPerfMonitorCore` free of SwiftUI