### PR TITLE
Keep hot battery Celsius readings out of the Kelvin decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ### Fixed
 
+- **Hot battery temperatures are no longer misread as sub-zero:** the
+  AppleSmartBattery `Temperature` key is centi-degrees, and most controllers
+  report centi-Celsius while a few report centi-Kelvin. The decoder told the
+  two apart with a greater-than-100 threshold, but 100 degrees is plausible
+  for an actively failing cell, so a genuine (if extreme) Celsius reading
+  above that was treated as Kelvin and converted to a value below absolute
+  zero. The detector now uses a 200 threshold: no real Celsius reading
+  reaches it (thermal runaway destroys the cell first), and no real Kelvin
+  reading falls below it (that would be a battery colder than minus 73
+  degrees), so the two units separate cleanly. The decode is also extracted
+  into a pure helper so it is unit-tested alongside the other battery
+  decoders.
 - **The network scanner recognises the whole IPv6 link-local range:** the NDP
   table parser and the per-interface address collector matched only an `fe80`
   prefix, but RFC 4291 defines link-local unicast as `fe80::/10`, which spans

--- a/Sources/MacPerfMonitorCore/System/BatteryReader.swift
+++ b/Sources/MacPerfMonitorCore/System/BatteryReader.swift
@@ -146,11 +146,7 @@ public struct BatteryReader: Sendable {
                 sample.amperageMilliAmps = Int(Int32(truncatingIfNeeded: ampRaw))
             }
             if let tempRaw = smart["Temperature"] as? Int {
-                // AppleSmartBattery reports temperature in 1/100 of a degree.
-                // Centi-Celsius for most controllers; a few report centi-Kelvin,
-                // so convert when the result lands in an implausibly hot range.
-                let scaled = Double(tempRaw) / 100
-                sample.temperatureCelsius = scaled > 100 ? scaled - 273.15 : scaled
+                sample.temperatureCelsius = Self.temperatureCelsius(fromCenti: tempRaw)
             }
         }
 
@@ -433,6 +429,20 @@ public struct BatteryReader: Sendable {
             out.gasGaugeChip = name
         }
         return out
+    }
+
+    /// Decode the AppleSmartBattery `Temperature` key (centi-degrees) to Celsius.
+    /// Most controllers report centi-Celsius; a few report centi-Kelvin, which the
+    /// detector spots from a value too hot to be a real Celsius reading. The
+    /// threshold is 200: a battery cell much past 120 degrees is in thermal
+    /// runaway, while a Kelvin reading below 200 would mean a battery below -73
+    /// degrees, outside any operating spec, so 200 separates the two units with
+    /// margin on each side. The previous 100 threshold sat right at the edge of
+    /// plausible hot-Celsius and converted a genuine, if extreme, reading into a
+    /// sub-absolute-zero value. Pure (no IOKit) so it can be unit-tested.
+    static func temperatureCelsius(fromCenti raw: Int) -> Double {
+        let scaled = Double(raw) / 100
+        return scaled > 200 ? scaled - 273.15 : scaled
     }
 
     /// The Mac's instantaneous total system power draw in watts, from the SMC's

--- a/Tests/MacPerfMonitorCoreTests/BatteryTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/BatteryTests.swift
@@ -304,6 +304,27 @@ final class BatteryTests: XCTestCase {
         XCTAssertNil(empty.gasGaugeChip)
     }
 
+    // MARK: - Temperature decode
+
+    func testBatteryTemperatureDecodesCentiCelsius() {
+        // Most controllers report centi-Celsius: 3142 -> 31.42 degrees.
+        XCTAssertEqual(BatteryReader.temperatureCelsius(fromCenti: 3142), 31.42, accuracy: 0.001)
+    }
+
+    func testBatteryTemperatureKeepsHotCelsiusBelowKelvinFloor() {
+        // 10500 centi = 105 degrees Celsius, a genuine (if extreme) reading that
+        // the old 100 threshold misread as Kelvin and converted to -168.15. It
+        // stays below the 200 Kelvin floor, so it is kept as Celsius.
+        XCTAssertEqual(BatteryReader.temperatureCelsius(fromCenti: 10500), 105.0, accuracy: 0.001)
+    }
+
+    func testBatteryTemperatureConvertsCentiKelvin() {
+        // A centi-Kelvin controller: 30315 -> 303.15 K -> 30.0 degrees Celsius.
+        XCTAssertEqual(BatteryReader.temperatureCelsius(fromCenti: 30315), 30.0, accuracy: 0.001)
+        // 0 degrees Celsius reported in Kelvin (27315 centi-Kelvin) round-trips.
+        XCTAssertEqual(BatteryReader.temperatureCelsius(fromCenti: 27315), 0.0, accuracy: 0.001)
+    }
+
     // MARK: - EnergyImpact
 
     func testEnergyImpactCombinesCPUAndWakeups() {


### PR DESCRIPTION
## Summary
The `AppleSmartBattery` `Temperature` key is reported in centi-degrees, and the decoder has to tell centi-Celsius (the common case) apart from the centi-Kelvin controllers by magnitude: a Kelvin reading is far larger than any plausible Celsius one. The discriminator was set at `> 100`, but 100 degrees is a plausible, if extreme, reading for an actively failing cell. A genuine Celsius value above that was treated as Kelvin and converted to a value below absolute zero (for example a 105 degree reading became minus 168).

The threshold moves to 200. A real Celsius reading never reaches it (thermal runaway destroys a lithium cell well below that), and a real Kelvin reading never falls below it (200 kelvin is minus 73 degrees, outside any battery operating spec), so the two units separate with margin on each side instead of meeting at the edge of plausible hot-Celsius. The decode is also extracted into a pure `temperatureCelsius(fromCenti:)` static helper, matching the other battery decoders (`capacityReadout`, `electricalDetail`, `manufactureDate`) that are already unit-tested.

## Related issue
No linked issue.

## How verified
- `swift test` - 352/352 pass (3 new in `BatteryTests`: normal centi-Celsius, the regression for a 105 degree reading kept as Celsius instead of minus 168, and centi-Kelvin conversion).
- `swift format lint --strict --recursive Sources Tests Package.swift` - clean.

## Checklist
- [x] `swift test` passes
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` passes
- [x] `CHANGELOG.md` updated under "Unreleased" for any user-visible change
- [x] No telemetry or network calls introduced
- [x] Data-layer changes keep `MacPerfMonitorCore` free of SwiftUI