### PR TITLE
Add a dedicated Disk tab with hardware, volumes, SMART, and IO history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ## [Unreleased]
 
+### Added
+
+- **A dedicated Disk tab:** every disk fact the system exposes, on one page.
+  Live read/write throughput and IOPS with history, per-operation service
+  latency and a busy-time utilization figure derived from the driver's
+  counters, a card per physical device with its full hardware identity (model,
+  vendor, firmware, serial, interconnect, NAND status, NVMe revision, block
+  size), per-volume capacity bars grouped by APFS container with purgeable
+  space and role badges, SMART health for the internal SSD (temperature, life
+  used, spare, power-on hours, unsafe shutdowns, lifetime reads and writes),
+  a boot-volume free-space trend with a low-space rule, and the top processes
+  by attributed disk I/O over the selected range. The menu bar disk panel's
+  Open button now lands on the new tab.
+- **Disk detail history (schema v12):** system samples now record read/write
+  service latency, disk utilization, and boot volume free space (sampled once
+  a minute), with minute and hour rollups. The new columns are nullable on
+  purpose: an interval with no IO charts as a gap, never as a fake 0 ms, and
+  free space keeps its low water mark through every aggregation tier.
+
 ### Fixed
 
 - **The network scanner recognises the whole IPv6 link-local range:** the NDP

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Free and open source. No telemetry. Every sample stays on your Mac.
   footprint as a share of the device.
 - **History and logging:** configurable-resolution logging to a local SQLite store;
   top consumers over any window you pick.
-- **Disk activity:** physical read/write throughput, IOPS, device health, and
-  per-process attribution, with history from one hour to seven days.
+- **Disk tab:** live throughput, IOPS, service latency, and utilization with
+  history; per-device hardware identity; per-volume capacity bars grouped by
+  APFS container with purgeable space; SMART health for the internal SSD; a
+  boot-volume free-space trend; and top processes by attributed disk I/O.
 - **Leak detection:** flags processes whose footprint climbs steadily, plus a log of
   pressure events over time.
 - **Deep-dive diagnostics:** explains what a process is and whether its behavior is

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -32,7 +32,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.7</string>
 	<key>CFBundleVersion</key>
-	<string>186</string>
+	<string>187</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>

--- a/Sources/CMacPerfMonitor/include/CMacPerfMonitor.h
+++ b/Sources/CMacPerfMonitor/include/CMacPerfMonitor.h
@@ -70,4 +70,20 @@ typedef struct {
 /// error, matching `PROC_PIDLISTFDS`.
 int cmacperfmonitor_list_fds(pid_t pid, cmacperfmonitor_fd_t *out, int capacity);
 
+/// Read the raw 512-byte NVMe SMART / Health log for the NVMe controller or
+/// block storage device with the given IORegistry entry ID, via the
+/// `IONVMeSMARTUserClient` plug-in interface.
+///
+/// C code only fetches the bytes (the COM-style plug-in dance is impossible in
+/// Swift); all parsing stays in Swift so it can be unit-tested against fixture
+/// blobs. `out` must point to at least 512 bytes and is only written on
+/// success.
+///
+/// Returns 0 on success, or a negative step code on failure: -1 no such
+/// registry entry, -2 the service has no SMART plug-in (external and USB
+/// enclosures commonly refuse this), -3 interface query failed, -4 the SMART
+/// read itself failed. Callers should treat every nonzero result as "SMART not
+/// available", not as an error worth surfacing.
+int cmacperfmonitor_nvme_smart_read(uint64_t registry_entry_id, uint8_t *out);
+
 #endif /* CMACPERFMONITOR_H */

--- a/Sources/CMacPerfMonitor/shim.c
+++ b/Sources/CMacPerfMonitor/shim.c
@@ -189,3 +189,49 @@ int cmacperfmonitor_list_fds(pid_t pid, cmacperfmonitor_fd_t *out, int capacity)
     free(fds);
     return written;
 }
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+#include <IOKit/IOCFPlugIn.h>
+#include <IOKit/storage/nvme/NVMeSMARTLibExternal.h>
+
+int cmacperfmonitor_nvme_smart_read(uint64_t registry_entry_id, uint8_t *out) {
+    io_service_t service = IOServiceGetMatchingService(
+        kIOMainPortDefault, IORegistryEntryIDMatching(registry_entry_id));
+    if (service == IO_OBJECT_NULL) {
+        return -1;
+    }
+
+    // COM-style plug-in dance: create the plug-in for the service, then query
+    // the SMART interface off it. Both must be released, in reverse order.
+    IOCFPlugInInterface **plugin = NULL;
+    SInt32 score = 0;
+    kern_return_t kr = IOCreatePlugInInterfaceForService(
+        service, kIONVMeSMARTUserClientTypeID, kIOCFPlugInInterfaceID, &plugin, &score);
+    IOObjectRelease(service);
+    if (kr != KERN_SUCCESS || plugin == NULL) {
+        return -2;
+    }
+
+    IONVMeSMARTInterface **smart = NULL;
+    HRESULT hr = (*plugin)->QueryInterface(
+        plugin, CFUUIDGetUUIDBytes(kIONVMeSMARTInterfaceID), (LPVOID *)&smart);
+    if (hr != S_OK || smart == NULL) {
+        IODestroyPlugInInterface(plugin);
+        return -3;
+    }
+
+    NVMeSMARTData data;
+    memset(&data, 0, sizeof(data));
+    IOReturn ret = (*smart)->SMARTReadData(smart, &data);
+    (*smart)->Release(smart);
+    IODestroyPlugInInterface(plugin);
+    if (ret != kIOReturnSuccess) {
+        return -4;
+    }
+
+    // NVMeSMARTData is pragma pack(1) and exactly the 512-byte log page.
+    _Static_assert(sizeof(NVMeSMARTData) == 512, "NVMe SMART log must be 512 bytes");
+    memcpy(out, &data, sizeof(data));
+    return 0;
+}

--- a/Sources/MacPerfMonitor/Charts/DiskChart.swift
+++ b/Sources/MacPerfMonitor/Charts/DiskChart.swift
@@ -30,7 +30,8 @@ struct DiskChart: View {
                     color: DiskStyle.write, filled: false, lineWidth: 1.8),
             ],
             yFormat: { ByteFormat.rate(max($0, 0)) },
-            showsTimeAxis: showsTimeAxis
+            showsTimeAxis: showsTimeAxis,
+            leftGutter: 56
         )
         .accessibilityLabel("Physical disk throughput trend")
         .accessibilityValue(accessibilitySummary)

--- a/Sources/MacPerfMonitor/Charts/DiskIOPSChart.swift
+++ b/Sources/MacPerfMonitor/Charts/DiskIOPSChart.swift
@@ -1,0 +1,40 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+struct DiskIOPSChart: View {
+    let points: [SystemHistoryPoint]
+    var showsTimeAxis = false
+
+    private var accessibilitySummary: String {
+        guard let latest = points.last else { return "No data yet." }
+        let peak =
+            points.map {
+                max($0.diskReadOperationsPerSec, $0.diskWriteOperationsPerSec)
+            }.max() ?? 0
+        return
+            "Currently \(Int(latest.diskReadOperationsPerSec)) read and "
+            + "\(Int(latest.diskWriteOperationsPerSec)) write operations per second. "
+            + "Peak \(Int(peak)) over the shown window."
+    }
+
+    var body: some View {
+        TrendChart(
+            series: [
+                TrendSeries(
+                    points: points.map {
+                        TrendPoint(date: $0.date, value: $0.diskReadOperationsPerSec)
+                    },
+                    color: DiskStyle.read, filled: true),
+                TrendSeries(
+                    points: points.map {
+                        TrendPoint(date: $0.date, value: $0.diskWriteOperationsPerSec)
+                    },
+                    color: DiskStyle.write, filled: false, lineWidth: 1.8),
+            ],
+            yFormat: { "\(Int(max($0, 0)))" },
+            showsTimeAxis: showsTimeAxis
+        )
+        .accessibilityLabel("Disk operations per second trend")
+        .accessibilityValue(accessibilitySummary)
+    }
+}

--- a/Sources/MacPerfMonitor/Charts/DiskLatencyChart.swift
+++ b/Sources/MacPerfMonitor/Charts/DiskLatencyChart.swift
@@ -1,0 +1,53 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// Average device service time per operation. The latency fields are optional
+/// (nil marks an interval with no IO), so each series carries only the points
+/// that have a value: `TrendChart`'s gap splitting then leaves quiet stretches
+/// blank instead of bridging them or drawing a misleading 0 ms floor.
+struct DiskLatencyChart: View {
+    let points: [SystemHistoryPoint]
+    var showsTimeAxis = false
+
+    private var readPoints: [TrendPoint] {
+        points.compactMap { point in
+            point.diskReadLatencyMs.map { TrendPoint(date: point.date, value: $0) }
+        }
+    }
+
+    private var writePoints: [TrendPoint] {
+        points.compactMap { point in
+            point.diskWriteLatencyMs.map { TrendPoint(date: point.date, value: $0) }
+        }
+    }
+
+    private var accessibilitySummary: String {
+        let reads = readPoints
+        let writes = writePoints
+        guard !reads.isEmpty || !writes.isEmpty else {
+            return "No disk activity with measurable latency in the shown window."
+        }
+        var parts: [String] = []
+        if let read = reads.last {
+            parts.append(String(format: "read %.2f milliseconds per operation", read.value))
+        }
+        if let write = writes.last {
+            parts.append(String(format: "write %.2f milliseconds per operation", write.value))
+        }
+        return "Latest " + parts.joined(separator: ", ") + "."
+    }
+
+    var body: some View {
+        TrendChart(
+            series: [
+                TrendSeries(points: readPoints, color: DiskStyle.read, filled: false),
+                TrendSeries(
+                    points: writePoints, color: DiskStyle.write, filled: false, lineWidth: 1.8),
+            ],
+            yFormat: { String(format: "%.1f ms", max($0, 0)) },
+            showsTimeAxis: showsTimeAxis
+        )
+        .accessibilityLabel("Disk service time trend")
+        .accessibilityValue(accessibilitySummary)
+    }
+}

--- a/Sources/MacPerfMonitor/Charts/FreeSpaceChart.swift
+++ b/Sources/MacPerfMonitor/Charts/FreeSpaceChart.swift
@@ -1,0 +1,56 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// Boot volume free space over the selected range: the "is the disk filling
+/// up" chart. Draws a dashed warning rule at 10 percent of the volume's
+/// capacity when the total is known.
+struct FreeSpaceChart: View {
+    let points: [SystemHistoryPoint]
+    var showsTimeAxis = false
+
+    private var freePoints: [TrendPoint] {
+        points.compactMap { point in
+            point.bootFreeBytes.map { TrendPoint(date: point.date, value: Double($0)) }
+        }
+    }
+
+    private var totalBytes: UInt64? {
+        points.reversed().compactMap(\.bootTotalBytes).first
+    }
+
+    private var accessibilitySummary: String {
+        guard let latest = freePoints.last else { return "No free space history yet." }
+        var summary = "Currently \(ByteFormat.string(UInt64(max(0, latest.value)))) free"
+        if let total = totalBytes {
+            summary += " of \(ByteFormat.string(total))"
+        }
+        if let first = freePoints.first, first.value > latest.value {
+            summary +=
+                ", down \(ByteFormat.string(UInt64(first.value - latest.value))) over the window"
+        }
+        return summary + "."
+    }
+
+    var body: some View {
+        TrendChart(
+            series: [
+                TrendSeries(points: freePoints, color: DiskStyle.read, filled: true)
+            ],
+            // Anchor the domain at zero up to the disk's capacity so the line's
+            // height reads as "how much of the disk is left", not an auto-zoomed
+            // wiggle that makes a stable disk look like a cliff.
+            yDomain: totalBytes.map { 0...Double($0) },
+            yFormat: { ByteFormat.string(UInt64(max($0, 0))) },
+            rules: totalBytes.map {
+                [
+                    TrendRule(
+                        value: Double($0) * 0.10, label: "Low", color: .orange)
+                ]
+            } ?? [],
+            showsTimeAxis: showsTimeAxis,
+            leftGutter: 56
+        )
+        .accessibilityLabel("Boot volume free space trend")
+        .accessibilityValue(accessibilitySummary)
+    }
+}

--- a/Sources/MacPerfMonitor/Charts/NetworkChart.swift
+++ b/Sources/MacPerfMonitor/Charts/NetworkChart.swift
@@ -36,7 +36,8 @@ struct NetworkChart: View {
                     color: NetworkStyle.upload, filled: false, lineWidth: 1.8),
             ],
             yFormat: { ByteFormat.rate(max($0, 0)) },
-            showsTimeAxis: showsTimeAxis
+            showsTimeAxis: showsTimeAxis,
+            leftGutter: 56
         )
         .accessibilityLabel("Network throughput trend")
         .accessibilityValue(accessibilitySummary)

--- a/Sources/MacPerfMonitor/Charts/TrendChart.swift
+++ b/Sources/MacPerfMonitor/Charts/TrendChart.swift
@@ -44,7 +44,11 @@ struct TrendChart: View {
     /// dashboard charts keep their full height.
     var showsTimeAxis: Bool = false
 
-    private let leftGutter: CGFloat = 38
+    /// Width reserved for the Y axis labels. The default fits short tick
+    /// strings ("85%", "1.2 GB"); charts whose ticks format as byte rates or
+    /// large sizes ("38.4 MB/s", "460.4 GB") pass a wider gutter, because the
+    /// canvas clips the label's left edge when it does not fit.
+    var leftGutter: CGFloat = 38
     private let topPad: CGFloat = 6
     private let bottomPad: CGFloat = 4
 

--- a/Sources/MacPerfMonitor/Util/DiskStyle.swift
+++ b/Sources/MacPerfMonitor/Util/DiskStyle.swift
@@ -1,6 +1,62 @@
+import AppKit
+import MacPerfMonitorCore
 import SwiftUI
 
 enum DiskStyle {
     static let read = Color.blue
     static let write = Color.orange
+
+    /// Utilization gauge tint: neutral until the disk is genuinely busy.
+    static func utilization(_ percent: Double) -> Color {
+        percent >= 90 ? .red : percent >= 60 ? .orange : .secondary
+    }
+
+    // MARK: - Capacity bar
+
+    // The capacity slices use a fixed five-slot categorical order validated
+    // for adjacent-pair colorblind separation on light and dark surfaces
+    // (adjacent hues in render order: blue, orange, aqua, yellow, magenta).
+    // Slices always render in this order: named volumes take slots 0 to 2,
+    // purgeable is always slot 3, folded "other volumes" slot 4, and free is
+    // a recessive track rather than a data hue. Reordering the slots breaks
+    // the validated adjacency; do not shuffle them.
+    private static let slots: [Color] = [
+        dynamic(light: 0x2A78D6, dark: 0x3987E5),  // blue
+        dynamic(light: 0xEB6834, dark: 0xD95926),  // orange
+        dynamic(light: 0x1BAF7A, dark: 0x199E70),  // aqua
+        dynamic(light: 0xEDA100, dark: 0xC98500),  // yellow (purgeable)
+        dynamic(light: 0xE87BA4, dark: 0xD55181),  // magenta (other volumes)
+    ]
+
+    static func capacityColor(for slice: DiskCapacitySlice, namedIndex: Int) -> Color {
+        switch slice.kind {
+        case .volume: return slots[min(namedIndex, 2)]
+        case .purgeable: return slots[3]
+        case .otherVolumes: return slots[4]
+        case .free: return freeTrack
+        }
+    }
+
+    /// Free space is absence, not a data series: a near-surface track fill.
+    static let freeTrack = Color.primary.opacity(0.10)
+
+    private static func dynamic(light: UInt32, dark: UInt32) -> Color {
+        Color(
+            nsColor: NSColor(
+                name: nil,
+                dynamicProvider: { appearance in
+                    let match = appearance.bestMatch(from: [.aqua, .darkAqua])
+                    return NSColor(hex: match == .darkAqua ? dark : light)
+                }))
+    }
+}
+
+extension NSColor {
+    fileprivate convenience init(hex: UInt32) {
+        self.init(
+            srgbRed: CGFloat((hex >> 16) & 0xFF) / 255,
+            green: CGFloat((hex >> 8) & 0xFF) / 255,
+            blue: CGFloat(hex & 0xFF) / 255,
+            alpha: 1)
+    }
 }

--- a/Sources/MacPerfMonitor/ViewModels/DiskDetailModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/DiskDetailModel.swift
@@ -1,0 +1,82 @@
+import Combine
+import Foundation
+import MacPerfMonitorCore
+
+/// The Disk tab's slow-moving data: mounted volumes with capacities, per-disk
+/// hardware identity, and SMART health. All of it is view-pulled: the tab's
+/// `TabGate` unmounts this model's owner when the tab is inactive, `stop()`
+/// cancels the poll, and nothing here ever touches the 1 Hz sampler. Reads run
+/// on a background queue; published state flips on the main actor.
+@MainActor
+final class DiskDetailModel: ObservableObject {
+    @Published private(set) var volumeSnapshot: VolumeSnapshot?
+    @Published private(set) var hardware: [UInt64: DiskHardwareInfo] = [:]
+    @Published private(set) var smart: [UInt64: NVMeSMARTSnapshot] = [:]
+
+    /// Volumes refresh every poll; hardware identity and SMART wear figures
+    /// move on the scale of hours, so they refresh at most once a minute.
+    private static let pollInterval: TimeInterval = 30
+    private static let slowInterval: TimeInterval = 60
+
+    /// The three readers boxed together so the poll can carry them into its
+    /// background hop. Every access happens on `DiskDetailModel.queue`;
+    /// `@unchecked Sendable` records that confinement contract (the readers
+    /// keep per-device caches, so they are stateful but single-queue, like the
+    /// sampler's readers on the sampling queue).
+    private final class Readers: @unchecked Sendable {
+        let volumes = VolumeReader()
+        let info = DiskInfoReader()
+        let smart = NVMeSMARTReader()
+    }
+
+    private let readers = Readers()
+    private static let queue = DispatchQueue(
+        label: "uk.co.bzwrd.macperfmonitor.diskdetail", qos: .utility)
+
+    private var timer: AnyCancellable?
+    private var lastSlowRefresh: Date?
+    private var refreshInFlight = false
+
+    func start() {
+        refresh()
+        timer = Timer.publish(every: Self.pollInterval, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in self?.refresh() }
+    }
+
+    func stop() {
+        timer = nil
+    }
+
+    func refresh(now: Date = Date()) {
+        guard !refreshInFlight else { return }
+        refreshInFlight = true
+        let refreshSlow =
+            lastSlowRefresh.map { now.timeIntervalSince($0) >= Self.slowInterval } ?? true
+        if refreshSlow { lastSlowRefresh = now }
+
+        Task { [readers] in
+            let result: (VolumeSnapshot, [UInt64: DiskHardwareInfo]?, [UInt64: NVMeSMARTSnapshot]?)
+            result = await withCheckedContinuation { continuation in
+                Self.queue.async {
+                    let volumes = readers.volumes.read(now: now)
+                    guard refreshSlow else {
+                        continuation.resume(returning: (volumes, nil, nil))
+                        return
+                    }
+                    let hardware = readers.info.read()
+                    var smart: [UInt64: NVMeSMARTSnapshot] = [:]
+                    for (id, info) in hardware where !info.smartCandidateIDs.isEmpty {
+                        smart[id] = readers.smart.read(
+                            candidateRegistryEntryIDs: info.smartCandidateIDs)
+                    }
+                    continuation.resume(returning: (volumes, hardware, smart))
+                }
+            }
+            self.volumeSnapshot = result.0
+            if let hardware = result.1 { self.hardware = hardware }
+            if let smart = result.2 { self.smart = smart }
+            self.refreshInFlight = false
+        }
+    }
+}

--- a/Sources/MacPerfMonitor/Views/CombinedMenuBarContentView.swift
+++ b/Sources/MacPerfMonitor/Views/CombinedMenuBarContentView.swift
@@ -239,7 +239,8 @@ struct CombinedMenuBarContentView: View {
         case .cpu: return .processes
         case .energy: return .battery
         case .network: return .network
-        case .pressure, .gpu, .disk: return .dashboard
+        case .disk: return .diskUsage
+        case .pressure, .gpu: return .dashboard
         }
     }
 
@@ -248,6 +249,7 @@ struct CombinedMenuBarContentView: View {
         case .processes: return "Open Processes"
         case .battery: return "Open Energy"
         case .network: return "Open Network"
+        case .diskUsage: return "Open Disk"
         case .dashboard: return "Open Dashboard"
         default: return "Open"
         }

--- a/Sources/MacPerfMonitor/Views/ContentView.swift
+++ b/Sources/MacPerfMonitor/Views/ContentView.swift
@@ -2,7 +2,7 @@ import MacPerfMonitorCore
 import SwiftUI
 
 enum MainWindowTab: Hashable {
-    case dashboard, processes, battery, network, analytics, insights, groups
+    case dashboard, processes, battery, network, diskUsage, analytics, insights, groups
 }
 
 /// The main window's four tabs: Dashboard (pressure timeline, taxonomy, swap,
@@ -51,6 +51,10 @@ struct ContentView: View {
             TabGate(isActive: tab == .network) { NetworkView() }
                 .tabItem { Label("Network", systemImage: "network") }
                 .tag(MainWindowTab.network)
+
+            TabGate(isActive: tab == .diskUsage) { DiskUsageView() }
+                .tabItem { Label("Disk", systemImage: "internaldrive") }
+                .tag(MainWindowTab.diskUsage)
 
             TabGate(isActive: tab == .analytics) {
                 AnalyticsView(imported: $importedTrace)

--- a/Sources/MacPerfMonitor/Views/DiskUsageView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskUsageView.swift
@@ -1,0 +1,824 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// The Disk tab: every disk fact the system exposes, on one page. Live
+/// throughput, IOPS, service latency, and utilization ride the sampler's
+/// existing tick and the v12 history columns; volumes, APFS containers,
+/// hardware identity, and SMART health are pulled by `DiskDetailModel` at a
+/// slow cadence while the tab is visible and stop entirely when it is not.
+struct DiskUsageView: View {
+    @EnvironmentObject private var model: SamplerModel
+    @EnvironmentObject private var appState: AppState
+
+    @StateObject private var diskDetail = DiskDetailModel()
+
+    @State private var range: HistoryWindow = .oneHour
+    @State private var history: [SystemHistoryPoint] = []
+    /// Downsampled timeline + live point, memoized like the dashboard's:
+    /// recomputed only when source data changes, never inside body.
+    @State private var points: [SystemHistoryPoint] = []
+    @State private var loadedRange: HistoryWindow?
+    @State private var topDiskConsumers: [ProcessConsumer] = []
+
+    private var awaitingData: Bool { loadedRange != range }
+
+    var body: some View {
+        ScrollView {
+            MainRailLayout {
+                pageHeader
+                headlineCards
+                throughputPanel
+                activityPanel
+                devicesPanel
+                capacityPanel
+            } rail: {
+                healthPanel
+                freeSpacePanel
+                topProcessesPanel
+            }
+            .padding(20)
+        }
+        .onAppear {
+            reload()
+            diskDetail.start()
+        }
+        .onDisappear { diskDetail.stop() }
+        .onChange(of: range) { reload() }
+        .onChange(of: model.displayProcessesVersion) {
+            if appState.mainWindowVisible { reload() }
+        }
+        .onChange(of: model.latest?.system.timestamp) { _, _ in
+            if appState.mainWindowVisible { rebuildPoints() }
+        }
+        .onChange(of: appState.mainWindowVisible) { _, visible in if visible { reload() } }
+    }
+
+    // MARK: - Header
+
+    /// The primary (internal) disk's identity on the left, the shared range
+    /// control on the right, mirroring the dashboard's page header.
+    private var pageHeader: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(primaryDiskTitle)
+                    .font(.headline)
+                Text(primaryDiskSubtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 4) {
+                Text("HISTORY")
+                    .font(.caption2.weight(.semibold))
+                    .tracking(0.6)
+                    .foregroundStyle(.tertiary)
+                Picker("Range", selection: $range) {
+                    ForEach(HistoryWindow.allCases) { r in Text(r.label).tag(r) }
+                }
+                .pickerStyle(.segmented)
+                .controlSize(.small)
+                .labelsHidden()
+                .fixedSize()
+                .historyRangeGate()
+            }
+        }
+    }
+
+    private var primaryDevice: DiskDeviceSample? {
+        model.latestDisk?.devices.first
+    }
+
+    private var primaryDiskTitle: String {
+        primaryDevice?.model ?? "Disk"
+    }
+
+    private var primaryDiskSubtitle: String {
+        guard let device = primaryDevice else { return "Waiting for the first disk sample" }
+        var parts: [String] = []
+        if let size = device.sizeBytes { parts.append(ByteFormat.string(size)) }
+        if let name = device.protocolName { parts.append(name) }
+        parts.append(device.isInternal == true ? "internal" : "external")
+        let others = (model.latestDisk?.devices.count ?? 1) - 1
+        if others > 0 { parts.append("+\(others) more disk\(others == 1 ? "" : "s")") }
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: - Headline cards
+
+    private var headlineCards: some View {
+        let rates = model.smoothedDiskRates
+        let disk = model.latestDisk
+        return MetricCardsRow(
+            cards: [
+                MetricCardData(
+                    label: "Read",
+                    value: rates.map { ByteFormat.rate($0.readBytesPerSec) },
+                    tint: DiskStyle.read,
+                    samples: points.map {
+                        MetricSample(date: $0.date, value: $0.diskReadBytesPerSec)
+                    },
+                    help: "Physical read throughput, smoothed over about 5 seconds."),
+                MetricCardData(
+                    label: "Write",
+                    value: rates.map { ByteFormat.rate($0.writeBytesPerSec) },
+                    tint: DiskStyle.write,
+                    samples: points.map {
+                        MetricSample(date: $0.date, value: $0.diskWriteBytesPerSec)
+                    },
+                    help: "Physical write throughput, smoothed over about 5 seconds."),
+                MetricCardData(
+                    label: "IOPS",
+                    value: disk.map {
+                        "\(Int(($0.readOperationsPerSec + $0.writeOperationsPerSec).rounded()))"
+                    },
+                    samples: points.map {
+                        MetricSample(
+                            date: $0.date,
+                            value: $0.diskReadOperationsPerSec + $0.diskWriteOperationsPerSec)
+                    },
+                    unit: .percent,
+                    help: "Read plus write operations per second across all disks."),
+                bootFreeCard,
+            ],
+            gridColumns: 4,
+            loading: awaitingData)
+    }
+
+    private var bootFreeCard: MetricCardData {
+        let root = diskDetail.volumeSnapshot?.volumes.first(where: \.isRoot)
+        // Finder-style figure (includes purgeable) when known; the sampler's
+        // plain statfs figure otherwise.
+        let free =
+            root?.importantUsageAvailableBytes
+            ?? root?.availableBytes
+            ?? model.latest?.system.bootVolumeFreeBytes
+        let total = root?.totalBytes ?? model.latest?.system.bootVolumeTotalBytes
+        return MetricCardData(
+            label: "Free space",
+            value: free.map { ByteFormat.string($0) },
+            samples: points.compactMap { point in
+                point.bootFreeBytes.map { MetricSample(date: point.date, value: Double($0)) }
+            },
+            detail: total.map { "of \(ByteFormat.string($0))" },
+            help: "Space the system could make available on the boot volume, "
+                + "including purgeable content.")
+    }
+
+    // MARK: - Main column panels
+
+    private var throughputPanel: some View {
+        DiskPanel("Throughput", systemImage: "internaldrive") {
+            DiskChart(points: points, showsTimeAxis: true)
+                .frame(height: 170)
+                .chartReloading(awaitingData)
+            footnote(
+                "Physical traffic across real internal and external disks. Disk images are "
+                    + "excluded, and per-process attribution below may not add up to this: "
+                    + "filesystem caching, metadata, and paging are device traffic too.")
+        }
+    }
+
+    private var activityPanel: some View {
+        DiskPanel("Operations and latency", systemImage: "waveform.path.ecg") {
+            HStack(spacing: 24) {
+                diskStat(
+                    "Read latency",
+                    model.latestDisk?.readLatencyMs.map { String(format: "%.2f ms", $0) },
+                    DiskStyle.read)
+                diskStat(
+                    "Write latency",
+                    model.latestDisk?.writeLatencyMs.map { String(format: "%.2f ms", $0) },
+                    DiskStyle.write)
+                utilizationStat
+                Spacer(minLength: 0)
+            }
+            chartCaption("OPERATIONS PER SECOND")
+            DiskIOPSChart(points: points)
+                .frame(height: 110)
+                .chartReloading(awaitingData)
+            chartCaption("SERVICE TIME PER OPERATION")
+            DiskLatencyChart(points: points, showsTimeAxis: true)
+                .frame(height: 110)
+                .chartReloading(awaitingData)
+            footnote(
+                "Service time is the device's average per completed operation; gaps mean no "
+                    + "IO happened in that interval. Utilization is the busiest disk's share "
+                    + "of time spent servicing IO.")
+        }
+    }
+
+    @ViewBuilder private var utilizationStat: some View {
+        let utilization = model.latestDisk?.utilizationPercent
+        VStack(alignment: .leading, spacing: 2) {
+            Text("UTILIZATION")
+                .font(.caption2.weight(.semibold))
+                .tracking(0.6)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Text(utilization.map { "\(Int($0.rounded()))%" } ?? "--")
+                    .font(.title3.monospacedDigit().weight(.semibold))
+                    .foregroundStyle(DiskStyle.utilization(utilization ?? 0))
+                Gauge(value: min(utilization ?? 0, 100), in: 0...100) { EmptyView() }
+                    .gaugeStyle(.accessoryLinearCapacity)
+                    .tint(DiskStyle.utilization(utilization ?? 0))
+                    .frame(width: 60)
+                    .accessibilityLabel("Disk utilization")
+            }
+        }
+    }
+
+    private var devicesPanel: some View {
+        DiskPanel("Devices", systemImage: "externaldrive") {
+            if let devices = model.latestDisk?.devices, !devices.isEmpty {
+                ForEach(devices) { device in
+                    DeviceCard(
+                        device: device,
+                        hardware: diskDetail.hardware[device.registryEntryID])
+                }
+            } else {
+                Text("No physical disks visible yet.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var capacityPanel: some View {
+        DiskPanel("Capacity and volumes", systemImage: "chart.bar.doc.horizontal") {
+            if let snapshot = diskDetail.volumeSnapshot {
+                let standalone = snapshot.volumes.filter { $0.containerBSDName == nil }
+                ForEach(orderedContainers(snapshot)) { container in
+                    CapacityBarSection(
+                        title: containerTitle(container, volumes: snapshot.volumes),
+                        subtitle: containerSubtitle(container),
+                        slices: DiskCapacityBreakdown.slices(
+                            container: container, volumes: snapshot.volumes))
+                }
+                ForEach(standalone) { volume in
+                    CapacityBarSection(
+                        title: volume.name,
+                        subtitle: "\(volume.fsTypeName) at \(volume.mountPoint)",
+                        slices: DiskCapacityBreakdown.slices(standaloneVolume: volume))
+                }
+                footnote(
+                    "APFS volumes share their container's free pool, so a container's volumes "
+                        + "are one bar. Purgeable space is allocated content the system can "
+                        + "reclaim when needed.")
+            } else {
+                Text("Reading volumes…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    /// Boot container first, then the rest by name.
+    private func orderedContainers(_ snapshot: VolumeSnapshot) -> [APFSContainerInfo] {
+        let bootContainer = snapshot.volumes.first(where: \.isRoot)?.containerBSDName
+        return snapshot.containers.sorted {
+            if ($0.bsdName == bootContainer) != ($1.bsdName == bootContainer) {
+                return $0.bsdName == bootContainer
+            }
+            return $0.bsdName.localizedStandardCompare($1.bsdName) == .orderedAscending
+        }
+    }
+
+    private func containerTitle(_ container: APFSContainerInfo, volumes: [VolumeInfo]) -> String {
+        let isBoot = volumes.contains { $0.isRoot && $0.containerBSDName == container.bsdName }
+        return isBoot ? "Boot container (\(container.bsdName))" : "Container \(container.bsdName)"
+    }
+
+    private func containerSubtitle(_ container: APFSContainerInfo) -> String {
+        var parts: [String] = []
+        if let capacity = container.capacityBytes {
+            parts.append(ByteFormat.string(capacity))
+        }
+        if !container.physicalStoreBSDNames.isEmpty {
+            parts.append("on \(container.physicalStoreBSDNames.joined(separator: ", "))")
+        }
+        parts.append("\(container.volumeBSDNames.count) volumes")
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: - Rail panels
+
+    private var healthPanel: some View {
+        DiskPanel("Health", systemImage: "stethoscope") {
+            if let (device, smart) = primarySMART {
+                smartSection(device: device, smart: smart)
+            } else {
+                Text(
+                    "SMART data is not available for this disk. External and USB enclosures "
+                        + "usually do not expose it."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            errorCountsSection
+        }
+    }
+
+    private var primarySMART: (DiskDeviceSample, NVMeSMARTSnapshot)? {
+        guard let devices = model.latestDisk?.devices else { return nil }
+        for device in devices {
+            if let smart = diskDetail.smart[device.registryEntryID] { return (device, smart) }
+        }
+        return nil
+    }
+
+    @ViewBuilder
+    private func smartSection(device: DiskDeviceSample, smart: NVMeSMARTSnapshot) -> some View {
+        HStack(spacing: 6) {
+            Image(
+                systemName: smart.isHealthy
+                    ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+            )
+            .foregroundStyle(smart.isHealthy ? Color.green : Color.red)
+            Text(smart.isHealthy ? "Verified" : "Failing")
+                .font(.subheadline.weight(.semibold))
+            Text(device.bsdName)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "SMART status \(smart.isHealthy ? "verified" : "failing") for \(device.bsdName)")
+
+        VStack(alignment: .leading, spacing: 5) {
+            if let temperature = smart.temperatureCelsius {
+                infoRow("Temperature", String(format: "%.0f\u{202F}C", temperature))
+            }
+            wearRow(smart)
+            infoRow(
+                "Available spare",
+                "\(smart.availableSparePercent)% (threshold \(smart.spareThresholdPercent)%)")
+            infoRow("Power-on time", "\(smart.powerOnHours) hours")
+            infoRow("Power cycles", "\(smart.powerCycles)")
+            infoRow("Unsafe shutdowns", "\(smart.unsafeShutdowns)")
+            infoRow("Media errors", "\(smart.mediaErrors)", dimZero: true)
+            infoRow("Error log entries", "\(smart.errorLogEntries)", dimZero: true)
+            infoRow("Lifetime reads", ByteFormat.string(smart.bytesRead))
+            infoRow("Lifetime writes", ByteFormat.string(smart.bytesWritten))
+        }
+    }
+
+    private func wearRow(_ smart: NVMeSMARTSnapshot) -> some View {
+        HStack(spacing: 8) {
+            Text("Life used")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Gauge(value: min(Double(smart.percentageUsed), 100), in: 0...100) { EmptyView() }
+                .gaugeStyle(.accessoryLinearCapacity)
+                .tint(smart.percentageUsed >= 80 ? .red : .accentColor)
+                .frame(width: 70)
+                .accessibilityHidden(true)
+            Text("\(smart.percentageUsed)%")
+                .font(.caption.monospacedDigit())
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Drive life used \(smart.percentageUsed) percent")
+    }
+
+    @ViewBuilder private var errorCountsSection: some View {
+        if let devices = model.latestDisk?.devices, !devices.isEmpty {
+            Divider()
+            chartCaption("DRIVER ERROR COUNTERS SINCE BOOT")
+            VStack(alignment: .leading, spacing: 5) {
+                ForEach(devices) { device in
+                    infoRow(
+                        device.bsdName,
+                        "\(device.readErrors + device.writeErrors) errors, "
+                            + "\(device.readRetries + device.writeRetries) retries",
+                        dimZero: device.readErrors + device.writeErrors
+                            + device.readRetries + device.writeRetries == 0)
+                }
+            }
+        }
+    }
+
+    private var freeSpacePanel: some View {
+        DiskPanel("Free space", systemImage: "chart.line.downtrend.xyaxis") {
+            FreeSpaceChart(points: points, showsTimeAxis: true)
+                .frame(height: 120)
+                .chartReloading(awaitingData)
+            purgeableSummary
+            footnote(
+                "Boot volume free space over the selected range, sampled once a minute. "
+                    + "On APFS this is the container's shared pool.")
+        }
+    }
+
+    @ViewBuilder private var purgeableSummary: some View {
+        if let volumes = diskDetail.volumeSnapshot?.volumes {
+            let purgeable = volumes.compactMap(\.purgeableBytes).max() ?? 0
+            if purgeable > 0 {
+                infoRow("Purgeable", ByteFormat.string(purgeable))
+            }
+        }
+    }
+
+    private var topProcessesPanel: some View {
+        DiskPanel("Top disk processes", systemImage: "list.number") {
+            if topDiskConsumers.isEmpty {
+                Text("No attributed disk activity in this range.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(topDiskConsumers.prefix(8)) { process in
+                    HStack(spacing: 7) {
+                        Image(
+                            nsImage: ProcessIconProvider.shared.icon(
+                                forPath: process.executablePath)
+                        )
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                        Text(process.displayName)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Text(ByteFormat.rate(process.averageDisk))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+            footnote("Kernel-attributed I/O over the selected range; read plus write.")
+        }
+    }
+
+    // MARK: - Shared bits
+
+    private func diskStat(_ label: String, _ value: String?, _ tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label.uppercased())
+                .font(.caption2.weight(.semibold))
+                .tracking(0.6)
+                .foregroundStyle(.secondary)
+            Text(value ?? "--")
+                .font(.title3.monospacedDigit().weight(.semibold))
+                .foregroundStyle(tint)
+        }
+    }
+
+    private func chartCaption(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .tracking(0.6)
+            .foregroundStyle(.tertiary)
+    }
+
+    private func footnote(_ text: String) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func infoRow(_ label: String, _ value: String, dimZero: Bool = false) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(dimZero ? .tertiary : .primary)
+        }
+    }
+
+    private static let maxChartPoints = 360
+
+    private func rebuildPoints() {
+        var pts = history
+        if let system = model.latest?.system {
+            let live = SystemHistoryPoint(
+                date: system.timestamp,
+                pressurePercent: system.pressurePercent,
+                appMemory: system.appMemory,
+                wired: system.wired,
+                compressed: system.compressed,
+                cachedFiles: system.cachedFiles,
+                swapUsed: system.swapUsed,
+                diskReadBytesPerSec: system.diskReadBytesPerSec,
+                diskWriteBytesPerSec: system.diskWriteBytesPerSec,
+                diskReadOperationsPerSec: system.diskReadOperationsPerSec,
+                diskWriteOperationsPerSec: system.diskWriteOperationsPerSec,
+                diskReadLatencyMs: system.diskReadLatencyMs,
+                diskWriteLatencyMs: system.diskWriteLatencyMs,
+                diskUtilizationPercent: system.diskUtilizationPercent,
+                bootFreeBytes: system.bootVolumeFreeBytes,
+                bootTotalBytes: system.bootVolumeTotalBytes
+            )
+            if let last = pts.last {
+                if live.date > last.date { pts.append(live) }
+            } else {
+                pts.append(live)
+            }
+        }
+        points = pts
+    }
+
+    private func reload() {
+        let requested = range
+        model.loadSystemHistory(requested, downsampledTo: Self.maxChartPoints) { pts in
+            self.history = pts
+            self.loadedRange = requested
+            self.rebuildPoints()
+        }
+        model.loadTopConsumers(window: requested, metric: .averageDisk, limit: 8) { rows in
+            guard self.range == requested else { return }
+            self.topDiskConsumers = rows
+        }
+    }
+}
+
+// MARK: - Device card
+
+/// One physical disk: identity row, hardware facts (nil rows omitted), and a
+/// live activity strip. Hardware identity arrives from `DiskDetailModel` a
+/// beat after first render; rows appear as they resolve.
+private struct DeviceCard: View {
+    let device: DiskDeviceSample
+    let hardware: DiskHardwareInfo?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 7) {
+                Image(systemName: device.isInternal == true ? "internaldrive" : "externaldrive")
+                    .foregroundStyle(.secondary)
+                Text(device.model)
+                    .font(.subheadline.weight(.semibold))
+                Text(device.bsdName)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                if device.isRemovable {
+                    badge("Removable")
+                }
+                badge(device.isInternal == true ? "Internal" : "External")
+                Spacer()
+                if let size = device.sizeBytes {
+                    Text(ByteFormat.string(size))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            factGrid
+
+            liveStrip
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(.quaternary.opacity(0.4)))
+    }
+
+    private var facts: [(String, String)] {
+        var rows: [(String, String)] = []
+        if let name = device.protocolName { rows.append(("Protocol", name)) }
+        if let hardware {
+            if let vendor = hardware.vendorName { rows.append(("Vendor", vendor)) }
+            if let revision = hardware.productRevision { rows.append(("Revision", revision)) }
+            if let firmware = hardware.firmwareRevision, firmware != hardware.productRevision {
+                rows.append(("Firmware", firmware))
+            }
+            if let serial = hardware.serialNumber { rows.append(("Serial", serial)) }
+            if let interconnect = hardware.interconnect {
+                let location = hardware.interconnectLocation.map { " (\($0))" } ?? ""
+                rows.append(("Interconnect", interconnect + location))
+            }
+            if let solidState = hardware.isSolidState {
+                rows.append(("Medium", solidState ? "Solid state" : "Rotational"))
+            }
+            if let blockSize = hardware.physicalBlockSizeBytes {
+                rows.append(("Block size", "\(blockSize) bytes"))
+            }
+            if let nand = hardware.nandStatus { rows.append(("NAND status", nand)) }
+            if let revision = hardware.nvmeRevision { rows.append(("NVMe revision", revision)) }
+            if let controller = hardware.controllerClass {
+                rows.append(("Controller", controller))
+            }
+        }
+        return rows
+    }
+
+    private var factGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible()), GridItem(.flexible())],
+            alignment: .leading, spacing: 4
+        ) {
+            ForEach(facts, id: \.0) { fact in
+                HStack(spacing: 4) {
+                    Text(fact.0)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(fact.1)
+                        .font(.caption2.monospacedDigit())
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+    }
+
+    private var liveStrip: some View {
+        HStack(spacing: 14) {
+            liveValue("R", ByteFormat.rate(device.readBytesPerSec), DiskStyle.read)
+            liveValue("W", ByteFormat.rate(device.writeBytesPerSec), DiskStyle.write)
+            liveValue(
+                "IOPS",
+                "\(Int((device.readOperationsPerSec + device.writeOperationsPerSec).rounded()))",
+                .primary)
+            if let readTime = device.averageReadTimeMilliseconds {
+                liveValue("R lat", String(format: "%.2f ms", readTime), .secondary)
+            }
+            if let writeTime = device.averageWriteTimeMilliseconds {
+                liveValue("W lat", String(format: "%.2f ms", writeTime), .secondary)
+            }
+            if let utilization = device.utilizationPercent {
+                liveValue(
+                    "Busy", "\(Int(utilization.rounded()))%",
+                    DiskStyle.utilization(utilization))
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func liveValue(_ label: String, _ value: String, _ tint: Color) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Text(value)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(tint)
+        }
+    }
+
+    private func badge(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(.quaternary))
+            .foregroundStyle(.secondary)
+    }
+}
+
+// MARK: - Capacity bar
+
+/// One container (or standalone volume): a single horizontal stacked bar with
+/// 2 point gaps between slices, and a legend of name, role, mount, bytes, and
+/// percent rows. Colors come from `DiskStyle.capacityColor`, whose slot order
+/// is the validated one; the free slice renders as a recessive track.
+private struct CapacityBarSection: View {
+    let title: String
+    let subtitle: String
+    let slices: [DiskCapacitySlice]
+
+    private var totalBytes: UInt64 { max(slices.reduce(0) { $0 + $1.bytes }, 1) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            bar
+                .frame(height: 14)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("\(title) capacity")
+                .accessibilityValue(accessibilitySummary)
+            legend
+        }
+        .padding(.bottom, 6)
+    }
+
+    private var bar: some View {
+        GeometryReader { geometry in
+            let gaps = CGFloat(max(slices.count - 1, 0)) * 2
+            let available = max(geometry.size.width - gaps, 1)
+            HStack(spacing: 2) {
+                ForEach(Array(slices.enumerated()), id: \.element.id) { index, slice in
+                    RoundedRectangle(cornerRadius: 3, style: .continuous)
+                        .fill(color(for: slice, at: index))
+                        .frame(
+                            width: max(
+                                available * CGFloat(slice.bytes) / CGFloat(totalBytes),
+                                slice.bytes > 0 ? 3 : 0))
+                }
+            }
+        }
+    }
+
+    private var legend: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            ForEach(Array(slices.enumerated()), id: \.element.id) { index, slice in
+                HStack(spacing: 6) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(color(for: slice, at: index))
+                        .frame(width: 8, height: 8)
+                    Text(legendLabel(slice))
+                        .font(.caption)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let role = slice.role {
+                        Text(role.label)
+                            .font(.caption2)
+                            .padding(.horizontal, 4)
+                            .background(Capsule().fill(.quaternary))
+                            .foregroundStyle(.secondary)
+                    }
+                    if let detail = slice.detail {
+                        Text(detail)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer()
+                    Text(ByteFormat.string(slice.bytes))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Text(percentText(slice))
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 38, alignment: .trailing)
+                }
+            }
+        }
+    }
+
+    /// Named volume slices count their own index among volumes so folded and
+    /// fixed-slot slices do not shift their colors.
+    private func color(for slice: DiskCapacitySlice, at index: Int) -> Color {
+        let namedIndex = slices.prefix(index).filter { $0.kind == .volume }.count
+        return DiskStyle.capacityColor(for: slice, namedIndex: namedIndex)
+    }
+
+    private func legendLabel(_ slice: DiskCapacitySlice) -> String {
+        if case .otherVolumes(let count) = slice.kind {
+            return "Other volumes (\(count))"
+        }
+        return slice.label
+    }
+
+    private func percentText(_ slice: DiskCapacitySlice) -> String {
+        let percent = Double(slice.bytes) / Double(totalBytes) * 100
+        if percent > 0 && percent < 1 { return "<1%" }
+        return "\(Int(percent.rounded()))%"
+    }
+
+    private var accessibilitySummary: String {
+        slices.map { "\(legendLabel($0)) \(ByteFormat.string($0.bytes))" }
+            .joined(separator: ", ")
+    }
+}
+
+// MARK: - Panel chrome
+
+/// The page's card chrome, matching the dashboard's panel (each page keeps a
+/// private copy by convention).
+private struct DiskPanel<Content: View>: View {
+    let title: String
+    let systemImage: String
+    @ViewBuilder var content: () -> Content
+
+    init(_ title: String, systemImage: String, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.systemImage = systemImage
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 7) {
+                Image(systemName: systemImage)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text(title)
+                    .font(.headline)
+                Spacer(minLength: 8)
+            }
+            content()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(.quaternary.opacity(0.35))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5)
+        )
+    }
+}

--- a/Sources/MacPerfMonitorCore/Analysis/DiskCapacityBreakdown.swift
+++ b/Sources/MacPerfMonitorCore/Analysis/DiskCapacityBreakdown.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// One slice of a capacity bar. Bytes only; colors and layout belong to the
+/// view. Slices are emitted in their fixed render order (named volumes by size,
+/// then purgeable, then folded extras, then free), which the Disk page maps
+/// onto its fixed color slots, so the order here is a UI contract, not
+/// cosmetics.
+public struct DiskCapacitySlice: Sendable, Equatable, Identifiable {
+    public enum Kind: Sendable, Equatable {
+        case volume
+        /// Volumes beyond the named cap, folded into one slice.
+        case otherVolumes(count: Int)
+        /// Space the system can reclaim for important writes (caches, local
+        /// snapshots). Carved out of the largest volume's used bytes, where
+        /// purgeable content overwhelmingly lives.
+        case purgeable
+        case free
+    }
+
+    public var id: String
+    public var label: String
+    /// Mount point for volume slices, nil otherwise.
+    public var detail: String?
+    public var role: VolumeRole?
+    public var bytes: UInt64
+    public var kind: Kind
+}
+
+/// Pure derivation of capacity-bar slices from a volume snapshot, kept in Core
+/// so the arithmetic (clamping, carving, folding) is unit-tested away from any
+/// view code.
+public enum DiskCapacityBreakdown {
+    /// Named volume slices before folding into "Other volumes". Three, so the
+    /// full bar (3 named + purgeable + other) matches the validated five-color
+    /// order the page renders with.
+    public static let maxNamedVolumes = 3
+
+    /// Slices for one APFS container. Members share the container's free pool,
+    /// so per-volume used bytes come from each mount's own accounting while
+    /// free space is derived once from the container capacity.
+    public static func slices(
+        container: APFSContainerInfo, volumes: [VolumeInfo]
+    ) -> [DiskCapacitySlice] {
+        let members = volumes.filter { $0.containerBSDName == container.bsdName }
+        let capacity = container.capacityBytes ?? members.map(\.totalBytes).max() ?? 0
+        return build(
+            capacity: capacity,
+            members: members,
+            purgeable: members.compactMap(\.purgeableBytes).max() ?? 0,
+            idPrefix: container.bsdName)
+    }
+
+    /// Slices for a volume with no known APFS container (external drives,
+    /// non-APFS filesystems).
+    public static func slices(standaloneVolume volume: VolumeInfo) -> [DiskCapacitySlice] {
+        build(
+            capacity: volume.totalBytes,
+            members: [volume],
+            purgeable: volume.purgeableBytes ?? 0,
+            idPrefix: volume.mountPoint)
+    }
+
+    private static func build(
+        capacity: UInt64, members: [VolumeInfo], purgeable: UInt64, idPrefix: String
+    ) -> [DiskCapacitySlice] {
+        let sorted = members.sorted { $0.usedBytes > $1.usedBytes }
+        let named = Array(sorted.prefix(maxNamedVolumes))
+        let folded = Array(sorted.dropFirst(maxNamedVolumes))
+
+        // Purgeable bytes are allocated space, so they must be carved out of a
+        // used slice (the largest volume's, where caches and snapshots live)
+        // or the bar would double-count them and overflow the capacity.
+        let clampedPurgeable = min(purgeable, named.first?.usedBytes ?? 0)
+        var namedBytes = named.map(\.usedBytes)
+        if !namedBytes.isEmpty { namedBytes[0] -= clampedPurgeable }
+
+        var slices: [DiskCapacitySlice] = []
+        for (volume, bytes) in zip(named, namedBytes) {
+            slices.append(
+                DiskCapacitySlice(
+                    id: "\(idPrefix)/\(volume.mountPoint)",
+                    label: volume.name,
+                    detail: volume.mountPoint,
+                    role: volume.role,
+                    bytes: bytes,
+                    kind: .volume))
+        }
+        if clampedPurgeable > 0 {
+            slices.append(
+                DiskCapacitySlice(
+                    id: "\(idPrefix)/purgeable", label: "Purgeable", detail: nil, role: nil,
+                    bytes: clampedPurgeable, kind: .purgeable))
+        }
+        if !folded.isEmpty {
+            slices.append(
+                DiskCapacitySlice(
+                    id: "\(idPrefix)/other",
+                    label: "Other volumes",
+                    detail: nil, role: nil,
+                    bytes: folded.reduce(0) { $0 + $1.usedBytes },
+                    kind: .otherVolumes(count: folded.count)))
+        }
+
+        let used = slices.reduce(0) { $0 + $1.bytes }
+        slices.append(
+            DiskCapacitySlice(
+                id: "\(idPrefix)/free", label: "Free", detail: nil, role: nil,
+                bytes: capacity > used ? capacity - used : 0, kind: .free))
+
+        // Drop empty volume slices (a freshly created volume can be 0 bytes
+        // used) but never the free slice: an entirely full disk should still
+        // show its zero-byte free slice in the legend.
+        return slices.filter { $0.bytes > 0 || $0.kind == .free }
+    }
+}
+
+extension VolumeInfo {
+    /// Bytes this volume itself consumes: the `ATTR_VOL_SPACEUSED` figure when
+    /// the reader obtained one, else total minus free. The fallback is only
+    /// correct for non-APFS filesystems; on APFS, `statfs` free fields report
+    /// the shared container pool, which is why the attribute is preferred.
+    public var usedBytes: UInt64 {
+        spaceUsedBytes ?? (totalBytes > freeBytes ? totalBytes - freeBytes : 0)
+    }
+}

--- a/Sources/MacPerfMonitorCore/Models/DiskHardwareInfo.swift
+++ b/Sources/MacPerfMonitorCore/Models/DiskHardwareInfo.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Static hardware identity for one physical disk, harvested from the
+/// IORegistry chain above its block storage driver. Every field is optional:
+/// external and USB devices publish only a subset, and a missing value renders
+/// as an omitted row, never a fabricated one. Keyed by the same driver registry
+/// entry ID as `DiskDeviceSample`, so live activity and hardware detail join
+/// trivially.
+public struct DiskHardwareInfo: Sendable, Equatable, Identifiable {
+    public var id: UInt64 { registryEntryID }
+    public var registryEntryID: UInt64
+    public var bsdName: String
+
+    // Device Characteristics (IOBlockStorageDevice).
+    public var vendorName: String?
+    public var productName: String?
+    public var productRevision: String?
+    public var serialNumber: String?
+    /// True when the device characteristics report "Solid State".
+    public var isSolidState: Bool?
+
+    // Protocol Characteristics: how the device is attached.
+    public var interconnect: String?
+    public var interconnectLocation: String?
+
+    /// The whole media's preferred (physical) block size in bytes.
+    public var physicalBlockSizeBytes: UInt64?
+
+    // NVMe controller detail, nil for non-NVMe attachments.
+    public var controllerClass: String?
+    public var firmwareRevision: String?
+    public var nandStatus: String?
+    public var nvmeRevision: String?
+
+    /// Registry entry IDs `NVMeSMARTReader` should try for this disk, in
+    /// order. Empty when no NVMe controller was found above the device.
+    public var smartCandidateIDs: [UInt64] = []
+}

--- a/Sources/MacPerfMonitorCore/Models/DiskSample.swift
+++ b/Sources/MacPerfMonitorCore/Models/DiskSample.swift
@@ -10,6 +10,15 @@ public struct DiskSample: Sendable, Equatable {
     public var writeBytesPerSec: Double
     public var readOperationsPerSec: Double
     public var writeOperationsPerSec: Double
+    /// Ops-weighted average service time across all real devices this interval,
+    /// nil when the interval saw zero operations: "no IO" must stay distinct
+    /// from "0 ms" so history charts show a gap rather than a false fast disk.
+    public var readLatencyMs: Double?
+    public var writeLatencyMs: Double?
+    /// Busiest device's share of the interval spent servicing IO, 0 to 100.
+    /// The max (not the mean) so one saturated external drive reads as
+    /// saturation. Nil on the first sample.
+    public var utilizationPercent: Double?
     public var devices: [DiskDeviceSample]
 
     public init(
@@ -18,6 +27,9 @@ public struct DiskSample: Sendable, Equatable {
         writeBytesPerSec: Double,
         readOperationsPerSec: Double,
         writeOperationsPerSec: Double,
+        readLatencyMs: Double? = nil,
+        writeLatencyMs: Double? = nil,
+        utilizationPercent: Double? = nil,
         devices: [DiskDeviceSample]
     ) {
         self.timestamp = timestamp
@@ -25,6 +37,9 @@ public struct DiskSample: Sendable, Equatable {
         self.writeBytesPerSec = writeBytesPerSec
         self.readOperationsPerSec = readOperationsPerSec
         self.writeOperationsPerSec = writeOperationsPerSec
+        self.readLatencyMs = readLatencyMs
+        self.writeLatencyMs = writeLatencyMs
+        self.utilizationPercent = utilizationPercent
         self.devices = devices
     }
 }
@@ -51,4 +66,10 @@ public struct DiskDeviceSample: Sendable, Equatable, Identifiable {
     public var writeErrors: UInt64
     public var readRetries: UInt64
     public var writeRetries: UInt64
+    /// Share of the interval this device spent servicing IO, 0 to 100, from the
+    /// driver's total read plus write time deltas. Nil on the first sample or
+    /// after a counter reset, matching the average-time convention above. The
+    /// statistics dictionary has no queue-depth key, so busy time is the closest
+    /// available saturation signal.
+    public var utilizationPercent: Double? = nil
 }

--- a/Sources/MacPerfMonitorCore/Models/NVMeSMARTSnapshot.swift
+++ b/Sources/MacPerfMonitorCore/Models/NVMeSMARTSnapshot.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Decoded NVMe SMART / Health log for one controller. Available unprivileged
+/// for the internal Apple SSD; external and USB enclosures usually refuse the
+/// query, in which case the whole snapshot is absent rather than partial.
+public struct NVMeSMARTSnapshot: Sendable, Equatable {
+    /// Bit flags; 0 means no active warning. Bit 0 = spare below threshold,
+    /// bit 1 = temperature out of range, bit 2 = media degraded, bit 3 =
+    /// volatile memory backup failed.
+    public var criticalWarning: UInt8
+    /// Composite controller temperature; nil when the drive reports 0 Kelvin
+    /// (unpopulated).
+    public var temperatureCelsius: Double?
+    /// Remaining spare capacity as a percentage of the initial spare pool.
+    public var availableSparePercent: UInt8
+    /// When available spare falls below this, the drive raises bit 0 above.
+    public var spareThresholdPercent: UInt8
+    /// Vendor estimate of life used, 0 to 100 (can exceed 100; capped at 255).
+    public var percentageUsed: UInt8
+    /// 1000-unit counts of 512-byte data units, low 64 bits of the spec's
+    /// 128-bit counters (the high half is beyond any real drive's lifetime).
+    public var dataUnitsRead: UInt64
+    public var dataUnitsWritten: UInt64
+    public var hostReadCommands: UInt64
+    public var hostWriteCommands: UInt64
+    public var controllerBusyTimeMinutes: UInt64
+    public var powerCycles: UInt64
+    public var powerOnHours: UInt64
+    public var unsafeShutdowns: UInt64
+    public var mediaErrors: UInt64
+    public var errorLogEntries: UInt64
+
+    public var isHealthy: Bool { criticalWarning == 0 }
+
+    /// Lifetime bytes, saturating rather than trapping on a fictional drive
+    /// that overflows UInt64 (one data unit = 1000 x 512 bytes).
+    public var bytesRead: UInt64 { Self.bytes(fromDataUnits: dataUnitsRead) }
+    public var bytesWritten: UInt64 { Self.bytes(fromDataUnits: dataUnitsWritten) }
+
+    static func bytes(fromDataUnits units: UInt64) -> UInt64 {
+        let (value, overflow) = units.multipliedReportingOverflow(by: 512_000)
+        return overflow ? .max : value
+    }
+}

--- a/Sources/MacPerfMonitorCore/Models/SystemSample.swift
+++ b/Sources/MacPerfMonitorCore/Models/SystemSample.swift
@@ -78,6 +78,20 @@ public struct SystemSample: Sendable, Codable {
     public var diskReadOperationsPerSec: Double
     public var diskWriteOperationsPerSec: Double
 
+    // Disk detail added alongside the throughput scalars. All optional (and
+    // decoded as such) so samples recorded before these fields existed keep
+    // decoding, and "no IO this tick" stays distinct from a measured zero.
+    /// Ops-weighted average device service time this tick, milliseconds.
+    public var diskReadLatencyMs: Double?
+    public var diskWriteLatencyMs: Double?
+    /// Busiest device's busy share of the tick, 0 to 100.
+    public var diskUtilizationPercent: Double?
+    /// Root filesystem capacity, refreshed at most once a minute by
+    /// `BootVolumeReader`. On APFS the free figure is the container's shared
+    /// free pool, the number that matters when the disk fills up.
+    public var bootVolumeTotalBytes: UInt64?
+    public var bootVolumeFreeBytes: UInt64?
+
     public init(
         timestamp: Date,
         totalRAM: UInt64,
@@ -115,7 +129,12 @@ public struct SystemSample: Sendable, Codable {
         diskReadBytesPerSec: Double = 0,
         diskWriteBytesPerSec: Double = 0,
         diskReadOperationsPerSec: Double = 0,
-        diskWriteOperationsPerSec: Double = 0
+        diskWriteOperationsPerSec: Double = 0,
+        diskReadLatencyMs: Double? = nil,
+        diskWriteLatencyMs: Double? = nil,
+        diskUtilizationPercent: Double? = nil,
+        bootVolumeTotalBytes: UInt64? = nil,
+        bootVolumeFreeBytes: UInt64? = nil
     ) {
         self.timestamp = timestamp
         self.totalRAM = totalRAM
@@ -154,5 +173,10 @@ public struct SystemSample: Sendable, Codable {
         self.diskWriteBytesPerSec = diskWriteBytesPerSec
         self.diskReadOperationsPerSec = diskReadOperationsPerSec
         self.diskWriteOperationsPerSec = diskWriteOperationsPerSec
+        self.diskReadLatencyMs = diskReadLatencyMs
+        self.diskWriteLatencyMs = diskWriteLatencyMs
+        self.diskUtilizationPercent = diskUtilizationPercent
+        self.bootVolumeTotalBytes = bootVolumeTotalBytes
+        self.bootVolumeFreeBytes = bootVolumeFreeBytes
     }
 }

--- a/Sources/MacPerfMonitorCore/Models/VolumeInfo.swift
+++ b/Sources/MacPerfMonitorCore/Models/VolumeInfo.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// A point-in-time enumeration of mounted volumes and the APFS containers they
+/// live in. Produced on demand by `VolumeReader` for the Disk page; it never
+/// rides the 1 Hz sampler because enumerating mounts and reading per-volume
+/// resource values costs milliseconds, not microseconds.
+public struct VolumeSnapshot: Sendable, Equatable {
+    public var timestamp: Date
+    public var volumes: [VolumeInfo]
+    public var containers: [APFSContainerInfo]
+}
+
+/// The role a volume plays inside its APFS container, mapped from the
+/// IORegistry role strings with a well-known mount point fallback for non-APFS
+/// or unmatched volumes.
+public enum VolumeRole: String, Sendable, Equatable {
+    case system
+    case data
+    case preboot
+    case recovery
+    case vm
+    /// Small OS bookkeeping volumes: Update, xART, Hardware, iSCPreboot.
+    case support
+    /// A plain user volume (external drive, secondary partition).
+    case user
+
+    /// Short badge text for UI use, kept here so the mapping stays testable.
+    public var label: String {
+        switch self {
+        case .system: return "System"
+        case .data: return "Data"
+        case .preboot: return "Preboot"
+        case .recovery: return "Recovery"
+        case .vm: return "VM"
+        case .support: return "Support"
+        case .user: return "User"
+        }
+    }
+}
+
+/// One mounted filesystem. Capacity fields come from `getfsstat`; the
+/// purgeable-aware figures come from Foundation's volume resource values and
+/// are nil when the query fails, so "unknown" never renders as "0 bytes".
+public struct VolumeInfo: Sendable, Equatable, Identifiable {
+    public var id: String { mountPoint }
+    public var mountPoint: String
+    public var name: String
+    public var bsdName: String?
+    public var fsTypeName: String
+    public var volumeUUID: String?
+    public var role: VolumeRole
+    public var isRoot: Bool
+    public var isLocal: Bool
+    public var isReadOnly: Bool
+    public var isInternal: Bool?
+    public var isEjectable: Bool?
+    public var isEncrypted: Bool?
+    public var totalBytes: UInt64
+    /// Free blocks including space reserved for root (`f_bfree`).
+    public var freeBytes: UInt64
+    /// Free blocks available to ordinary processes (`f_bavail`), the figure
+    /// `df` prints in its Available column.
+    public var availableBytes: UInt64
+    /// What the system could free up for important writes: available space
+    /// plus purgeable content. This is the Finder-style number and is the one
+    /// to show as the headline free figure when present.
+    public var importantUsageAvailableBytes: UInt64?
+    /// Purgeable content on this volume, derived as the gap between the
+    /// important-usage figure and plain available space.
+    public var purgeableBytes: UInt64?
+    /// The APFS container (synthesized whole disk, e.g. "disk3") this volume
+    /// belongs to, nil for non-APFS volumes.
+    public var containerBSDName: String?
+    public var blockSize: UInt64
+    /// Bytes this volume itself consumes, from `getattrlist`'s
+    /// `ATTR_VOL_SPACEUSED`. On APFS this is the only per-volume truth:
+    /// `statfs` reports the shared container pool in its free fields for most
+    /// mounts, so `total - free` is container-wide, not per-volume.
+    public var spaceUsedBytes: UInt64? = nil
+}
+
+/// One APFS container: a pool of space shared by its volumes on top of one or
+/// more physical store partitions.
+public struct APFSContainerInfo: Sendable, Equatable, Identifiable {
+    public var id: String { bsdName }
+    /// The synthesized whole-disk BSD name, e.g. "disk3".
+    public var bsdName: String
+    /// Total pool capacity from the synthesized media's Size, nil when the
+    /// registry lookup fails.
+    public var capacityBytes: UInt64?
+    /// Physical partitions backing the pool, e.g. ["disk0s2"].
+    public var physicalStoreBSDNames: [String]
+    /// BSD names of the container's volumes, mounted or not.
+    public var volumeBSDNames: [String]
+}

--- a/Sources/MacPerfMonitorCore/Persistence/Database.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/Database.swift
@@ -162,6 +162,16 @@ public enum MacPerfMonitorDatabase {
         migrator.registerMigration("v11-system-disk-activity") { db in
             try db.execute(sql: Schema.v11)
         }
+        // Disk service latency, utilization, and boot volume free space for the
+        // Disk page's history charts. Unlike v11 these columns are nullable on
+        // purpose: a tick with zero IO has no latency (charting it as 0 ms
+        // would paint an implausibly fast disk), and the boot volume figures
+        // are absent until the first statfs succeeds. Free space rolls up as
+        // avg plus MIN, not max: the alarming extremum for free space is the
+        // low water mark.
+        migrator.registerMigration("v12-disk-detail") { db in
+            try db.execute(sql: Schema.v12)
+        }
         return migrator
     }
 }
@@ -473,6 +483,34 @@ enum Schema {
             ON process_hour(bucket, process_id, samples, footprint_avg,
                             footprint_max, cpu_avg, energy_avg, net_avg,
                             disk_read_max, disk_written_max);
+        """
+
+    static let v12 = """
+        ALTER TABLE system_samples ADD COLUMN disk_read_latency REAL;
+        ALTER TABLE system_samples ADD COLUMN disk_write_latency REAL;
+        ALTER TABLE system_samples ADD COLUMN disk_util REAL;
+        ALTER TABLE system_samples ADD COLUMN boot_free INTEGER;
+        ALTER TABLE system_samples ADD COLUMN boot_total INTEGER;
+
+        ALTER TABLE system_minute ADD COLUMN disk_read_latency_avg REAL;
+        ALTER TABLE system_minute ADD COLUMN disk_read_latency_max REAL;
+        ALTER TABLE system_minute ADD COLUMN disk_write_latency_avg REAL;
+        ALTER TABLE system_minute ADD COLUMN disk_write_latency_max REAL;
+        ALTER TABLE system_minute ADD COLUMN disk_util_avg REAL;
+        ALTER TABLE system_minute ADD COLUMN disk_util_max REAL;
+        ALTER TABLE system_minute ADD COLUMN boot_free_avg INTEGER;
+        ALTER TABLE system_minute ADD COLUMN boot_free_min INTEGER;
+        ALTER TABLE system_minute ADD COLUMN boot_total INTEGER;
+
+        ALTER TABLE system_hour ADD COLUMN disk_read_latency_avg REAL;
+        ALTER TABLE system_hour ADD COLUMN disk_read_latency_max REAL;
+        ALTER TABLE system_hour ADD COLUMN disk_write_latency_avg REAL;
+        ALTER TABLE system_hour ADD COLUMN disk_write_latency_max REAL;
+        ALTER TABLE system_hour ADD COLUMN disk_util_avg REAL;
+        ALTER TABLE system_hour ADD COLUMN disk_util_max REAL;
+        ALTER TABLE system_hour ADD COLUMN boot_free_avg INTEGER;
+        ALTER TABLE system_hour ADD COLUMN boot_free_min INTEGER;
+        ALTER TABLE system_hour ADD COLUMN boot_total INTEGER;
         """
 }
 

--- a/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
@@ -78,6 +78,15 @@ extension Array where Element == SystemHistoryPoint {
             func dmean(_ value: (SystemHistoryPoint) -> Double) -> Double {
                 slice.reduce(0.0) { $0 + value($1) } / n
             }
+            // Mean over only the points that carry a value; nil (an interval
+            // with no IO, or no boot capacity recorded yet) must not drag the
+            // average toward zero, and an all-nil bucket must stay nil so the
+            // chart draws a gap.
+            func omean(_ value: (SystemHistoryPoint) -> Double?) -> Double? {
+                let present = slice.compactMap(value)
+                guard !present.isEmpty else { return nil }
+                return present.reduce(0, +) / Double(present.count)
+            }
             result.append(
                 SystemHistoryPoint(
                     // Grid-anchored start of the bucket: a fixed point that does
@@ -111,7 +120,14 @@ extension Array where Element == SystemHistoryPoint {
                     diskReadBytesPerSec: dmean { $0.diskReadBytesPerSec },
                     diskWriteBytesPerSec: dmean { $0.diskWriteBytesPerSec },
                     diskReadOperationsPerSec: dmean { $0.diskReadOperationsPerSec },
-                    diskWriteOperationsPerSec: dmean { $0.diskWriteOperationsPerSec }
+                    diskWriteOperationsPerSec: dmean { $0.diskWriteOperationsPerSec },
+                    diskReadLatencyMs: omean { $0.diskReadLatencyMs },
+                    diskWriteLatencyMs: omean { $0.diskWriteLatencyMs },
+                    diskUtilizationPercent: omean { $0.diskUtilizationPercent },
+                    // Free space wants its low water mark, not its average: the
+                    // moment the disk nearly filled is the moment that matters.
+                    bootFreeBytes: slice.compactMap(\.bootFreeBytes).min(),
+                    bootTotalBytes: slice.compactMap(\.bootTotalBytes).last
                 ))
             i = j
         }

--- a/Sources/MacPerfMonitorCore/Persistence/Retention.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/Retention.swift
@@ -291,7 +291,7 @@ public enum Retention {
 
         try db.execute(
             sql: """
-                INSERT INTO system_minute (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max)
+                INSERT INTO system_minute (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total)
                 SELECT CAST(timestamp / \(b) AS INTEGER) * \(b) AS b,
                        AVG(pressure_percent), MAX(pressure_percent),
                        CAST(AVG(app_memory) AS INTEGER), CAST(AVG(wired) AS INTEGER),
@@ -302,7 +302,11 @@ public enum Retention {
                        AVG(net_in), MAX(net_in), AVG(net_out), MAX(net_out),
                        AVG(disk_read), MAX(disk_read), AVG(disk_write), MAX(disk_write),
                        AVG(disk_read_iops), MAX(disk_read_iops),
-                       AVG(disk_write_iops), MAX(disk_write_iops)
+                       AVG(disk_write_iops), MAX(disk_write_iops),
+                       AVG(disk_read_latency), MAX(disk_read_latency),
+                       AVG(disk_write_latency), MAX(disk_write_latency),
+                       AVG(disk_util), MAX(disk_util),
+                       CAST(AVG(boot_free) AS INTEGER), MIN(boot_free), MAX(boot_total)
                 FROM system_samples
                 WHERE timestamp >= ? AND timestamp < ?
                 GROUP BY b
@@ -325,7 +329,16 @@ public enum Retention {
                   disk_read_iops_avg = excluded.disk_read_iops_avg,
                   disk_read_iops_max = excluded.disk_read_iops_max,
                   disk_write_iops_avg = excluded.disk_write_iops_avg,
-                  disk_write_iops_max = excluded.disk_write_iops_max
+                  disk_write_iops_max = excluded.disk_write_iops_max,
+                  disk_read_latency_avg = excluded.disk_read_latency_avg,
+                  disk_read_latency_max = excluded.disk_read_latency_max,
+                  disk_write_latency_avg = excluded.disk_write_latency_avg,
+                  disk_write_latency_max = excluded.disk_write_latency_max,
+                  disk_util_avg = excluded.disk_util_avg,
+                  disk_util_max = excluded.disk_util_max,
+                  boot_free_avg = excluded.boot_free_avg,
+                  boot_free_min = excluded.boot_free_min,
+                  boot_total = excluded.boot_total
                 """, arguments: [watermark, completeUpTo])
 
         try setMeta(db, "minute_watermark", completeUpTo)
@@ -377,7 +390,7 @@ public enum Retention {
 
         try db.execute(
             sql: """
-                INSERT INTO system_hour (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max)
+                INSERT INTO system_hour (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total)
                 SELECT CAST(bucket / 3600 AS INTEGER) * 3600 AS b,
                        SUM(pressure_avg * samples) / SUM(samples), MAX(pressure_max),
                        CAST(SUM(app_avg * samples) / SUM(samples) AS INTEGER),
@@ -397,7 +410,19 @@ public enum Retention {
                        SUM(disk_read_avg * samples) / SUM(samples), MAX(disk_read_max),
                        SUM(disk_write_avg * samples) / SUM(samples), MAX(disk_write_max),
                        SUM(disk_read_iops_avg * samples) / SUM(samples), MAX(disk_read_iops_max),
-                       SUM(disk_write_iops_avg * samples) / SUM(samples), MAX(disk_write_iops_max)
+                       SUM(disk_write_iops_avg * samples) / SUM(samples), MAX(disk_write_iops_max),
+                       SUM(disk_read_latency_avg * samples)
+                           / SUM(CASE WHEN disk_read_latency_avg IS NOT NULL THEN samples END),
+                       MAX(disk_read_latency_max),
+                       SUM(disk_write_latency_avg * samples)
+                           / SUM(CASE WHEN disk_write_latency_avg IS NOT NULL THEN samples END),
+                       MAX(disk_write_latency_max),
+                       SUM(disk_util_avg * samples)
+                           / SUM(CASE WHEN disk_util_avg IS NOT NULL THEN samples END),
+                       MAX(disk_util_max),
+                       CAST(SUM(boot_free_avg * samples)
+                           / SUM(CASE WHEN boot_free_avg IS NOT NULL THEN samples END) AS INTEGER),
+                       MIN(boot_free_min), MAX(boot_total)
                 FROM system_minute
                 WHERE bucket >= ? AND bucket < ?
                 GROUP BY b
@@ -420,7 +445,16 @@ public enum Retention {
                   disk_read_iops_avg = excluded.disk_read_iops_avg,
                   disk_read_iops_max = excluded.disk_read_iops_max,
                   disk_write_iops_avg = excluded.disk_write_iops_avg,
-                  disk_write_iops_max = excluded.disk_write_iops_max
+                  disk_write_iops_max = excluded.disk_write_iops_max,
+                  disk_read_latency_avg = excluded.disk_read_latency_avg,
+                  disk_read_latency_max = excluded.disk_read_latency_max,
+                  disk_write_latency_avg = excluded.disk_write_latency_avg,
+                  disk_write_latency_max = excluded.disk_write_latency_max,
+                  disk_util_avg = excluded.disk_util_avg,
+                  disk_util_max = excluded.disk_util_max,
+                  boot_free_avg = excluded.boot_free_avg,
+                  boot_free_min = excluded.boot_free_min,
+                  boot_total = excluded.boot_total
                 """, arguments: [watermark, completeUpTo])
 
         try setMeta(db, "hour_watermark", completeUpTo)

--- a/Sources/MacPerfMonitorCore/Persistence/SampleStore.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/SampleStore.swift
@@ -268,8 +268,10 @@ public final class SampleStore {
                  page_ins_delta, page_outs_delta, compressions_delta, decompressions_delta, cpu_load,
                  battery_present, battery_charge, battery_power, battery_charging, battery_health,
                  battery_cycles, battery_temp, net_in, net_out,
-                 disk_read, disk_write, disk_read_iops, disk_write_iops)
-                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                 disk_read, disk_write, disk_read_iops, disk_write_iops,
+                 disk_read_latency, disk_write_latency, disk_util, boot_free, boot_total)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
+                        ?,?,?,?,?)
                 """)
         try statement.execute(
             arguments: [
@@ -289,6 +291,8 @@ public final class SampleStore {
                 s.networkInBytesPerSec, s.networkOutBytesPerSec,
                 s.diskReadBytesPerSec, s.diskWriteBytesPerSec,
                 s.diskReadOperationsPerSec, s.diskWriteOperationsPerSec,
+                s.diskReadLatencyMs, s.diskWriteLatencyMs, s.diskUtilizationPercent,
+                s.bootVolumeFreeBytes.map(SQLInt.store), s.bootVolumeTotalBytes.map(SQLInt.store),
             ])
     }
 
@@ -508,7 +512,12 @@ public final class SampleStore {
             diskReadBytesPerSec: row["disk_read"],
             diskWriteBytesPerSec: row["disk_write"],
             diskReadOperationsPerSec: row["disk_read_iops"],
-            diskWriteOperationsPerSec: row["disk_write_iops"]
+            diskWriteOperationsPerSec: row["disk_write_iops"],
+            diskReadLatencyMs: row["disk_read_latency"],
+            diskWriteLatencyMs: row["disk_write_latency"],
+            diskUtilizationPercent: row["disk_util"],
+            bootVolumeTotalBytes: (row["boot_total"] as Int64?).map(SQLInt.read),
+            bootVolumeFreeBytes: (row["boot_free"] as Int64?).map(SQLInt.read)
         )
     }
 

--- a/Sources/MacPerfMonitorCore/Persistence/SystemHistory.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/SystemHistory.swift
@@ -32,6 +32,14 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
     public var diskWriteBytesPerSec: Double
     public var diskReadOperationsPerSec: Double
     public var diskWriteOperationsPerSec: Double
+    // Disk detail (v12). Optional, unlike the scalars above: nil marks "no IO
+    // in this interval" (latency/utilization) or "not recorded yet" (boot
+    // volume capacity), and charts must gap rather than draw zero.
+    public var diskReadLatencyMs: Double?
+    public var diskWriteLatencyMs: Double?
+    public var diskUtilizationPercent: Double?
+    public var bootFreeBytes: UInt64?
+    public var bootTotalBytes: UInt64?
 
     public var id: Date { date }
 
@@ -53,7 +61,12 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
         diskReadBytesPerSec: Double = 0,
         diskWriteBytesPerSec: Double = 0,
         diskReadOperationsPerSec: Double = 0,
-        diskWriteOperationsPerSec: Double = 0
+        diskWriteOperationsPerSec: Double = 0,
+        diskReadLatencyMs: Double? = nil,
+        diskWriteLatencyMs: Double? = nil,
+        diskUtilizationPercent: Double? = nil,
+        bootFreeBytes: UInt64? = nil,
+        bootTotalBytes: UInt64? = nil
     ) {
         self.date = date
         self.pressurePercent = pressurePercent
@@ -73,6 +86,11 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
         self.diskWriteBytesPerSec = diskWriteBytesPerSec
         self.diskReadOperationsPerSec = diskReadOperationsPerSec
         self.diskWriteOperationsPerSec = diskWriteOperationsPerSec
+        self.diskReadLatencyMs = diskReadLatencyMs
+        self.diskWriteLatencyMs = diskWriteLatencyMs
+        self.diskUtilizationPercent = diskUtilizationPercent
+        self.bootFreeBytes = bootFreeBytes
+        self.bootTotalBytes = bootTotalBytes
     }
 }
 
@@ -114,7 +132,8 @@ extension SampleStore {
                 sql: """
                     SELECT timestamp, pressure_percent, app_memory, wired, compressed, cached_files, swap_used, cpu_load,
                            battery_charge, battery_power, battery_health, battery_temp, net_in, net_out,
-                           disk_read, disk_write, disk_read_iops, disk_write_iops
+                           disk_read, disk_write, disk_read_iops, disk_write_iops,
+                           disk_read_latency, disk_write_latency, disk_util, boot_free, boot_total
                     FROM system_samples
                     WHERE timestamp >= ?
                     ORDER BY timestamp ASC
@@ -131,7 +150,9 @@ extension SampleStore {
                     SELECT bucket, pressure_avg, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg,
                            battery_charge_avg, battery_power_avg, battery_health_avg, battery_temp_avg,
                            net_in_avg, net_out_avg,
-                           disk_read_avg, disk_write_avg, disk_read_iops_avg, disk_write_iops_avg
+                           disk_read_avg, disk_write_avg, disk_read_iops_avg, disk_write_iops_avg,
+                           disk_read_latency_avg, disk_write_latency_avg, disk_util_avg,
+                           boot_free_min, boot_total
                     FROM \(table)
                     WHERE bucket >= ?
                     ORDER BY bucket ASC
@@ -141,7 +162,7 @@ extension SampleStore {
     }
 
     /// Positional decode shared by the raw and aggregate queries, which list the
-    /// same 18 columns in the same order. Reading by index (`row[0]`) rather than
+    /// same 23 columns in the same order. Reading by index (`row[0]`) rather than
     /// by name (`row["..."]`) avoids a column-name→index lookup per field per row,
     /// which over a few hundred points × 14 columns was a measurable read cost.
     private static func decodeHistoryPoint(_ row: Row) -> SystemHistoryPoint {
@@ -164,7 +185,12 @@ extension SampleStore {
             diskReadBytesPerSec: row[14],
             diskWriteBytesPerSec: row[15],
             diskReadOperationsPerSec: row[16],
-            diskWriteOperationsPerSec: row[17]
+            diskWriteOperationsPerSec: row[17],
+            diskReadLatencyMs: row[18],
+            diskWriteLatencyMs: row[19],
+            diskUtilizationPercent: row[20],
+            bootFreeBytes: (row[21] as Int64?).map(SQLInt.read),
+            bootTotalBytes: (row[22] as Int64?).map(SQLInt.read)
         )
     }
 }

--- a/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
@@ -58,6 +58,9 @@ public final class Sampler {
     private let networkReader: NetworkReader
     /// Physical block-device activity (always on; cheap IOKit property reads).
     private let diskReader: DiskReader
+    /// Root filesystem capacity for the free-space history. Self-throttled to
+    /// one statfs a minute, so it costs nothing on the 1 Hz tick.
+    private let bootVolumeReader: BootVolumeReader
     /// GPU utilization reader (IOAccelerator). Only read when `tickSystem` is asked
     /// to (the menubar GPU item gates it), so it costs nothing when GPU is off.
     private let gpuReader = GPUReader()
@@ -198,7 +201,8 @@ public final class Sampler {
         cpuReader: CPUReader = CPUReader(),
         batteryReader: BatteryReader = BatteryReader(),
         networkReader: NetworkReader = NetworkReader(),
-        diskReader: DiskReader = DiskReader()
+        diskReader: DiskReader = DiskReader(),
+        bootVolumeReader: BootVolumeReader = BootVolumeReader()
     ) {
         self.processReader = processReader
         self.memoryReader = memoryReader
@@ -206,6 +210,7 @@ public final class Sampler {
         self.batteryReader = batteryReader
         self.networkReader = networkReader
         self.diskReader = diskReader
+        self.bootVolumeReader = bootVolumeReader
     }
 
     /// Install (or remove) the privileged reader used to fill coverage gaps.
@@ -266,6 +271,7 @@ public final class Sampler {
         let battery = cachedBattery
         let network = networkReader.read(now: now)
         let disk = diskReader.read(now: now)
+        let bootVolume = bootVolumeReader.read(now: now)
         // Gated: only walk the IOAccelerator registry when something shows GPU.
         var gpu = readGPU ? gpuReader.read() : nil
         if readGPU, gpu != nil {
@@ -283,7 +289,7 @@ public final class Sampler {
         }
         let system = sampleSystem(
             now: now, wallDeltaSeconds: wallDeltaSeconds, cpuLoad: cpu.totalUsage, battery: battery,
-            network: network, disk: disk)
+            network: network, disk: disk, bootVolume: bootVolume)
         lastSystemTime = now
         return (system, cpu, battery, network, disk, gpu)
     }
@@ -643,6 +649,7 @@ public final class Sampler {
         lastBatteryReadAt = nil
         networkReader.reset()
         diskReader.reset()
+        bootVolumeReader.reset()
         privilegedFailureStreak = 0
         privilegedQuietUntil = nil
     }
@@ -655,7 +662,7 @@ public final class Sampler {
     /// and feeds the persisted system-history CPU timeline.
     private func sampleSystem(
         now: Date, wallDeltaSeconds: TimeInterval, cpuLoad: Double, battery: BatterySample?,
-        network: NetworkSample?, disk: DiskSample?
+        network: NetworkSample?, disk: DiskSample?, bootVolume: BootVolumeReader.Capacity?
     ) -> SystemSample {
         let totalRAM = memoryReader.totalRAM
         let vm = memoryReader.sampleVM()
@@ -745,7 +752,12 @@ public final class Sampler {
             diskReadBytesPerSec: disk?.readBytesPerSec ?? 0,
             diskWriteBytesPerSec: disk?.writeBytesPerSec ?? 0,
             diskReadOperationsPerSec: disk?.readOperationsPerSec ?? 0,
-            diskWriteOperationsPerSec: disk?.writeOperationsPerSec ?? 0
+            diskWriteOperationsPerSec: disk?.writeOperationsPerSec ?? 0,
+            diskReadLatencyMs: disk?.readLatencyMs,
+            diskWriteLatencyMs: disk?.writeLatencyMs,
+            diskUtilizationPercent: disk?.utilizationPercent,
+            bootVolumeTotalBytes: bootVolume?.totalBytes,
+            bootVolumeFreeBytes: bootVolume?.freeBytes
         )
     }
 

--- a/Sources/MacPerfMonitorCore/System/DiskInfoReader.swift
+++ b/Sources/MacPerfMonitorCore/System/DiskInfoReader.swift
@@ -1,0 +1,178 @@
+import Foundation
+import IOKit
+import IOKit.storage
+
+/// Reads static hardware identity for each physical disk from the registry
+/// chain above its `IOBlockStorageDriver`: the block storage device's
+/// characteristics dictionaries, the whole media's block size, and, when the
+/// disk hangs off an NVMe controller, the controller's identity properties.
+/// View-pulled by the Disk page at its slow poll cadence and cached per
+/// registry entry, so it never touches the 1 Hz sampler path.
+public final class DiskInfoReader {
+    struct DeviceReadout: Sendable, Equatable {
+        var registryEntryID: UInt64
+        var bsdName: String
+        var deviceCharacteristics: [String: String]
+        var protocolCharacteristics: [String: String]
+        var mediaPreferredBlockSize: UInt64?
+        var controllerClass: String?
+        var controllerProperties: [String: String]
+        /// Registry entry IDs to try for the SMART plug-in, controller first.
+        var smartCandidateIDs: [UInt64] = []
+    }
+
+    private let source: () -> [DeviceReadout]
+    private var cache: [UInt64: DiskHardwareInfo] = [:]
+
+    public convenience init() {
+        self.init(source: Self.readDevices)
+    }
+
+    init(source: @escaping () -> [DeviceReadout]) {
+        self.source = source
+    }
+
+    /// Hardware info keyed by the driver's registry entry ID (the same key
+    /// `DiskDeviceSample.registryEntryID` carries). Cached per device for as
+    /// long as the device stays in the registry; entries for vanished devices
+    /// are dropped so an unplugged drive does not linger.
+    public func read() -> [UInt64: DiskHardwareInfo] {
+        let readouts = source()
+        var next: [UInt64: DiskHardwareInfo] = [:]
+        for readout in readouts {
+            next[readout.registryEntryID] =
+                cache[readout.registryEntryID] ?? Self.info(from: readout)
+        }
+        cache = next
+        return next
+    }
+
+    public func reset() {
+        cache.removeAll()
+    }
+
+    /// Pure mapping from a harvested readout to the public model, so the whole
+    /// translation is testable against fixture dictionaries.
+    static func info(from readout: DeviceReadout) -> DiskHardwareInfo {
+        let device = readout.deviceCharacteristics
+        let proto = readout.protocolCharacteristics
+        let controller = readout.controllerProperties
+        return DiskHardwareInfo(
+            registryEntryID: readout.registryEntryID,
+            bsdName: readout.bsdName,
+            vendorName: nonEmpty(device["Vendor Name"]),
+            productName: nonEmpty(device["Product Name"]),
+            productRevision: nonEmpty(device["Product Revision Level"]),
+            serialNumber: nonEmpty(device["Serial Number"] ?? controller["Serial Number"]),
+            isSolidState: device["Medium Type"].map { $0 == "Solid State" },
+            interconnect: nonEmpty(proto["Physical Interconnect"]),
+            interconnectLocation: nonEmpty(proto["Physical Interconnect Location"]),
+            physicalBlockSizeBytes: readout.mediaPreferredBlockSize,
+            controllerClass: readout.controllerClass,
+            firmwareRevision: nonEmpty(controller["Firmware Revision"]),
+            nandStatus: nonEmpty(controller["AppleNANDStatus"]),
+            nvmeRevision: nonEmpty(controller["NVMe Revision Supported"]),
+            smartCandidateIDs: readout.smartCandidateIDs)
+    }
+
+    /// The registry publishes some identity strings as "" rather than omitting
+    /// them (the internal SSD's vendor name, for one); treat empty as absent.
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+
+    // MARK: - Real registry walk
+
+    private static func readDevices() -> [DeviceReadout] {
+        var iterator: io_iterator_t = 0
+        guard
+            IOServiceGetMatchingServices(
+                kIOMainPortDefault, IOServiceMatching(kIOBlockStorageDriverClass), &iterator)
+                == KERN_SUCCESS
+        else { return [] }
+        defer { IOObjectRelease(iterator) }
+
+        var result: [DeviceReadout] = []
+        var driver = IOIteratorNext(iterator)
+        while driver != 0 {
+            if let media = DiskReader.immediateWholeMedia(of: driver) {
+                defer { IOObjectRelease(media) }
+                if let bsdName = IOKitProperty.string(media, "BSD Name") {
+                    var entryID: UInt64 = 0
+                    IORegistryEntryGetRegistryEntryID(driver, &entryID)
+
+                    var device: [String: String] = [:]
+                    var proto: [String: String] = [:]
+                    var storageDeviceID: UInt64?
+                    var storageDevice: io_registry_entry_t = 0
+                    if IORegistryEntryGetParentEntry(driver, kIOServicePlane, &storageDevice)
+                        == KERN_SUCCESS, storageDevice != 0
+                    {
+                        defer { IOObjectRelease(storageDevice) }
+                        device = stringValues(
+                            IOKitProperty.dictionary(storageDevice, "Device Characteristics"))
+                        proto = stringValues(
+                            IOKitProperty.dictionary(storageDevice, "Protocol Characteristics"))
+                        var id: UInt64 = 0
+                        if IORegistryEntryGetRegistryEntryID(storageDevice, &id) == KERN_SUCCESS {
+                            storageDeviceID = id
+                        }
+                    }
+
+                    var controllerClass: String?
+                    var controllerProperties: [String: String] = [:]
+                    var smartCandidates: [UInt64] = []
+                    if let controller = IOKitProperty.firstParent(
+                        of: driver, conformingTo: "IONVMeController")
+                    {
+                        defer { IOObjectRelease(controller) }
+                        controllerClass = className(of: controller)
+                        for key in [
+                            "Firmware Revision", "Serial Number", "Model Number",
+                            "AppleNANDStatus", "NVMe Revision Supported",
+                        ] {
+                            controllerProperties[key] = IOKitProperty.string(controller, key)
+                        }
+                        // Which entry vends the SMART plug-in varies by macOS
+                        // release: try the controller first, then the block
+                        // storage device between driver and controller.
+                        var id: UInt64 = 0
+                        if IORegistryEntryGetRegistryEntryID(controller, &id) == KERN_SUCCESS {
+                            smartCandidates.append(id)
+                        }
+                        if let storageDeviceID {
+                            smartCandidates.append(storageDeviceID)
+                        }
+                    }
+
+                    result.append(
+                        DeviceReadout(
+                            registryEntryID: entryID,
+                            bsdName: bsdName,
+                            deviceCharacteristics: device,
+                            protocolCharacteristics: proto,
+                            mediaPreferredBlockSize: IOKitProperty.number(
+                                media, "Preferred Block Size"),
+                            controllerClass: controllerClass,
+                            controllerProperties: controllerProperties,
+                            smartCandidateIDs: smartCandidates))
+                }
+            }
+            IOObjectRelease(driver)
+            driver = IOIteratorNext(iterator)
+        }
+        return result
+    }
+
+    private static func stringValues(_ dictionary: [String: Any]?) -> [String: String] {
+        guard let dictionary else { return [:] }
+        return dictionary.compactMapValues { $0 as? String }
+    }
+
+    private static func className(of entry: io_registry_entry_t) -> String? {
+        var name = [CChar](repeating: 0, count: MemoryLayout<io_name_t>.size)
+        guard IOObjectGetClass(entry, &name) == KERN_SUCCESS else { return nil }
+        return String(cString: name)
+    }
+}

--- a/Sources/MacPerfMonitorCore/System/DiskReader.swift
+++ b/Sources/MacPerfMonitorCore/System/DiskReader.swift
@@ -61,6 +61,10 @@ public final class DiskReader {
         let current = counterSource()
         var nextPrevious: [UInt64: Previous] = [:]
         var devices: [DiskDeviceSample] = []
+        var readTimeDeltaTotal: UInt64 = 0
+        var readOpsDeltaTotal: UInt64 = 0
+        var writeTimeDeltaTotal: UInt64 = 0
+        var writeOpsDeltaTotal: UInt64 = 0
 
         for counters in current {
             let details =
@@ -81,6 +85,30 @@ public final class DiskReader {
                 counters.readOperations, prior?.counters.readOperations, interval: interval)
             let writeOperations = rate(
                 counters.writeOperations, prior?.counters.writeOperations, interval: interval)
+
+            let readTimeDelta = delta(
+                counters.readTimeNanoseconds, prior?.counters.readTimeNanoseconds)
+            let writeTimeDelta = delta(
+                counters.writeTimeNanoseconds, prior?.counters.writeTimeNanoseconds)
+            if let readTimeDelta,
+                let ops = delta(
+                    counters.readOperations, prior?.counters.readOperations)
+            {
+                readTimeDeltaTotal += readTimeDelta
+                readOpsDeltaTotal += ops
+            }
+            if let writeTimeDelta,
+                let ops = delta(
+                    counters.writeOperations, prior?.counters.writeOperations)
+            {
+                writeTimeDeltaTotal += writeTimeDelta
+                writeOpsDeltaTotal += ops
+            }
+            let utilization: Double? = {
+                guard interval > 0, let readTimeDelta, let writeTimeDelta else { return nil }
+                let busyNanoseconds = Double(readTimeDelta + writeTimeDelta)
+                return min(100, busyNanoseconds / (interval * 1_000_000_000) * 100)
+            }()
 
             devices.append(
                 DiskDeviceSample(
@@ -108,7 +136,8 @@ public final class DiskReader {
                     readErrors: counters.readErrors,
                     writeErrors: counters.writeErrors,
                     readRetries: counters.readRetries,
-                    writeRetries: counters.writeRetries))
+                    writeRetries: counters.writeRetries,
+                    utilizationPercent: utilization))
             nextPrevious[counters.registryEntryID] = Previous(counters: counters, timestamp: now)
         }
 
@@ -126,6 +155,9 @@ public final class DiskReader {
             writeBytesPerSec: devices.reduce(0) { $0 + $1.writeBytesPerSec },
             readOperationsPerSec: devices.reduce(0) { $0 + $1.readOperationsPerSec },
             writeOperationsPerSec: devices.reduce(0) { $0 + $1.writeOperationsPerSec },
+            readLatencyMs: latency(timeDelta: readTimeDeltaTotal, opsDelta: readOpsDeltaTotal),
+            writeLatencyMs: latency(timeDelta: writeTimeDeltaTotal, opsDelta: writeOpsDeltaTotal),
+            utilizationPercent: devices.compactMap(\.utilizationPercent).max(),
             devices: devices)
     }
 
@@ -136,6 +168,21 @@ public final class DiskReader {
     private func rate(_ current: UInt64, _ prior: UInt64?, interval: TimeInterval) -> Double {
         guard let prior, interval > 0, current >= prior else { return 0 }
         return Double(current - prior) / interval
+    }
+
+    /// Counter delta guarded the same way as `rate`: nil (not zero) without a
+    /// prior sample or after a counter reset, so downstream averages skip the
+    /// interval instead of folding in a bogus zero.
+    private func delta(_ current: UInt64, _ prior: UInt64?) -> UInt64? {
+        guard let prior, current >= prior else { return nil }
+        return current - prior
+    }
+
+    /// Ops-weighted service time in milliseconds across every device that had a
+    /// valid interval; nil when the interval saw zero completed operations.
+    private func latency(timeDelta: UInt64, opsDelta: UInt64) -> Double? {
+        guard opsDelta > 0 else { return nil }
+        return Double(timeDelta) / Double(opsDelta) / 1_000_000
     }
 
     private func averageMilliseconds(
@@ -162,8 +209,9 @@ public final class DiskReader {
         while driver != 0 {
             if let media = immediateWholeMedia(of: driver) {
                 defer { IOObjectRelease(media) }
-                if let bsdName = stringProperty(media, "BSD Name"),
-                    let stats = dictionaryProperty(driver, kIOBlockStorageDriverStatisticsKey)
+                if let bsdName = IOKitProperty.string(media, "BSD Name"),
+                    let stats = IOKitProperty.dictionary(
+                        driver, kIOBlockStorageDriverStatisticsKey)
                 {
                     var entryID: UInt64 = 0
                     IORegistryEntryGetRegistryEntryID(driver, &entryID)
@@ -196,8 +244,9 @@ public final class DiskReader {
         return result
     }
 
-    private static func immediateWholeMedia(of driver: io_registry_entry_t) -> io_registry_entry_t?
-    {
+    /// Internal (not private) so `DiskInfoReader` walks the identical chain and
+    /// the two readers can never disagree about which media a driver owns.
+    static func immediateWholeMedia(of driver: io_registry_entry_t) -> io_registry_entry_t? {
         var iterator: io_iterator_t = 0
         guard
             IORegistryEntryGetChildIterator(driver, kIOServicePlane, &iterator) == KERN_SUCCESS
@@ -207,7 +256,7 @@ public final class DiskReader {
         var child = IOIteratorNext(iterator)
         while child != 0 {
             if IOObjectConformsTo(child, kIOMediaClass) != 0,
-                boolProperty(child, "Whole") == true
+                IOKitProperty.bool(child, "Whole") == true
             {
                 return child
             }
@@ -236,23 +285,6 @@ public final class DiskReader {
                 ?? false,
             isVirtual: model == "Disk Image" || protocolName == "Virtual Interface"
                 || path.contains("IOHDIXController"))
-    }
-
-    private static func dictionaryProperty(
-        _ entry: io_registry_entry_t, _ key: String
-    ) -> [String: Any]? {
-        IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? [String: Any]
-    }
-
-    private static func stringProperty(_ entry: io_registry_entry_t, _ key: String) -> String? {
-        IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String
-    }
-
-    private static func boolProperty(_ entry: io_registry_entry_t, _ key: String) -> Bool? {
-        IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? Bool
     }
 
     private static func number(_ dictionary: [String: Any], _ key: String) -> UInt64 {

--- a/Sources/MacPerfMonitorCore/System/IOKitProperty.swift
+++ b/Sources/MacPerfMonitorCore/System/IOKitProperty.swift
@@ -1,0 +1,57 @@
+import Foundation
+import IOKit
+
+/// Typed wrappers over `IORegistryEntryCreateCFProperty`, shared by the disk
+/// and volume readers so every registry read releases its CF value the same
+/// way. Each returns nil when the key is absent or has an unexpected type.
+enum IOKitProperty {
+    static func string(_ entry: io_registry_entry_t, _ key: String) -> String? {
+        IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? String
+    }
+
+    static func stringArray(_ entry: io_registry_entry_t, _ key: String) -> [String]? {
+        IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? [String]
+    }
+
+    static func bool(_ entry: io_registry_entry_t, _ key: String) -> Bool? {
+        IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? Bool
+    }
+
+    static func number(_ entry: io_registry_entry_t, _ key: String) -> UInt64? {
+        (IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? NSNumber)?.uint64Value
+    }
+
+    static func dictionary(_ entry: io_registry_entry_t, _ key: String) -> [String: Any]? {
+        IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? [String: Any]
+    }
+
+    /// Raw data property, for fixed-layout blobs like SMART logs.
+    static func data(_ entry: io_registry_entry_t, _ key: String) -> Data? {
+        IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? Data
+    }
+
+    /// First parent in the service plane that conforms to `className`, walking
+    /// upward at most `maxDepth` levels. The caller owns the returned entry and
+    /// must `IOObjectRelease` it.
+    static func firstParent(
+        of entry: io_registry_entry_t, conformingTo className: String, maxDepth: Int = 6
+    ) -> io_registry_entry_t? {
+        var current = entry
+        for depth in 0..<maxDepth {
+            var parent: io_registry_entry_t = 0
+            let status = IORegistryEntryGetParentEntry(current, kIOServicePlane, &parent)
+            if depth > 0 { IOObjectRelease(current) }
+            guard status == KERN_SUCCESS, parent != 0 else { return nil }
+            if IOObjectConformsTo(parent, className) != 0 { return parent }
+            current = parent
+        }
+        if current != entry { IOObjectRelease(current) }
+        return nil
+    }
+}

--- a/Sources/MacPerfMonitorCore/System/NVMeSMARTReader.swift
+++ b/Sources/MacPerfMonitorCore/System/NVMeSMARTReader.swift
@@ -1,0 +1,78 @@
+import CMacPerfMonitor
+import Foundation
+
+/// Reads the NVMe SMART / Health log through the `IONVMeSMARTUserClient`
+/// plug-in interface. The C shim fetches the raw 512 bytes (the COM-style
+/// plug-in dance cannot be written in Swift); everything here is parsing, so
+/// the decoder is fully testable against fixture blobs. Never called from the
+/// sampler: the Disk page pulls it at its slow poll cadence, and the caller
+/// throttles per device.
+public final class NVMeSMARTReader {
+    private let fetch: (UInt64) -> [UInt8]?
+
+    public convenience init() {
+        self.init(fetch: Self.fetchViaShim)
+    }
+
+    init(fetch: @escaping (UInt64) -> [UInt8]?) {
+        self.fetch = fetch
+    }
+
+    /// Try each candidate registry entry (the controller, then the block
+    /// storage device; which one exposes the plug-in varies by macOS release)
+    /// and return the first log that decodes. Nil means SMART is simply not
+    /// available for this disk, the expected outcome for externals.
+    public func read(candidateRegistryEntryIDs: [UInt64]) -> NVMeSMARTSnapshot? {
+        for id in candidateRegistryEntryIDs {
+            if let bytes = fetch(id), let snapshot = Self.parse(Data(bytes)) {
+                return snapshot
+            }
+        }
+        return nil
+    }
+
+    /// Decode the standard 512-byte SMART / Health log page (NVMe spec figure
+    /// 194 layout, all fields little-endian, 128-bit counters truncated to
+    /// their low 64 bits). Returns nil for short input; a real log is always
+    /// exactly 512 bytes.
+    static func parse(_ data: Data) -> NVMeSMARTSnapshot? {
+        guard data.count >= 512 else { return nil }
+        let kelvin = uint16(data, at: 1)
+        return NVMeSMARTSnapshot(
+            criticalWarning: data[data.startIndex],
+            temperatureCelsius: kelvin == 0 ? nil : Double(kelvin) - 273.15,
+            availableSparePercent: data[data.startIndex + 3],
+            spareThresholdPercent: data[data.startIndex + 4],
+            percentageUsed: data[data.startIndex + 5],
+            dataUnitsRead: uint64(data, at: 32),
+            dataUnitsWritten: uint64(data, at: 48),
+            hostReadCommands: uint64(data, at: 64),
+            hostWriteCommands: uint64(data, at: 80),
+            controllerBusyTimeMinutes: uint64(data, at: 96),
+            powerCycles: uint64(data, at: 112),
+            powerOnHours: uint64(data, at: 128),
+            unsafeShutdowns: uint64(data, at: 144),
+            mediaErrors: uint64(data, at: 160),
+            errorLogEntries: uint64(data, at: 176))
+    }
+
+    private static func uint16(_ data: Data, at offset: Int) -> UInt16 {
+        let base = data.startIndex + offset
+        return UInt16(data[base]) | UInt16(data[base + 1]) << 8
+    }
+
+    private static func uint64(_ data: Data, at offset: Int) -> UInt64 {
+        let base = data.startIndex + offset
+        var value: UInt64 = 0
+        for byte in 0..<8 {
+            value |= UInt64(data[base + byte]) << (8 * byte)
+        }
+        return value
+    }
+
+    private static func fetchViaShim(_ registryEntryID: UInt64) -> [UInt8]? {
+        var buffer = [UInt8](repeating: 0, count: 512)
+        guard cmacperfmonitor_nvme_smart_read(registryEntryID, &buffer) == 0 else { return nil }
+        return buffer
+    }
+}

--- a/Sources/MacPerfMonitorCore/System/VolumeReader.swift
+++ b/Sources/MacPerfMonitorCore/System/VolumeReader.swift
@@ -1,0 +1,450 @@
+import Foundation
+import IOKit
+
+/// `statfs` names both the C struct and the C function; Swift resolves a bare
+/// `statfs()` expression to the function, so the struct needs its own name.
+private typealias FSStatBuffer = statfs
+
+/// Enumerates mounted volumes with capacity, purgeable-aware free space, and
+/// APFS container topology. On-demand only: the Disk page pulls a snapshot
+/// every poll while visible. `getfsstat` runs with `MNT_NOWAIT` so a dead
+/// network mount can never stall the call, and every enrichment layer (resource
+/// values, IORegistry) degrades field by field like the other readers.
+public final class VolumeReader {
+    struct FSStatRow: Sendable, Equatable {
+        var mountPoint: String
+        var deviceNode: String
+        var fsTypeName: String
+        var blockSize: UInt64
+        var totalBytes: UInt64
+        var freeBytes: UInt64
+        var availableBytes: UInt64
+        var isLocal: Bool
+        var isReadOnly: Bool
+        var isRoot: Bool
+        /// Bytes this volume itself consumes, from `getattrlist`'s
+        /// `ATTR_VOL_SPACEUSED` (what `df` reports as Used). On APFS,
+        /// `statfs.f_bfree` is the container's shared free pool for most
+        /// mounts, so `total - free` wildly overstates per-volume usage; this
+        /// attribute is the only per-volume truth. Nil when the query fails.
+        var spaceUsedBytes: UInt64? = nil
+    }
+
+    struct VolumeResourceReadout: Sendable, Equatable {
+        var name: String?
+        var uuid: String?
+        var importantUsageAvailableBytes: UInt64?
+        var isInternal: Bool?
+        var isEjectable: Bool?
+        var isEncrypted: Bool?
+    }
+
+    struct APFSVolumeReadout: Sendable, Equatable {
+        var bsdName: String
+        var roles: [String]
+    }
+
+    struct APFSContainerReadout: Sendable, Equatable {
+        var bsdName: String
+        var capacityBytes: UInt64?
+        var physicalStoreBSDNames: [String]
+        var volumes: [APFSVolumeReadout]
+    }
+
+    private let fsstatSource: () -> [FSStatRow]
+    private let resourceSource: (String) -> VolumeResourceReadout?
+    private let containerSource: () -> [APFSContainerReadout]
+
+    public convenience init() {
+        self.init(
+            fsstatSource: Self.readFSStat,
+            resourceSource: Self.readResources,
+            containerSource: Self.readContainers)
+    }
+
+    init(
+        fsstatSource: @escaping () -> [FSStatRow],
+        resourceSource: @escaping (String) -> VolumeResourceReadout?,
+        containerSource: @escaping () -> [APFSContainerReadout]
+    ) {
+        self.fsstatSource = fsstatSource
+        self.resourceSource = resourceSource
+        self.containerSource = containerSource
+    }
+
+    public func read(now: Date = Date()) -> VolumeSnapshot {
+        // Pseudo filesystems (devfs, autofs) report zero capacity; they are
+        // noise on a storage page.
+        let rows = fsstatSource().filter { $0.totalBytes > 0 }
+        let containers = containerSource()
+
+        var containerByVolume: [String: String] = [:]
+        var rolesByVolume: [String: [String]] = [:]
+        for container in containers {
+            for volume in container.volumes {
+                containerByVolume[volume.bsdName] = container.bsdName
+                rolesByVolume[volume.bsdName] = volume.roles
+            }
+        }
+
+        var volumes: [VolumeInfo] = rows.map { row in
+            let resources = resourceSource(row.mountPoint)
+            let bsdName = Self.bsdName(fromDeviceNode: row.deviceNode)
+            // The root mount is a sealed snapshot named like "disk3s3s1"; its
+            // registry volume is the parent "disk3s3".
+            let registryBSDName = bsdName.map(Self.strippingSnapshotSuffix)
+            let importantUsage = Self.sanitizedImportantUsage(
+                resources?.importantUsageAvailableBytes, totalBytes: row.totalBytes)
+            return VolumeInfo(
+                mountPoint: row.mountPoint,
+                name: resources?.name ?? Self.fallbackName(forMountPoint: row.mountPoint),
+                bsdName: bsdName,
+                fsTypeName: row.fsTypeName,
+                volumeUUID: resources?.uuid,
+                role: Self.classifyRole(
+                    registryRoles: registryBSDName.flatMap { rolesByVolume[$0] } ?? [],
+                    mountPoint: row.mountPoint,
+                    isRoot: row.isRoot),
+                isRoot: row.isRoot,
+                isLocal: row.isLocal,
+                isReadOnly: row.isReadOnly,
+                isInternal: resources?.isInternal,
+                isEjectable: resources?.isEjectable,
+                isEncrypted: resources?.isEncrypted,
+                totalBytes: row.totalBytes,
+                freeBytes: row.freeBytes,
+                availableBytes: row.availableBytes,
+                importantUsageAvailableBytes: importantUsage,
+                purgeableBytes: importantUsage.map {
+                    $0 > row.availableBytes ? $0 - row.availableBytes : 0
+                },
+                containerBSDName: registryBSDName.flatMap { containerByVolume[$0] },
+                blockSize: row.blockSize,
+                spaceUsedBytes: row.spaceUsedBytes)
+        }
+        volumes = Self.deduplicatingMultipleMounts(volumes)
+        volumes.sort {
+            if $0.isRoot != $1.isRoot { return $0.isRoot }
+            return $0.mountPoint.localizedStandardCompare($1.mountPoint) == .orderedAscending
+        }
+
+        let containerInfos = containers.map { container in
+            APFSContainerInfo(
+                bsdName: container.bsdName,
+                capacityBytes: container.capacityBytes,
+                physicalStoreBSDNames: container.physicalStoreBSDNames,
+                volumeBSDNames: container.volumes.map(\.bsdName))
+        }
+        return VolumeSnapshot(timestamp: now, volumes: volumes, containers: containerInfos)
+    }
+
+    // MARK: - Pure derivations (unit-tested against fixtures)
+
+    /// One APFS volume can be mounted more than once at a time: the System
+    /// volume appears as the sealed snapshot at "/" AND as a staging mount
+    /// under /System/Volumes/Update during a pending macOS update. Counting
+    /// both would double the volume's bytes in the capacity bar, so keep one
+    /// mount per underlying volume, preferring the root mount, then the first
+    /// by mount point.
+    static func deduplicatingMultipleMounts(_ volumes: [VolumeInfo]) -> [VolumeInfo] {
+        var seen: [String: Int] = [:]
+        var result: [VolumeInfo] = []
+        for volume in volumes {
+            guard let bsd = volume.bsdName else {
+                result.append(volume)
+                continue
+            }
+            let key = strippingSnapshotSuffix(bsd)
+            if let existingIndex = seen[key] {
+                if volume.isRoot && !result[existingIndex].isRoot {
+                    result[existingIndex] = volume
+                }
+            } else {
+                seen[key] = result.count
+                result.append(volume)
+            }
+        }
+        return result
+    }
+
+    /// Map IORegistry role strings to the display role, falling back to
+    /// well-known mount points when the registry gave nothing. Pure so the
+    /// whole table is testable.
+    static func classifyRole(
+        registryRoles: [String], mountPoint: String, isRoot: Bool
+    ) -> VolumeRole {
+        switch registryRoles.first {
+        case "System": return .system
+        case "Data": return .data
+        case "Preboot": return .preboot
+        case "Recovery": return .recovery
+        case "VM": return .vm
+        case "Update", "xART", "Hardware", "iSCPreboot", "Sysdiagnose": return .support
+        default: break
+        }
+        if isRoot { return .system }
+        switch mountPoint {
+        case "/System/Volumes/Data": return .data
+        case "/System/Volumes/Preboot": return .preboot
+        case "/System/Volumes/Recovery": return .recovery
+        case "/System/Volumes/VM": return .vm
+        default: break
+        }
+        // OS plumbing that mounts real volumes in system locations: update
+        // staging, cryptexes, and simulator runtime images are not the user's
+        // storage even though they are ordinary APFS mounts.
+        let supportPrefixes = [
+            "/System/Volumes/", "/System/Cryptexes/", "/private/var/run/",
+            "/Library/Developer/CoreSimulator/Volumes/",
+        ]
+        if supportPrefixes.contains(where: mountPoint.hasPrefix) { return .support }
+        return .user
+    }
+
+    /// "/dev/disk3s1" -> "disk3s1"; non device-backed mounts return nil.
+    static func bsdName(fromDeviceNode node: String) -> String? {
+        guard node.hasPrefix("/dev/") else { return nil }
+        return String(node.dropFirst("/dev/".count))
+    }
+
+    /// "disk3s3s1" (a mounted snapshot) -> "disk3s3"; anything else unchanged.
+    /// Only the digits after the "disk" prefix are split, since the word
+    /// "disk" itself contains an "s".
+    static func strippingSnapshotSuffix(_ bsdName: String) -> String {
+        guard bsdName.hasPrefix("disk") else { return bsdName }
+        let parts = bsdName.dropFirst("disk".count)
+            .split(separator: "s", omittingEmptySubsequences: false)
+        guard parts.count == 3, parts.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) })
+        else { return bsdName }
+        return "disk\(parts[0])s\(parts[1])"
+    }
+
+    /// Foundation sometimes reports 0 for the important-usage capacity on
+    /// volumes it cannot assess; a literal zero next to a nonzero total is far
+    /// more likely "unknown" than "completely full", so treat it as nil.
+    static func sanitizedImportantUsage(_ value: UInt64?, totalBytes: UInt64) -> UInt64? {
+        guard let value else { return nil }
+        return (value == 0 && totalBytes > 0) ? nil : value
+    }
+
+    static func fallbackName(forMountPoint mountPoint: String) -> String {
+        mountPoint == "/" ? "Macintosh HD" : (mountPoint as NSString).lastPathComponent
+    }
+
+    // MARK: - Real sources
+
+    private static func readFSStat() -> [FSStatRow] {
+        var count = getfsstat(nil, 0, MNT_NOWAIT)
+        guard count > 0 else { return [] }
+        var buffer = [FSStatBuffer](repeating: FSStatBuffer(), count: Int(count))
+        let bufferBytes = Int32(MemoryLayout<FSStatBuffer>.stride * buffer.count)
+        count = getfsstat(&buffer, bufferBytes, MNT_NOWAIT)
+        guard count > 0 else { return [] }
+
+        return buffer.prefix(Int(count)).map { fs in
+            let blockSize = UInt64(fs.f_bsize)
+            let flags = UInt32(fs.f_flags)
+            let mountPoint = string(fromCString: fs.f_mntonname)
+            return FSStatRow(
+                mountPoint: mountPoint,
+                deviceNode: string(fromCString: fs.f_mntfromname),
+                fsTypeName: string(fromCString: fs.f_fstypename),
+                blockSize: blockSize,
+                totalBytes: fs.f_blocks * blockSize,
+                freeBytes: fs.f_bfree * blockSize,
+                availableBytes: UInt64(max(0, fs.f_bavail)) * blockSize,
+                isLocal: flags & UInt32(MNT_LOCAL) != 0,
+                isReadOnly: flags & UInt32(MNT_RDONLY) != 0,
+                isRoot: flags & UInt32(MNT_ROOTFS) != 0,
+                spaceUsedBytes: spaceUsed(atMountPoint: mountPoint))
+        }
+    }
+
+    /// Per-volume bytes consumed, via `getattrlist(ATTR_VOL_SPACEUSED)`: the
+    /// figure `df` prints as Used. The attribute buffer is packed (a 4-byte
+    /// length then an 8-byte value at offset 4), so the value needs an
+    /// unaligned load rather than a struct overlay.
+    private static func spaceUsed(atMountPoint mountPoint: String) -> UInt64? {
+        var attributes = attrlist()
+        attributes.bitmapcount = u_short(ATTR_BIT_MAP_COUNT)
+        attributes.volattr = attrgroup_t(ATTR_VOL_INFO) | attrgroup_t(ATTR_VOL_SPACEUSED)
+        var buffer = [UInt8](repeating: 0, count: 16)
+        let status = buffer.withUnsafeMutableBytes { raw in
+            getattrlist(mountPoint, &attributes, raw.baseAddress, raw.count, 0)
+        }
+        guard status == 0 else { return nil }
+        let value = buffer.withUnsafeBytes { raw in
+            raw.loadUnaligned(fromByteOffset: 4, as: Int64.self)
+        }
+        return value >= 0 ? UInt64(value) : nil
+    }
+
+    private static func readResources(mountPoint: String) -> VolumeResourceReadout? {
+        let url = URL(fileURLWithPath: mountPoint, isDirectory: true)
+        let keys: Set<URLResourceKey> = [
+            .volumeNameKey, .volumeUUIDStringKey, .volumeAvailableCapacityForImportantUsageKey,
+            .volumeIsInternalKey, .volumeIsEjectableKey, .volumeIsEncryptedKey,
+        ]
+        guard let values = try? url.resourceValues(forKeys: keys) else { return nil }
+        return VolumeResourceReadout(
+            name: values.volumeName,
+            uuid: values.volumeUUIDString,
+            importantUsageAvailableBytes: values.volumeAvailableCapacityForImportantUsage
+                .map { UInt64(max(0, $0)) },
+            isInternal: values.volumeIsInternal,
+            isEjectable: values.volumeIsEjectable,
+            isEncrypted: values.volumeIsEncrypted)
+    }
+
+    /// Walk the registry once: each `AppleAPFSContainer` yields its volumes
+    /// (children) and physical store (parent `IOMedia`); the synthesized
+    /// container media (`AppleAPFSMedia`) supplies the container's BSD name and
+    /// capacity, joined via the volume BSD prefix ("disk3s1" lives in "disk3").
+    private static func readContainers() -> [APFSContainerReadout] {
+        var mediaSizeByBSD: [String: UInt64] = [:]
+        forEachService(matching: "AppleAPFSMedia") { media in
+            if let bsd = IOKitProperty.string(media, "BSD Name"),
+                let size = IOKitProperty.number(media, "Size")
+            {
+                mediaSizeByBSD[bsd] = size
+            }
+        }
+
+        var containers: [APFSContainerReadout] = []
+        forEachService(matching: "AppleAPFSContainer") { container in
+            var volumes: [APFSVolumeReadout] = []
+            var iterator: io_iterator_t = 0
+            if IORegistryEntryGetChildIterator(container, kIOServicePlane, &iterator)
+                == KERN_SUCCESS
+            {
+                defer { IOObjectRelease(iterator) }
+                var child = IOIteratorNext(iterator)
+                while child != 0 {
+                    if IOObjectConformsTo(child, "AppleAPFSVolume") != 0,
+                        let bsd = IOKitProperty.string(child, "BSD Name")
+                    {
+                        volumes.append(
+                            APFSVolumeReadout(
+                                bsdName: bsd,
+                                roles: IOKitProperty.stringArray(child, "Role") ?? []))
+                    }
+                    IOObjectRelease(child)
+                    child = IOIteratorNext(iterator)
+                }
+            }
+            guard let containerBSD = volumes.first.flatMap({ containerName(ofVolume: $0.bsdName) })
+            else { return }
+
+            // The parent chain above a container interleaves synthesized APFS
+            // media (the container's own "diskN") with the real partition; the
+            // physical store is the first IOMedia ancestor that is NOT itself
+            // an AppleAPFSMedia (e.g. "disk0s2").
+            var stores: [String] = []
+            var ancestor = IOKitProperty.firstParent(of: container, conformingTo: kIOMediaClass)
+            while let media = ancestor {
+                if IOObjectConformsTo(media, "AppleAPFSMedia") == 0 {
+                    if let bsd = IOKitProperty.string(media, "BSD Name") { stores.append(bsd) }
+                    IOObjectRelease(media)
+                    break
+                }
+                ancestor = IOKitProperty.firstParent(of: media, conformingTo: kIOMediaClass)
+                IOObjectRelease(media)
+            }
+            containers.append(
+                APFSContainerReadout(
+                    bsdName: containerBSD,
+                    capacityBytes: mediaSizeByBSD[containerBSD],
+                    physicalStoreBSDNames: stores,
+                    volumes: volumes.sorted {
+                        $0.bsdName.localizedStandardCompare($1.bsdName) == .orderedAscending
+                    }))
+        }
+        return containers.sorted {
+            $0.bsdName.localizedStandardCompare($1.bsdName) == .orderedAscending
+        }
+    }
+
+    /// "disk3s1" -> "disk3".
+    private static func containerName(ofVolume bsdName: String) -> String? {
+        guard let range = bsdName.range(of: "s", options: .backwards),
+            bsdName.hasPrefix("disk")
+        else { return nil }
+        return String(bsdName[..<range.lowerBound])
+    }
+
+    private static func forEachService(
+        matching className: String, _ body: (io_registry_entry_t) -> Void
+    ) {
+        var iterator: io_iterator_t = 0
+        guard
+            IOServiceGetMatchingServices(
+                kIOMainPortDefault, IOServiceMatching(className), &iterator) == KERN_SUCCESS
+        else { return }
+        defer { IOObjectRelease(iterator) }
+        var entry = IOIteratorNext(iterator)
+        while entry != 0 {
+            body(entry)
+            IOObjectRelease(entry)
+            entry = IOIteratorNext(iterator)
+        }
+    }
+
+    private static func string<T>(fromCString tuple: T) -> String {
+        withUnsafeBytes(of: tuple) { raw in
+            guard let base = raw.baseAddress else { return "" }
+            return String(cString: base.assumingMemoryBound(to: CChar.self))
+        }
+    }
+}
+
+/// The one volume figure that rides the sampler: root filesystem capacity, so
+/// free-space history accrues even while the Disk page is closed. A single
+/// cached `statfs("/")` refreshed at most once a minute; free space moves far
+/// too slowly to deserve the 1 Hz tick. On APFS the root volume's available
+/// space is the container's shared free pool, exactly the "disk filling up"
+/// number.
+public final class BootVolumeReader {
+    public struct Capacity: Sendable, Equatable {
+        public var totalBytes: UInt64
+        public var freeBytes: UInt64
+    }
+
+    private let source: () -> Capacity?
+    private let minInterval: TimeInterval
+    private var cached: Capacity?
+    private var lastReadAt: Date?
+
+    public convenience init() {
+        self.init(source: Self.readRoot)
+    }
+
+    init(minInterval: TimeInterval = 60, source: @escaping () -> Capacity?) {
+        self.minInterval = minInterval
+        self.source = source
+    }
+
+    public func read(now: Date = Date()) -> Capacity? {
+        let due = lastReadAt.map { now.timeIntervalSince($0) >= minInterval } ?? true
+        if due {
+            // Gate on time regardless of the result, so a failing statfs also
+            // stops retrying every tick (the battery reader's convention).
+            cached = source() ?? cached
+            lastReadAt = now
+        }
+        return cached
+    }
+
+    public func reset() {
+        cached = nil
+        lastReadAt = nil
+    }
+
+    private static func readRoot() -> Capacity? {
+        var fs = FSStatBuffer()
+        guard statfs("/", &fs) == 0 else { return nil }
+        let blockSize = UInt64(fs.f_bsize)
+        return Capacity(
+            totalBytes: fs.f_blocks * blockSize,
+            freeBytes: UInt64(max(0, fs.f_bavail)) * blockSize)
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/DiskCapacityBreakdownTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskCapacityBreakdownTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class DiskCapacityBreakdownTests: XCTestCase {
+    func testSlicesSumToContainerCapacityWithPurgeableCarvedFromLargest() {
+        let container = APFSContainerInfo(
+            bsdName: "disk3", capacityBytes: 1_000,
+            physicalStoreBSDNames: ["disk0s2"], volumeBSDNames: [])
+        let slices = DiskCapacityBreakdown.slices(
+            container: container,
+            volumes: [
+                volume(mount: "/System/Volumes/Data", used: 600, purgeable: 50, role: .data),
+                volume(mount: "/", used: 100, role: .system),
+            ])
+
+        XCTAssertEqual(slices.reduce(0) { $0 + $1.bytes }, 1_000)
+        XCTAssertEqual(
+            slices.map(\.label), ["Macintosh HD - Data", "Macintosh HD", "Purgeable", "Free"])
+        // Purgeable (50) carved out of Data (600 - 50 = 550), not double counted.
+        XCTAssertEqual(slices[0].bytes, 550)
+        XCTAssertEqual(slices[2].bytes, 50)
+        XCTAssertEqual(slices[3].bytes, 300)
+        XCTAssertEqual(slices[3].kind, .free)
+    }
+
+    func testFoldsVolumesBeyondTheNamedCapAfterPurgeable() {
+        let container = APFSContainerInfo(
+            bsdName: "disk3", capacityBytes: 1_000,
+            physicalStoreBSDNames: [], volumeBSDNames: [])
+        let slices = DiskCapacityBreakdown.slices(
+            container: container,
+            volumes: [
+                volume(mount: "/a", used: 400, purgeable: 10),
+                volume(mount: "/b", used: 200),
+                volume(mount: "/c", used: 100),
+                volume(mount: "/d", used: 50),
+                volume(mount: "/e", used: 25),
+            ])
+
+        // Fixed render order: 3 named, purgeable, folded other, free.
+        XCTAssertEqual(slices.count, 6)
+        XCTAssertEqual(slices[3].kind, .purgeable)
+        XCTAssertEqual(slices[4].kind, .otherVolumes(count: 2))
+        XCTAssertEqual(slices[4].bytes, 75)
+        XCTAssertEqual(slices.reduce(0) { $0 + $1.bytes }, 1_000)
+    }
+
+    func testOverfullContainerClampsFreeToZeroNotUnderflow() {
+        let container = APFSContainerInfo(
+            bsdName: "disk3", capacityBytes: 100,
+            physicalStoreBSDNames: [], volumeBSDNames: [])
+        let slices = DiskCapacityBreakdown.slices(
+            container: container, volumes: [volume(mount: "/a", used: 150)])
+        XCTAssertEqual(slices.last?.bytes, 0)
+        XCTAssertEqual(slices.last?.kind, .free)
+    }
+
+    func testPurgeableLargerThanBiggestVolumeIsClamped() {
+        // Purgeable claims 80 but only 30 bytes are used: clamp to 30, which
+        // empties the volume slice (dropped at 0) and leaves purgeable + free.
+        let slices = DiskCapacityBreakdown.slices(
+            standaloneVolume: volume(mount: "/v", used: 30, purgeable: 80, total: 100))
+        XCTAssertEqual(slices.map(\.kind), [.purgeable, .free])
+        XCTAssertEqual(slices.map(\.bytes), [30, 70])
+    }
+
+    func testStandaloneVolumeShape() {
+        let slices = DiskCapacityBreakdown.slices(
+            standaloneVolume: volume(
+                mount: "/Volumes/Backup", used: 700, purgeable: 100, total: 1_000, role: .user))
+        XCTAssertEqual(slices.map(\.kind), [.volume, .purgeable, .free])
+        XCTAssertEqual(slices.map(\.bytes), [600, 100, 300])
+        XCTAssertEqual(slices[0].role, .user)
+    }
+
+    func testZeroByteVolumesDropButFreeAlwaysRemains() {
+        let container = APFSContainerInfo(
+            bsdName: "disk3", capacityBytes: 100, physicalStoreBSDNames: [], volumeBSDNames: [])
+        let slices = DiskCapacityBreakdown.slices(
+            container: container,
+            volumes: [volume(mount: "/x", used: 0), volume(mount: "/y", used: 100)])
+        XCTAssertEqual(slices.map(\.kind), [.volume, .free])
+        XCTAssertEqual(slices.last?.bytes, 0, "full disk still shows its zero free slice")
+    }
+
+    private func volume(
+        mount: String, used: UInt64, purgeable: UInt64? = nil, total: UInt64 = 1_000,
+        role: VolumeRole = .user
+    ) -> VolumeInfo {
+        VolumeInfo(
+            mountPoint: mount,
+            name: mount == "/"
+                ? "Macintosh HD"
+                : mount == "/System/Volumes/Data"
+                    ? "Macintosh HD - Data"
+                    : (mount as NSString).lastPathComponent,
+            bsdName: nil, fsTypeName: "apfs", volumeUUID: nil, role: role,
+            isRoot: mount == "/", isLocal: true, isReadOnly: false,
+            isInternal: true, isEjectable: false, isEncrypted: nil,
+            totalBytes: total, freeBytes: total - used, availableBytes: total - used,
+            importantUsageAvailableBytes: nil, purgeableBytes: purgeable,
+            containerBSDName: "disk3", blockSize: 4096)
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/DiskInfoReaderTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskInfoReaderTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class DiskInfoReaderTests: XCTestCase {
+    func testMapsInternalNVMeReadout() {
+        let info = DiskInfoReader.info(
+            from: .init(
+                registryEntryID: 7,
+                bsdName: "disk0",
+                deviceCharacteristics: [
+                    "Vendor Name": "",
+                    "Product Name": "APPLE SSD AP0512Z",
+                    "Product Revision Level": "561.100.",
+                    "Serial Number": "0ba0",
+                    "Medium Type": "Solid State",
+                ],
+                protocolCharacteristics: [
+                    "Physical Interconnect": "Apple Fabric",
+                    "Physical Interconnect Location": "Internal",
+                ],
+                mediaPreferredBlockSize: 4096,
+                controllerClass: "AppleANS3NVMeController",
+                controllerProperties: [
+                    "Firmware Revision": "561.100.",
+                    "AppleNANDStatus": "Ready",
+                    "NVMe Revision Supported": "1.10",
+                ]))
+
+        XCTAssertEqual(info.registryEntryID, 7)
+        XCTAssertNil(info.vendorName, "empty registry strings must read as absent")
+        XCTAssertEqual(info.productName, "APPLE SSD AP0512Z")
+        XCTAssertEqual(info.isSolidState, true)
+        XCTAssertEqual(info.interconnect, "Apple Fabric")
+        XCTAssertEqual(info.physicalBlockSizeBytes, 4096)
+        XCTAssertEqual(info.controllerClass, "AppleANS3NVMeController")
+        XCTAssertEqual(info.firmwareRevision, "561.100.")
+        XCTAssertEqual(info.nandStatus, "Ready")
+        XCTAssertEqual(info.nvmeRevision, "1.10")
+    }
+
+    func testAllNilExternalUSBShapeSurvives() {
+        let info = DiskInfoReader.info(
+            from: .init(
+                registryEntryID: 9, bsdName: "disk5",
+                deviceCharacteristics: [:], protocolCharacteristics: [:],
+                mediaPreferredBlockSize: nil, controllerClass: nil, controllerProperties: [:]))
+        XCTAssertEqual(info.bsdName, "disk5")
+        XCTAssertNil(info.productName)
+        XCTAssertNil(info.isSolidState)
+        XCTAssertNil(info.controllerClass)
+        XCTAssertNil(info.serialNumber)
+    }
+
+    func testSerialFallsBackToControllerWhenDeviceOmitsIt() {
+        let info = DiskInfoReader.info(
+            from: .init(
+                registryEntryID: 1, bsdName: "disk0",
+                deviceCharacteristics: [:], protocolCharacteristics: [:],
+                mediaPreferredBlockSize: nil, controllerClass: "IONVMeController",
+                controllerProperties: ["Serial Number": "ctrl-serial"]))
+        XCTAssertEqual(info.serialNumber, "ctrl-serial")
+    }
+
+    func testCachesPerDeviceAndDropsVanishedDevices() {
+        var readouts = [
+            DiskInfoReader.DeviceReadout(
+                registryEntryID: 1, bsdName: "disk0",
+                deviceCharacteristics: ["Product Name": "First"],
+                protocolCharacteristics: [:], mediaPreferredBlockSize: nil,
+                controllerClass: nil, controllerProperties: [:])
+        ]
+        let reader = DiskInfoReader(source: { readouts })
+
+        XCTAssertEqual(reader.read()[1]?.productName, "First")
+
+        // Same registry ID with changed data: the cache must win (identity is
+        // stable while the entry lives, so re-harvesting is wasted work).
+        readouts[0].deviceCharacteristics["Product Name"] = "Changed"
+        XCTAssertEqual(reader.read()[1]?.productName, "First")
+
+        // A new registry ID replaces the vanished one.
+        readouts = [
+            .init(
+                registryEntryID: 2, bsdName: "disk6",
+                deviceCharacteristics: ["Product Name": "External"],
+                protocolCharacteristics: [:], mediaPreferredBlockSize: nil,
+                controllerClass: nil, controllerProperties: [:])
+        ]
+        let after = reader.read()
+        XCTAssertNil(after[1])
+        XCTAssertEqual(after[2]?.productName, "External")
+    }
+
+    func testLiveReadMatchesDiskReaderDeviceSet() {
+        // Live smoke: hardware entries must exist for exactly the devices the
+        // activity reader reports, and the internal SSD (when present) should
+        // carry a product name. Passes on any Mac, including one with no NVMe.
+        let hardware = DiskInfoReader().read()
+        let devices = DiskReader().read(now: Date()).devices
+        for device in devices {
+            guard let info = hardware[device.registryEntryID] else {
+                XCTFail("no hardware info for \(device.bsdName)")
+                continue
+            }
+            XCTAssertEqual(info.bsdName, device.bsdName)
+        }
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/DiskPersistenceTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskPersistenceTests.swift
@@ -58,6 +58,128 @@ final class DiskPersistenceTests: XCTestCase {
         XCTAssertEqual(hour.diskWriteBytesPerSec, 2_000_000, accuracy: 0.001)
     }
 
+    func testDiskDetailFieldsRoundTripIncludingNil() throws {
+        let now = Date()
+        var withValues = Make.system(timestamp: now)
+        withValues.diskReadLatencyMs = 0.42
+        withValues.diskWriteLatencyMs = 1.5
+        withValues.diskUtilizationPercent = 37.5
+        withValues.bootVolumeTotalBytes = 500_000_000_000
+        withValues.bootVolumeFreeBytes = 38_000_000_000
+        try store.insert(systemSample: withValues)
+
+        let decoded = try XCTUnwrap(try store.latestSystemSample())
+        XCTAssertEqual(decoded.diskReadLatencyMs, 0.42)
+        XCTAssertEqual(decoded.diskWriteLatencyMs, 1.5)
+        XCTAssertEqual(decoded.diskUtilizationPercent, 37.5)
+        XCTAssertEqual(decoded.bootVolumeTotalBytes, 500_000_000_000)
+        XCTAssertEqual(decoded.bootVolumeFreeBytes, 38_000_000_000)
+
+        // Nil must survive as nil, not as zero: a quiet tick has no latency.
+        let idle = Make.system(timestamp: now.addingTimeInterval(1))
+        try store.insert(systemSample: idle)
+        let decodedIdle = try XCTUnwrap(try store.latestSystemSample())
+        XCTAssertNil(decodedIdle.diskReadLatencyMs)
+        XCTAssertNil(decodedIdle.diskUtilizationPercent)
+        XCTAssertNil(decodedIdle.bootVolumeFreeBytes)
+
+        let points = try store.systemHistory(.oneHour, now: now.addingTimeInterval(2))
+        XCTAssertEqual(points.first?.diskReadLatencyMs, 0.42)
+        XCTAssertEqual(points.first?.bootFreeBytes, 38_000_000_000)
+        XCTAssertNil(points.last?.diskReadLatencyMs)
+    }
+
+    func testDiskDetailRollupExcludesNilAndKeepsFreeSpaceLowWaterMark() throws {
+        let anchor = Date(timeIntervalSince1970: 1_700_000_040)
+        // Same minute bucket: two busy ticks (latency 1 ms and 3 ms) and two
+        // quiet ticks (nil). The minute average must be 2 ms, not 1 ms.
+        for index in 0..<4 {
+            var system = Make.system(timestamp: anchor.addingTimeInterval(Double(index) * 6))
+            if index.isMultiple(of: 2) {
+                system.diskReadLatencyMs = index == 0 ? 1.0 : 3.0
+                system.diskUtilizationPercent = 50
+            }
+            system.bootVolumeTotalBytes = 1_000_000
+            system.bootVolumeFreeBytes = UInt64(100_000 - index * 10_000)
+            try store.insert(systemSample: system)
+        }
+
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(600))
+        let minute = try XCTUnwrap(
+            try store.systemHistory(.oneDay, now: anchor.addingTimeInterval(600)).first)
+        XCTAssertEqual(minute.diskReadLatencyMs ?? -1, 2.0, accuracy: 0.001)
+        XCTAssertEqual(minute.diskUtilizationPercent ?? -1, 50, accuracy: 0.001)
+        XCTAssertEqual(minute.bootFreeBytes, 70_000, "tier point carries the low water mark")
+        XCTAssertEqual(minute.bootTotalBytes, 1_000_000)
+
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(7200))
+        let hour = try XCTUnwrap(
+            try store.systemHistory(.sevenDays, now: anchor.addingTimeInterval(7200)).first)
+        XCTAssertEqual(hour.diskReadLatencyMs ?? -1, 2.0, accuracy: 0.001)
+        XCTAssertEqual(hour.bootFreeBytes, 70_000)
+    }
+
+    func testAllNilDetailRollsUpAsNilNotZero() throws {
+        let anchor = Date(timeIntervalSince1970: 1_700_000_040)
+        for index in 0..<3 {
+            try store.insert(
+                systemSample: Make.system(timestamp: anchor.addingTimeInterval(Double(index) * 6)))
+        }
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(600))
+        let minute = try XCTUnwrap(
+            try store.systemHistory(.oneDay, now: anchor.addingTimeInterval(600)).first)
+        XCTAssertNil(minute.diskReadLatencyMs)
+        XCTAssertNil(minute.diskUtilizationPercent)
+        XCTAssertNil(minute.bootFreeBytes)
+    }
+
+    func testV11DatabaseMigratesWithNilDiskDetailDefaults() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macperf-v11-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: url.path + "-wal"))
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: url.path + "-shm"))
+        }
+        let pool = try DatabasePool(path: url.path)
+        try MacPerfMonitorDatabase.migrator.migrate(pool, upTo: "v11-system-disk-activity")
+        let now = Date()
+        try pool.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO system_samples
+                    (timestamp, total_ram, free, active, inactive, wired, speculative, compressed,
+                     app_memory, cached_files, swap_total, swap_used, pressure_level,
+                     pressure_percent, page_ins, page_outs, compressions, decompressions,
+                     page_ins_delta, page_outs_delta, compressions_delta, decompressions_delta,
+                     cpu_load, battery_present, battery_charge, battery_power, battery_charging,
+                     battery_health, battery_cycles, battery_temp, net_in, net_out,
+                     disk_read, disk_write, disk_read_iops, disk_write_iops)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    """,
+                arguments: [
+                    now.timeIntervalSince1970, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, false, 0, 0, false, 0, 0, 0, 0, 0, 5, 6, 7, 8,
+                ])
+        }
+
+        try MacPerfMonitorDatabase.migrator.migrate(pool)
+        let migrated = SampleStore(pool: pool)
+        let old = try XCTUnwrap(try migrated.latestSystemSample())
+        XCTAssertEqual(old.diskReadBytesPerSec, 5)
+        XCTAssertNil(old.diskReadLatencyMs, "pre-v12 rows must decode the new columns as nil")
+        XCTAssertNil(old.bootVolumeFreeBytes)
+
+        var new = Make.system(timestamp: now.addingTimeInterval(1))
+        new.diskReadLatencyMs = 0.9
+        new.bootVolumeFreeBytes = 42
+        new.bootVolumeTotalBytes = 100
+        try migrated.insert(systemSample: new)
+        let latest = try XCTUnwrap(try migrated.latestSystemSample())
+        XCTAssertEqual(latest.diskReadLatencyMs, 0.9)
+        XCTAssertEqual(latest.bootVolumeFreeBytes, 42)
+    }
+
     func testV10DatabaseMigratesWithZeroDiskDefaults() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("macperf-v10-\(UUID().uuidString).sqlite")

--- a/Tests/MacPerfMonitorCoreTests/DiskReaderTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskReaderTests.swift
@@ -66,6 +66,89 @@ final class DiskReaderTests: XCTestCase {
         XCTAssertEqual(reader.read(now: t0.addingTimeInterval(1)).devices.map(\.bsdName), ["disk0"])
     }
 
+    func testUtilizationDerivesFromBusyTimeDeltas() {
+        // 40 ms read busy + 10 ms write busy over a 1 s interval = 5 percent.
+        var snapshots = [
+            [counters(read: 0, write: 0, readOps: 0, writeOps: 0)],
+            [
+                counters(
+                    read: 1_000, write: 1_000, readOps: 10, writeOps: 10,
+                    readTime: 40_000_000, writeTime: 10_000_000)
+            ],
+        ]
+        let reader = makeReader { snapshots.removeFirst() }
+
+        let first = reader.read(now: t0)
+        XCTAssertNil(first.devices[0].utilizationPercent)
+        XCTAssertNil(first.utilizationPercent)
+
+        let second = reader.read(now: t0.addingTimeInterval(1))
+        XCTAssertEqual(second.devices[0].utilizationPercent ?? -1, 5, accuracy: 0.001)
+        XCTAssertEqual(second.utilizationPercent ?? -1, 5, accuracy: 0.001)
+    }
+
+    func testUtilizationIsCappedAtOneHundredAndSystemTakesBusiestDevice() {
+        // Device 1 reports more busy time than wall clock (overlapping queued
+        // IO does this); device 2 is 20 percent busy. System = max = 100.
+        var snapshots = [
+            [
+                counters(id: 1, read: 0, write: 0),
+                counters(id: 2, bsdName: "disk2", read: 0, write: 0),
+            ],
+            [
+                counters(
+                    id: 1, read: 1, write: 1, readOps: 1, writeOps: 1,
+                    readTime: 900_000_000, writeTime: 700_000_000),
+                counters(
+                    id: 2, bsdName: "disk2", read: 1, write: 1, readOps: 1, writeOps: 1,
+                    readTime: 100_000_000, writeTime: 100_000_000),
+            ],
+        ]
+        let reader = makeReader { snapshots.removeFirst() }
+        _ = reader.read(now: t0)
+
+        let sample = reader.read(now: t0.addingTimeInterval(1))
+        XCTAssertEqual(sample.devices.map { $0.utilizationPercent ?? -1 }, [100, 20])
+        XCTAssertEqual(sample.utilizationPercent, 100)
+    }
+
+    func testSystemLatencyIsOpsWeightedAcrossDevices() {
+        // Device 1: 90 read ops at 1 ms. Device 2: 10 read ops at 11 ms.
+        // Ops-weighted mean = (90*1 + 10*11) / 100 = 2 ms.
+        var snapshots = [
+            [
+                counters(id: 1, read: 0, write: 0),
+                counters(id: 2, bsdName: "disk2", read: 0, write: 0),
+            ],
+            [
+                counters(id: 1, read: 1, write: 0, readOps: 90, readTime: 90_000_000),
+                counters(
+                    id: 2, bsdName: "disk2", read: 1, write: 0, readOps: 10,
+                    readTime: 110_000_000),
+            ],
+        ]
+        let reader = makeReader { snapshots.removeFirst() }
+        _ = reader.read(now: t0)
+
+        let sample = reader.read(now: t0.addingTimeInterval(1))
+        XCTAssertEqual(sample.readLatencyMs ?? -1, 2, accuracy: 0.001)
+        XCTAssertNil(sample.writeLatencyMs, "zero write ops must yield nil, not 0 ms")
+    }
+
+    func testLatencyAndUtilizationAreNilAfterCounterReset() {
+        // A reset counter (current below prior) must not fabricate a huge delta.
+        var snapshots = [
+            [counters(read: 0, write: 0, readOps: 100, readTime: 500_000_000)],
+            [counters(read: 1, write: 0, readOps: 10, readTime: 40_000_000)],
+        ]
+        let reader = makeReader { snapshots.removeFirst() }
+        _ = reader.read(now: t0)
+
+        let sample = reader.read(now: t0.addingTimeInterval(1))
+        XCTAssertNil(sample.readLatencyMs)
+        XCTAssertNil(sample.devices[0].utilizationPercent)
+    }
+
     func testResetMakesNextSampleZero() {
         var value: UInt64 = 1_000
         let reader = makeReader { [self.counters(read: value, write: value)] }

--- a/Tests/MacPerfMonitorCoreTests/HistoryDownsampleTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/HistoryDownsampleTests.swift
@@ -66,4 +66,57 @@ final class HistoryDownsampleTests: XCTestCase {
             XCTAssertEqual(point.networkOutBytesPerSec, 1024, accuracy: 1e-6)
         }
     }
+
+    /// The v12 optional detail fields have their own carry rules: nil-excluded
+    /// means for latency and utilization (an idle tick must not drag a bucket's
+    /// average toward zero), an all-nil bucket stays nil so charts draw a gap,
+    /// and free space keeps the bucket's minimum, the low water mark.
+    func testDownsampleCarriesOptionalDiskDetailWithNilRules() throws {
+        let anchor = Date(timeIntervalSince1970: 1_700_000_000)
+        var points: [SystemHistoryPoint] = []
+        for index in 0..<400 {
+            var point = SystemHistoryPoint(
+                date: anchor.addingTimeInterval(Double(index) * 2),
+                pressurePercent: 10, appMemory: 1, wired: 1, compressed: 1,
+                cachedFiles: 1, swapUsed: 1)
+            // First half: alternate busy (2 ms, 40 percent) and idle (nil).
+            // Second half: entirely idle, so those buckets must stay nil.
+            if index < 200, index.isMultiple(of: 2) {
+                point.diskReadLatencyMs = 2.0
+                point.diskUtilizationPercent = 40
+            }
+            point.bootFreeBytes = UInt64(1_000_000 - index)
+            point.bootTotalBytes = 2_000_000
+            points.append(point)
+        }
+
+        let downsampled = points.chartDownsampled(span: 3600, to: 60)
+        XCTAssertFalse(downsampled.isEmpty)
+
+        let firstHalf = downsampled.filter {
+            $0.date < anchor.addingTimeInterval(390)
+        }
+        let secondHalf = downsampled.filter {
+            $0.date > anchor.addingTimeInterval(410)
+        }
+        XCTAssertFalse(firstHalf.isEmpty)
+        XCTAssertFalse(secondHalf.isEmpty)
+        for point in firstHalf {
+            XCTAssertEqual(
+                point.diskReadLatencyMs ?? -1, 2.0, accuracy: 1e-9,
+                "idle ticks must not drag the busy mean toward zero")
+            XCTAssertEqual(point.diskUtilizationPercent ?? -1, 40, accuracy: 1e-9)
+        }
+        for point in secondHalf {
+            XCTAssertNil(point.diskReadLatencyMs, "an all-idle bucket must gap, not read 0 ms")
+            XCTAssertNil(point.diskUtilizationPercent)
+        }
+
+        // Free space: each bucket keeps its minimum, and the series stays
+        // monotonically nonincreasing across buckets for this fixture.
+        let frees = downsampled.compactMap(\.bootFreeBytes)
+        XCTAssertEqual(frees.count, downsampled.count)
+        XCTAssertEqual(frees, frees.sorted(by: >))
+        XCTAssertEqual(downsampled.last?.bootTotalBytes, 2_000_000)
+    }
 }

--- a/Tests/MacPerfMonitorCoreTests/NVMeSMARTTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/NVMeSMARTTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class NVMeSMARTTests: XCTestCase {
+    func testParsesFixtureLogPage() {
+        var blob = [UInt8](repeating: 0, count: 512)
+        blob[0] = 0b0000_0100  // critical warning: media degraded
+        put16(&blob, at: 1, 310)  // Kelvin -> 36.85 C
+        blob[3] = 98  // available spare
+        blob[4] = 10  // spare threshold
+        blob[5] = 3  // percentage used
+        put64(&blob, at: 32, 11_000)  // data units read
+        put64(&blob, at: 40, 1)  // high half of the 128-bit counter, ignored
+        put64(&blob, at: 48, 7_000)  // data units written
+        put64(&blob, at: 64, 123_456)  // host read commands
+        put64(&blob, at: 80, 654_321)  // host write commands
+        put64(&blob, at: 96, 42)  // controller busy minutes
+        put64(&blob, at: 112, 500)  // power cycles
+        put64(&blob, at: 128, 1_234)  // power on hours
+        put64(&blob, at: 144, 7)  // unsafe shutdowns
+        put64(&blob, at: 160, 2)  // media errors
+        put64(&blob, at: 176, 9)  // error log entries
+
+        guard let snapshot = NVMeSMARTReader.parse(Data(blob)) else {
+            return XCTFail("fixture must parse")
+        }
+        XCTAssertEqual(snapshot.criticalWarning, 4)
+        XCTAssertFalse(snapshot.isHealthy)
+        XCTAssertEqual(snapshot.temperatureCelsius ?? -1, 36.85, accuracy: 0.001)
+        XCTAssertEqual(snapshot.availableSparePercent, 98)
+        XCTAssertEqual(snapshot.spareThresholdPercent, 10)
+        XCTAssertEqual(snapshot.percentageUsed, 3)
+        XCTAssertEqual(snapshot.dataUnitsRead, 11_000, "high 64 bits must not bleed in")
+        XCTAssertEqual(snapshot.dataUnitsWritten, 7_000)
+        XCTAssertEqual(snapshot.hostReadCommands, 123_456)
+        XCTAssertEqual(snapshot.hostWriteCommands, 654_321)
+        XCTAssertEqual(snapshot.controllerBusyTimeMinutes, 42)
+        XCTAssertEqual(snapshot.powerCycles, 500)
+        XCTAssertEqual(snapshot.powerOnHours, 1_234)
+        XCTAssertEqual(snapshot.unsafeShutdowns, 7)
+        XCTAssertEqual(snapshot.mediaErrors, 2)
+        XCTAssertEqual(snapshot.errorLogEntries, 9)
+        XCTAssertEqual(snapshot.bytesRead, 11_000 * 512_000)
+        XCTAssertEqual(snapshot.bytesWritten, 7_000 * 512_000)
+    }
+
+    func testZeroTemperatureReadsAsUnknown() {
+        let blob = [UInt8](repeating: 0, count: 512)
+        let snapshot = NVMeSMARTReader.parse(Data(blob))
+        XCTAssertNil(snapshot?.temperatureCelsius)
+        XCTAssertEqual(snapshot?.isHealthy, true)
+    }
+
+    func testShortInputReturnsNil() {
+        XCTAssertNil(NVMeSMARTReader.parse(Data()))
+        XCTAssertNil(NVMeSMARTReader.parse(Data(repeating: 0xFF, count: 511)))
+    }
+
+    func testParseHonorsDataSlices() {
+        // A Data slice whose startIndex is nonzero must decode identically;
+        // Data indexing is absolute, the classic trap.
+        var blob = [UInt8](repeating: 0, count: 520)
+        blob[8] = 1  // critical warning once sliced
+        put16(&blob, at: 9, 300)
+        let sliced = Data(blob)[8...]
+        let snapshot = NVMeSMARTReader.parse(sliced)
+        XCTAssertEqual(snapshot?.criticalWarning, 1)
+        XCTAssertEqual(snapshot?.temperatureCelsius ?? -1, 26.85, accuracy: 0.001)
+    }
+
+    func testLifetimeBytesSaturateInsteadOfTrapping() {
+        XCTAssertEqual(NVMeSMARTSnapshot.bytes(fromDataUnits: .max), .max)
+        XCTAssertEqual(NVMeSMARTSnapshot.bytes(fromDataUnits: 2), 1_024_000)
+    }
+
+    func testLiveReadIsNilOrPlausible() {
+        // Live smoke: on a Mac with a readable internal NVMe drive we get real
+        // figures; on anything else we get nil. Both are correct.
+        let hardware = DiskInfoReader().read()
+        let reader = NVMeSMARTReader()
+        for info in hardware.values where !info.smartCandidateIDs.isEmpty {
+            guard let smart = reader.read(candidateRegistryEntryIDs: info.smartCandidateIDs)
+            else { continue }
+            if let temperature = smart.temperatureCelsius {
+                XCTAssertGreaterThan(temperature, -20)
+                XCTAssertLessThan(temperature, 120)
+            }
+            XCTAssertLessThan(smart.powerOnHours, 500_000)
+            XCTAssertGreaterThan(smart.dataUnitsWritten, 0)
+        }
+    }
+
+    private func put16(_ blob: inout [UInt8], at offset: Int, _ value: UInt16) {
+        blob[offset] = UInt8(value & 0xFF)
+        blob[offset + 1] = UInt8(value >> 8)
+    }
+
+    private func put64(_ blob: inout [UInt8], at offset: Int, _ value: UInt64) {
+        for byte in 0..<8 {
+            blob[offset + byte] = UInt8((value >> (8 * byte)) & 0xFF)
+        }
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/VolumeReaderTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/VolumeReaderTests.swift
@@ -1,0 +1,271 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class VolumeReaderTests: XCTestCase {
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testSnapshotJoinsMountsResourcesAndContainers() {
+        let reader = VolumeReader(
+            fsstatSource: {
+                [
+                    self.row(
+                        mount: "/System/Volumes/Data", device: "/dev/disk3s1",
+                        total: 500_000, available: 100_000),
+                    self.row(mount: "/", device: "/dev/disk3s3s1", total: 500_000, root: true),
+                ]
+            },
+            resourceSource: { mount in
+                mount == "/System/Volumes/Data"
+                    ? VolumeReader.VolumeResourceReadout(
+                        name: "Macintosh HD - Data", uuid: "AAAA",
+                        importantUsageAvailableBytes: 130_000,
+                        isInternal: true, isEjectable: false, isEncrypted: true)
+                    : nil
+            },
+            containerSource: {
+                [
+                    VolumeReader.APFSContainerReadout(
+                        bsdName: "disk3", capacityBytes: 500_000,
+                        physicalStoreBSDNames: ["disk0s2"],
+                        volumes: [
+                            .init(bsdName: "disk3s1", roles: ["Data"]),
+                            .init(bsdName: "disk3s3", roles: ["System"]),
+                        ])
+                ]
+            })
+
+        let snapshot = reader.read(now: t0)
+        XCTAssertEqual(snapshot.timestamp, t0)
+        XCTAssertEqual(snapshot.volumes.count, 2)
+
+        // Root sorts first even though it mounted from a snapshot device.
+        let root = snapshot.volumes[0]
+        XCTAssertTrue(root.isRoot)
+        XCTAssertEqual(root.role, .system)
+        XCTAssertEqual(root.containerBSDName, "disk3", "snapshot suffix must strip to disk3s3")
+        XCTAssertEqual(root.name, "Macintosh HD", "no resource values still names the boot volume")
+        XCTAssertNil(root.isInternal)
+
+        let data = snapshot.volumes[1]
+        XCTAssertEqual(data.name, "Macintosh HD - Data")
+        XCTAssertEqual(data.role, .data)
+        XCTAssertEqual(data.isEncrypted, true)
+        XCTAssertEqual(data.purgeableBytes, 30_000)
+        XCTAssertEqual(data.containerBSDName, "disk3")
+
+        XCTAssertEqual(
+            snapshot.containers,
+            [
+                APFSContainerInfo(
+                    bsdName: "disk3", capacityBytes: 500_000,
+                    physicalStoreBSDNames: ["disk0s2"],
+                    volumeBSDNames: ["disk3s1", "disk3s3"])
+            ])
+    }
+
+    func testZeroCapacityPseudoFilesystemsAreDropped() {
+        let reader = VolumeReader(
+            fsstatSource: {
+                [
+                    self.row(mount: "/dev", device: "devfs", fsType: "devfs", total: 0),
+                    self.row(mount: "/", device: "/dev/disk3s3s1", total: 500_000, root: true),
+                ]
+            },
+            resourceSource: { _ in nil },
+            containerSource: { [] })
+
+        XCTAssertEqual(reader.read(now: t0).volumes.map(\.mountPoint), ["/"])
+    }
+
+    func testRoleClassificationTable() {
+        // Registry roles win outright.
+        XCTAssertEqual(
+            VolumeReader.classifyRole(registryRoles: ["System"], mountPoint: "/x", isRoot: false),
+            .system)
+        XCTAssertEqual(
+            VolumeReader.classifyRole(registryRoles: ["VM"], mountPoint: "/x", isRoot: false), .vm)
+        XCTAssertEqual(
+            VolumeReader.classifyRole(registryRoles: ["xART"], mountPoint: "/x", isRoot: false),
+            .support)
+        // Fallbacks: root, well-known mounts, system-volume prefix, then user.
+        XCTAssertEqual(
+            VolumeReader.classifyRole(registryRoles: [], mountPoint: "/", isRoot: true), .system)
+        XCTAssertEqual(
+            VolumeReader.classifyRole(
+                registryRoles: [], mountPoint: "/System/Volumes/VM", isRoot: false), .vm)
+        XCTAssertEqual(
+            VolumeReader.classifyRole(
+                registryRoles: [], mountPoint: "/System/Volumes/Update", isRoot: false), .support)
+        XCTAssertEqual(
+            VolumeReader.classifyRole(
+                registryRoles: [], mountPoint: "/Volumes/Backup", isRoot: false), .user)
+    }
+
+    func testPurgeableDerivationAndImportantUsageSanitizing() {
+        // Important usage below plain available clamps purgeable to zero.
+        let reader = VolumeReader(
+            fsstatSource: {
+                [self.row(mount: "/v", device: "/dev/disk5s1", total: 1_000, available: 400)]
+            },
+            resourceSource: { _ in
+                VolumeReader.VolumeResourceReadout(
+                    name: "V", uuid: nil, importantUsageAvailableBytes: 300,
+                    isInternal: nil, isEjectable: nil, isEncrypted: nil)
+            },
+            containerSource: { [] })
+        XCTAssertEqual(reader.read(now: t0).volumes[0].purgeableBytes, 0)
+
+        // A zero important-usage reading against a nonzero total means
+        // "unknown", not "full": both derived fields must come back nil.
+        XCTAssertNil(VolumeReader.sanitizedImportantUsage(0, totalBytes: 1_000))
+        XCTAssertEqual(VolumeReader.sanitizedImportantUsage(50, totalBytes: 1_000), 50)
+        XCTAssertNil(VolumeReader.sanitizedImportantUsage(nil, totalBytes: 1_000))
+    }
+
+    func testSnapshotSuffixStripping() {
+        XCTAssertEqual(VolumeReader.strippingSnapshotSuffix("disk3s3s1"), "disk3s3")
+        XCTAssertEqual(VolumeReader.strippingSnapshotSuffix("disk3s1"), "disk3s1")
+        XCTAssertEqual(VolumeReader.strippingSnapshotSuffix("disk10s2s1"), "disk10s2")
+        XCTAssertEqual(VolumeReader.strippingSnapshotSuffix("weird"), "weird")
+    }
+
+    func testBSDNameParsing() {
+        XCTAssertEqual(VolumeReader.bsdName(fromDeviceNode: "/dev/disk3s1"), "disk3s1")
+        XCTAssertNil(VolumeReader.bsdName(fromDeviceNode: "map auto_home"))
+    }
+
+    func testBootVolumeReaderThrottlesToOneReadPerMinute() {
+        var reads = 0
+        let reader = BootVolumeReader(minInterval: 60) {
+            reads += 1
+            return .init(totalBytes: 1_000, freeBytes: UInt64(500 - reads))
+        }
+
+        XCTAssertEqual(reader.read(now: t0)?.freeBytes, 499)
+        XCTAssertEqual(reader.read(now: t0.addingTimeInterval(30))?.freeBytes, 499)
+        XCTAssertEqual(reads, 1, "a second read inside the interval must hit the cache")
+
+        XCTAssertEqual(reader.read(now: t0.addingTimeInterval(61))?.freeBytes, 498)
+        XCTAssertEqual(reads, 2)
+
+        reader.reset()
+        XCTAssertEqual(reader.read(now: t0.addingTimeInterval(62))?.freeBytes, 497)
+        XCTAssertEqual(reads, 3, "reset must force a fresh read")
+    }
+
+    func testBootVolumeReaderKeepsLastGoodValueThroughFailures() {
+        var results: [BootVolumeReader.Capacity?] = [
+            .init(totalBytes: 1_000, freeBytes: 400), nil,
+        ]
+        let reader = BootVolumeReader(minInterval: 60) { results.removeFirst() }
+
+        XCTAssertEqual(reader.read(now: t0)?.freeBytes, 400)
+        // The failed refresh keeps the previous figure rather than dropping to
+        // nil for a minute.
+        XCTAssertEqual(reader.read(now: t0.addingTimeInterval(61))?.freeBytes, 400)
+    }
+
+    func testDeduplicatesMultipleMountsOfOneVolume() {
+        // The System volume mounted twice: as the root snapshot (disk3s3s1)
+        // and as update staging (disk3s3). One survivor, and it is the root.
+        let reader = VolumeReader(
+            fsstatSource: {
+                [
+                    self.row(
+                        mount: "/System/Volumes/Update/mnt1", device: "/dev/disk3s3",
+                        total: 500_000),
+                    self.row(mount: "/", device: "/dev/disk3s3s1", total: 500_000, root: true),
+                    self.row(mount: "/System/Volumes/Data", device: "/dev/disk3s1", total: 500_000),
+                ]
+            },
+            resourceSource: { _ in nil },
+            containerSource: { [] })
+
+        let volumes = reader.read(now: t0).volumes
+        XCTAssertEqual(volumes.count, 2)
+        XCTAssertTrue(volumes[0].isRoot, "the root mount must win the dedupe")
+        XCTAssertEqual(volumes[1].mountPoint, "/System/Volumes/Data")
+    }
+
+    func testSpaceUsedAttributeIsPreferredOverStatfsArithmetic() {
+        // On APFS, statfs free fields are the shared pool, so total - free
+        // would claim 460 GB used for a 17 GB volume. The getattrlist figure
+        // must win; the arithmetic only backstops filesystems without it.
+        let withAttribute = VolumeInfo(
+            mountPoint: "/v", name: "V", bsdName: "disk3s4", fsTypeName: "apfs",
+            volumeUUID: nil, role: .preboot, isRoot: false, isLocal: true, isReadOnly: false,
+            isInternal: true, isEjectable: false, isEncrypted: nil,
+            totalBytes: 494_000, freeBytes: 37_000, availableBytes: 37_000,
+            importantUsageAvailableBytes: nil, purgeableBytes: nil,
+            containerBSDName: "disk3", blockSize: 4096, spaceUsedBytes: 17_600)
+        XCTAssertEqual(withAttribute.usedBytes, 17_600)
+
+        var withoutAttribute = withAttribute
+        withoutAttribute.spaceUsedBytes = nil
+        XCTAssertEqual(withoutAttribute.usedBytes, 457_000)
+    }
+
+    func testCryptexAndSimulatorMountsClassifyAsSupport() {
+        XCTAssertEqual(
+            VolumeReader.classifyRole(
+                registryRoles: [],
+                mountPoint: "/private/var/run/com.apple.security.cryptexd/mnt/x",
+                isRoot: false),
+            .support)
+        XCTAssertEqual(
+            VolumeReader.classifyRole(
+                registryRoles: [],
+                mountPoint: "/Library/Developer/CoreSimulator/Volumes/iOS_23C54",
+                isRoot: false),
+            .support)
+        XCTAssertEqual(
+            VolumeReader.classifyRole(
+                registryRoles: [], mountPoint: "/Volumes/Backup", isRoot: false),
+            .user)
+    }
+
+    func testLiveVolumeReaderReturnsRootAndSaneBounds() {
+        // Live smoke: must pass on any Mac. Root exists, capacities are
+        // consistent, and every volume's free space fits inside its total.
+        let snapshot = VolumeReader().read(now: Date())
+        guard let root = snapshot.volumes.first(where: \.isRoot) else {
+            return XCTFail("no root volume in live snapshot")
+        }
+        XCTAssertGreaterThan(root.totalBytes, 0)
+        for volume in snapshot.volumes {
+            XCTAssertLessThanOrEqual(volume.availableBytes, volume.totalBytes)
+            XCTAssertFalse(volume.mountPoint.isEmpty)
+            XCTAssertLessThanOrEqual(
+                volume.usedBytes, volume.totalBytes,
+                "\(volume.mountPoint) used must fit inside its capacity")
+        }
+        // The root snapshot's own usage is a fraction of the disk; if the
+        // shared-pool arithmetic ever leaks back in, this catches it (the bug
+        // showed the sealed system volume as consuming the whole container).
+        XCTAssertLessThan(
+            root.usedBytes, root.totalBytes / 2,
+            "root snapshot usage should be far below container capacity")
+        for container in snapshot.containers {
+            XCTAssertFalse(container.volumeBSDNames.isEmpty)
+        }
+    }
+
+    func testLiveBootVolumeReaderMatchesRootStatfs() {
+        guard let capacity = BootVolumeReader().read(now: Date()) else {
+            return XCTFail("statfs of / must succeed")
+        }
+        XCTAssertGreaterThan(capacity.totalBytes, 0)
+        XCTAssertLessThan(capacity.freeBytes, capacity.totalBytes)
+    }
+
+    private func row(
+        mount: String, device: String, fsType: String = "apfs", total: UInt64,
+        available: UInt64 = 0, root: Bool = false
+    ) -> VolumeReader.FSStatRow {
+        VolumeReader.FSStatRow(
+            mountPoint: mount, deviceNode: device, fsTypeName: fsType, blockSize: 4096,
+            totalBytes: total, freeBytes: available, availableBytes: available,
+            isLocal: true, isReadOnly: false, isRoot: root)
+    }
+}


### PR DESCRIPTION
## Summary

A new Disk page collects everything the system exposes about storage on one tab: live read/write throughput and IOPS with history, per-operation service latency and a busy-time utilization figure derived from the driver's counters, a card per physical device with its full hardware identity (model, vendor, firmware, serial, interconnect, NAND status, NVMe revision, block size), per-volume capacity bars grouped by APFS container with purgeable space and role badges, NVMe SMART health for the internal SSD, a boot-volume free-space trend with a low-space rule, and the top processes by attributed disk I/O over the selected range. The menu bar disk panel's Open button now lands on the new tab.

The history schema moves to v12: system samples record read/write service latency, disk utilization, and boot volume free space (sampled once a minute), with minute and hour rollups. The new columns are nullable on purpose: an interval with no IO charts as a gap, never as a fake 0 ms, and free space keeps its low water mark through every aggregation tier. Build number bumps to 187.

## Related issue

No linked issue.

## How verified

- `swift test`: 390/390 pass (37 new disk tests: new suites for the capacity breakdown, disk info reader, NVMe SMART reader, and volume reader, plus additions to the disk reader, disk persistence, and downsample suites), run after rebasing on main with #15 merged.
- `swift format lint --strict --recursive Sources Tests Package.swift`: clean.

## Checklist

- [x] `swift test` passes
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` passes
- [x] `CHANGELOG.md` updated under "Unreleased" for any user-visible change
- [x] No telemetry or network calls introduced
- [x] Data-layer changes keep `MacPerfMonitorCore` free of SwiftUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)