### PR TITLE
Make the first-run wizard and reopen reliably produce a window

### DIFF
--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -158,3 +158,5 @@ fi
 echo "==> Launching"
 open "$APP"
 echo "Launched $APP"
+echo "Note: this is a menu bar app (no window, no Dock icon by default);"
+echo "look for its read-out near the clock at the right end of the menu bar."

--- a/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
+++ b/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
@@ -164,6 +164,10 @@ struct MacPerfMonitorApp: App {
         }
         .windowResizability(.contentSize)
         .defaultPosition(.center)
+        // Until setup completes, the scene system itself presents the wizard at
+        // launch. The notification path below depends on a status item view
+        // being mounted before the post; this one has no such ordering to lose.
+        .defaultLaunchBehavior(appDelegate.onboarding.hasCompletedSetup ? .suppressed : .presented)
 
         // The Memory Inspector: one resizable window per inspected process,
         // keyed on a self-contained `InspectorTarget` value. It deliberately gets
@@ -471,20 +475,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
         CheckCatalogStore.shared.refreshInBackground()
         ProcessGlossaryStore.shared.refreshInBackground()
 
-        // On first ever launch, surface the education flow so the menubar-first
-        // app still teaches its core idea even though no window opens
-        // automatically. Deferred so the menubar scene (which holds the
-        // `openWindow` action) is mounted and listening before the post.
-        // First run — or first run after updating to a build with the setup
-        // wizard — surface the wizard. New users get the education screens plus
+        // First run (or first run after updating to a build with the setup
+        // wizard): surface the wizard. New users get the education screens plus
         // the config steps; users who already saw the education get the config
-        // steps only. Deferred so the menubar scene (which holds the `openWindow`
-        // action) is mounted and listening before the post.
+        // steps only. The onboarding scene's `defaultLaunchBehavior` presents it
+        // on a cold first launch; this bridge request covers the update case and
+        // queues until a router view is mounted, so it cannot be dropped by
+        // launch ordering the way the old fire-once notification could.
         if !onboarding.hasCompletedSetup {
             onboarding.autoConfigOnly = onboarding.hasCompleted
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .macperfmonitorShowOnboarding, object: nil)
-            }
+            WindowOpenBridge.shared.open(id: WindowID.onboarding)
         }
 
         // Check for updates on every cold start (silent unless one is available),
@@ -643,7 +643,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
         _ sender: NSApplication, hasVisibleWindows flag: Bool
     ) -> Bool {
         if !flag {
-            NotificationCenter.default.post(name: .macperfmonitorShowMainWindow, object: nil)
+            // Through the bridge, not a notification: a reopen that arrives
+            // before (or without) a mounted router view queues instead of
+            // vanishing, so `open`-ing the running app always ends in a window.
+            WindowOpenBridge.shared.open(id: WindowID.main)
         }
         return true
     }
@@ -737,6 +740,38 @@ struct MainWindowGate: View {
 /// The primary menubar item is now an AppKit `NSStatusItem` with no SwiftUI label
 /// (see `MemoryStatusItemController`), so the `openWindow`/`openSettings` actions
 /// that used to live on the `MenuBarExtra` label need another always-present home.
+/// Bridges AppKit-side window-open requests (the app delegate) to SwiftUI's
+/// `openWindow` action, which only exists inside a mounted view. A request that
+/// arrives before any `MenuBarWindowRouter` has registered is queued and flushed
+/// on registration, so launch ordering can no longer drop it the way a
+/// fire-once notification with no listener could.
+@MainActor
+final class WindowOpenBridge {
+    static let shared = WindowOpenBridge()
+
+    private var openAction: ((String) -> Void)?
+    private var pending: [String] = []
+
+    /// Called from `MenuBarWindowRouter.onAppear`; replays anything queued while
+    /// no router was mounted. Last registration wins, which is fine: every
+    /// router drives the same scene ids.
+    func register(_ action: @escaping (String) -> Void) {
+        openAction = action
+        let queued = pending
+        pending = []
+        queued.forEach(action)
+    }
+
+    /// Open a window scene by id now if a router is mounted, else queue it.
+    func open(id: String) {
+        if let openAction {
+            openAction(id)
+        } else {
+            pending.append(id)
+        }
+    }
+}
+
 /// `MemoryStatusItemController` hosts one of these inside its status item button
 /// (whose window is live), so the notifications posted by the popovers, the
 /// process actions, notification clicks, and reopen keep opening the right window.
@@ -749,6 +784,12 @@ struct MenuBarWindowRouter: View {
             .frame(width: 1, height: 1)
             .allowsHitTesting(false)
             .accessibilityHidden(true)
+            .onAppear {
+                WindowOpenBridge.shared.register { id in
+                    openWindow(id: id)
+                    NSApp.activate(ignoringOtherApps: true)
+                }
+            }
             .onReceive(NotificationCenter.default.publisher(for: .macperfmonitorShowMainWindow)) {
                 _ in
                 openWindow(id: WindowID.main)

--- a/Sources/MacPerfMonitor/Onboarding/OnboardingView.swift
+++ b/Sources/MacPerfMonitor/Onboarding/OnboardingView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// The first-run education flow (PRD 8.9). Three short, skippable screens that
@@ -8,6 +9,7 @@ import SwiftUI
 struct OnboardingView: View {
     @EnvironmentObject private var onboarding: OnboardingState
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
 
     @State private var page = 0
 
@@ -38,6 +40,10 @@ struct OnboardingView: View {
         // Reset the transient "config only" hint so a later manual replay from the
         // menu shows the full flow again.
         .onDisappear { onboarding.autoConfigOnly = false }
+        // On first run the scene system presents this window while the app is
+        // still a background accessory; without activation it opens behind
+        // whatever is frontmost and a new user sees nothing.
+        .onAppear { NSApp.activate(ignoringOtherApps: true) }
     }
 
     @ViewBuilder
@@ -65,7 +71,7 @@ struct OnboardingView: View {
 
     private var footer: some View {
         HStack {
-            Button("Skip") { finish() }
+            Button("Skip") { finish(openingDashboard: false) }
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
                 .opacity(isLastPage ? 0 : 1)
@@ -80,7 +86,7 @@ struct OnboardingView: View {
 
             Button(isLastPage ? "Get started" : "Next") {
                 if isLastPage {
-                    finish()
+                    finish(openingDashboard: true)
                 } else {
                     withOptionalAnimation { page += 1 }
                 }
@@ -91,10 +97,17 @@ struct OnboardingView: View {
 
     private var isLastPage: Bool { page >= steps.count - 1 }
 
-    private func finish() {
+    /// "Get started" hands the user the dashboard as the payoff (and as
+    /// insurance if they never spot the menu bar item); Skip means "leave me
+    /// alone" and opens nothing.
+    private func finish(openingDashboard: Bool) {
         onboarding.complete()
         onboarding.autoConfigOnly = false
         dismiss()
+        if openingDashboard {
+            openWindow(id: WindowID.main)
+            NSApp.activate(ignoringOtherApps: true)
+        }
     }
 
     /// Animate page changes unless the user has asked for reduced motion.
@@ -440,6 +453,19 @@ private struct OnboardingMenuBarStep: View {
                     .labelsHidden()
                     .fixedSize()
                 }
+
+                Text(
+                    """
+                    \(AppInfo.displayName) lives in the menu bar: look for its read-out \
+                    near the clock. A crowded menu bar (or a MacBook's notch) can hide \
+                    it; quit another menu bar item to make room.
+                    """
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 2)
             }
             .padding(.top, 4)
         }


### PR DESCRIPTION
Follow-up to the Reddit feedback where a user built from source, saw "Launched", and never got a window.

The first-run wizard already existed, but its auto-open was a fire-once notification posted one runloop turn after launch, and the only listener is a 1x1 view hosted inside a status item button that can mount later. Notifications are not queued, so losing that race dropped the wizard silently. Reopen (running open on the already-running app) went through the same router, so second launches showed nothing either. That matches the user's log exactly.

Changes:

- The onboarding Window scene now has defaultLaunchBehavior(.presented) until setup completes, so the scene system itself presents the wizard at launch with no dependency on the status item. OnboardingView activates the accessory app on appear so the window is not born behind other apps.
- New WindowOpenBridge: app-delegate originated window opens (first-run wizard, reopen) queue until a MenuBarWindowRouter registers its openWindow action, then flush. Requests can no longer be lost to launch ordering. Popover-originated notifications are unchanged.
- "Get started" opens the main dashboard as the payoff of finishing the wizard; Skip still opens nothing. The wizard's last step now says the app lives in the menu bar near the clock and that a crowded menu bar or a notch can hide it.
- Scripts/run.sh prints a menu bar hint after "Launched".

Verified: swift build, swift test (446 tests, 0 failures), swift format lint --strict all pass. Not runtime-verified: exercising the true first-run path needs virgin UserDefaults, which would disturb the running production app on my machine; the queue-and-flush logic and scene behavior are covered by review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ