### PR TITLE
Thermal 1/4: fix SMC die-temperature discovery, read every sensor domain

### DIFF
--- a/Sources/MacPerfMonitorCore/Models/GPUSample.swift
+++ b/Sources/MacPerfMonitorCore/Models/GPUSample.swift
@@ -53,7 +53,8 @@ public struct GPUSample: Sendable, Codable, Equatable {
     /// GPU hang recoveries since boot (IOAccelerator `recoveryCount`).
     public var recoveryCount: Int?
     // --- SMC thermal, filled by the Sampler ---
-    /// SoC die temperature (°C). The GPU shares the die, so this is its temperature.
+    /// GPU die temperature (°C): the hottest GPU cluster sensor, falling back
+    /// to the hottest CPU die sensor on chips with no GPU-specific keys.
     public var dieTemperatureC: Double?
     public var fanRPM: Int?
     public var fanMaxRPM: Int?

--- a/Sources/MacPerfMonitorCore/Sampling/SMCReader.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/SMCReader.swift
@@ -1,27 +1,63 @@
 import Foundation
 import IOKit
 
-/// Apple silicon die temperature and fan speed read from the SMC. The GPU shares
-/// the SoC die with the CPU, so there is no GPU-only temperature key; this reports
-/// the average of the die's thermal sensors (a faithful "what the GPU runs at")
-/// plus the primary fan RPM. Sensor keys are discovered once and then sampled, and
-/// an internal throttle keeps the cost negligible — temperature and fans move
-/// slowly, so it re-reads at most every couple of seconds however often it's
-/// called. Only used while the GPU menubar item is shown.
-struct ThermalSample: Sendable, Equatable {
-    var dieTemperatureC: Double?
-    var fanRPM: Int?
-    var fanMaxRPM: Int?
+/// One fan's telemetry from the SMC.
+struct FanSample: Sendable, Equatable {
+    var rpm: Int
+    var maxRPM: Int?
 }
 
+/// Apple silicon temperatures and fan speeds read from the SMC, grouped by
+/// domain. Sensor keys are discovered once by name prefix and then sampled on
+/// an internal throttle (temperatures move slowly, so the SMC is touched at
+/// most every few seconds however often this is called).
+struct ThermalSample: Sendable, Equatable {
+    /// Hottest CPU die sensor (P or E cluster), degrees Celsius. Max, not
+    /// average: "CPU temperature" means the hottest core to a user.
+    var cpuDieMaxC: Double?
+
+    /// Average across the CPU die sensors, the secondary trend figure.
+    var cpuDieAvgC: Double?
+
+    /// Hottest GPU cluster sensor. Nil on chips with no GPU-specific keys.
+    var gpuDieMaxC: Double?
+
+    /// Hottest SSD sensor.
+    var ssdMaxC: Double?
+
+    /// Every fan the SMC reports, in index order. Empty on fanless Macs.
+    var fans: [FanSample] = []
+
+    /// The fastest-spinning fan, for single-readout displays.
+    var primaryFanRPM: Int? { fans.map(\.rpm).max() }
+
+    /// The highest rated maximum across the fans.
+    var primaryFanMaxRPM: Int? { fans.compactMap(\.maxRPM).max() }
+}
+
+/// Reads die, SSD, and fan telemetry from the AppleSMC user client.
+///
+/// Discovery is pattern based (prefix plus plausibility), never a per-chip key
+/// table: key names drift between M1/M2/M3/M4 generations but the prefixes
+/// have held. See docs/temperature-design.md for the probed key inventory.
 final class SMCReader {
+    /// The temperature domain a discovered key's readings belong to.
+    enum SensorDomain: Sendable, Equatable {
+        case cpuDie
+        case gpuDie
+        case ssd
+    }
+
     private var connection: io_connect_t = 0
     private var didOpen = false
-    private var temperatureKeys: [UInt32] = []
-    private var hasFan = false
+    private var didDiscover = false
+    private var cpuKeys: [UInt32] = []
+    private var gpuKeys: [UInt32] = []
+    private var ssdKeys: [UInt32] = []
+    private var fanCount = 0
     private var cached = ThermalSample()
     private var lastRead: Date?
-    private let minInterval: TimeInterval = 2.0
+    private let minInterval: TimeInterval = 5.0
 
     deinit {
         if connection != 0 { IOServiceClose(connection) }
@@ -30,27 +66,86 @@ final class SMCReader {
     func read(now: Date) -> ThermalSample? {
         if let lastRead, now.timeIntervalSince(lastRead) < minInterval { return cached }
         guard open() else { return nil }
-        if temperatureKeys.isEmpty && !hasFan { discoverKeys() }
+        if !didDiscover { discoverKeys() }
 
         var sample = ThermalSample()
-        if !temperatureKeys.isEmpty {
-            var sum = 0.0
-            var count = 0
-            for key in temperatureKeys {
-                if let v = readFloat(key), v > 1, v < 130 {
-                    sum += v
-                    count += 1
-                }
-            }
-            if count > 0 { sample.dieTemperatureC = sum / Double(count) }
-        }
-        if hasFan {
-            sample.fanRPM = readFloat(Self.fourCC("F0Ac")).map { Int($0.rounded()) }
-            sample.fanMaxRPM = readFloat(Self.fourCC("F0Mx")).map { Int($0.rounded()) }
-        }
+        let cpu = temperatures(of: cpuKeys)
+        sample.cpuDieMaxC = cpu.max()
+        if !cpu.isEmpty { sample.cpuDieAvgC = cpu.reduce(0, +) / Double(cpu.count) }
+        sample.gpuDieMaxC = temperatures(of: gpuKeys).max()
+        sample.ssdMaxC = temperatures(of: ssdKeys).max()
+        sample.fans = (0..<fanCount).compactMap(readFan)
         cached = sample
         lastRead = now
         return sample
+    }
+
+    // MARK: - Classification policy
+
+    /// Which domain an SMC key's readings belong to, or nil for keys that must
+    /// never feed a die figure. `TV*` keys are voltage-rail sensors, not die:
+    /// the SMC enumerates keys sorted with uppercase before lowercase, so a
+    /// `TV`-accepting discovery with a small cap used to fill every slot with
+    /// voltage rails on chips with many `TV*` keys (M3 Pro has 12+ plausible
+    /// ones) and never reach a single `Te*`/`Tp*` die sensor. Case matters
+    /// throughout: `Tg*` is the GPU, while `TG0*` keys are battery-adjacent.
+    static func domain(forKeyName name: String) -> SensorDomain? {
+        if name.hasPrefix("Tp") || name.hasPrefix("Te") { return .cpuDie }
+        if name.hasPrefix("Tg") { return .gpuDie }
+        if name.hasPrefix("TH0") { return .ssd }
+        return nil
+    }
+
+    /// Discovery gate: strict, so calibration offsets (0.00 / -3.10 pairs),
+    /// dead zones, and sub-ambient junk never become sampled keys.
+    static func isPlausibleDiscoveryTemperature(_ celsius: Double) -> Bool {
+        celsius > 10 && celsius < 110
+    }
+
+    /// Read-time gate: lenient, so a known-good key still reports from a Mac
+    /// in a cold room while a failed read (0) stays excluded.
+    static func isPlausibleReading(_ celsius: Double) -> Bool {
+        celsius > 1 && celsius < 130
+    }
+
+    /// Decodes an SMC value by type code. `ioft` is a 64-bit little-endian
+    /// fixed point with 16 fraction bits.
+    static func decode(type: String, bytes: [UInt8]) -> Double? {
+        switch type {
+        case "flt ":
+            guard bytes.count >= 4 else { return nil }
+            let bits =
+                UInt32(bytes[0]) | UInt32(bytes[1]) << 8 | UInt32(bytes[2]) << 16
+                | UInt32(bytes[3]) << 24
+            return Double(Float(bitPattern: bits))
+        case "ioft":
+            guard bytes.count >= 8 else { return nil }
+            var value: UInt64 = 0
+            for index in (0..<8).reversed() { value = value << 8 | UInt64(bytes[index]) }
+            return Double(value) / 65536.0
+        case "ui16":
+            guard bytes.count >= 2 else { return nil }
+            return Double(UInt16(bytes[0]) << 8 | UInt16(bytes[1]))
+        case "ui8 ":
+            return bytes.first.map(Double.init)
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Reading
+
+    private func temperatures(of keys: [UInt32]) -> [Double] {
+        keys.compactMap { key in
+            guard let value = readFloat(key), Self.isPlausibleReading(value) else { return nil }
+            return value
+        }
+    }
+
+    private func readFan(_ index: Int) -> FanSample? {
+        guard let rpm = readFloat(Self.fourCC("F\(index)Ac")) else { return nil }
+        let maxRPM = readFloat(Self.fourCC("F\(index)Mx")).map { Int($0.rounded()) }
+        return FanSample(rpm: Int(rpm.rounded()), maxRPM: maxRPM)
     }
 
     // MARK: - Connection
@@ -64,25 +159,27 @@ final class SMCReader {
         return IOServiceOpen(service, mach_task_self_, 0, &connection) == kIOReturnSuccess
     }
 
-    /// One-time discovery: cap the temperature set to a representative dozen die
-    /// sensors (more than enough for a stable average) and note whether a fan is
-    /// present. Costs a single enumeration the first time the GPU item is shown.
+    /// One-time discovery: a single enumeration classifying every plausible
+    /// temperature key into its domain (uncapped: the full die-sensor sweep
+    /// costs single-digit milliseconds at the read throttle), plus the fan
+    /// count from `FNum` with a probe of fan 0 as the fallback.
     private func discoverKeys() {
-        hasFan = (readFloat(Self.fourCC("F0Mx")) ?? 0) > 0
+        didDiscover = true
+        fanCount = readFloat(Self.fourCC("FNum")).map { Int($0) } ?? 0
+        if fanCount == 0, (readFloat(Self.fourCC("F0Mx")) ?? 0) > 0 { fanCount = 1 }
         guard let total = readUInt32(Self.fourCC("#KEY")), total > 0 else { return }
-        var keys: [UInt32] = []
-        var i: UInt32 = 0
-        while i < total && keys.count < 12 {
-            defer { i += 1 }
-            guard let key = keyAtIndex(i) else { continue }
-            // CPU/SoC die clusters: P-cores (Tp), E-cores (Te), die/voltage (TV).
-            let name = Self.toString(key)
-            guard name.hasPrefix("Tp") || name.hasPrefix("Te") || name.hasPrefix("TV") else {
+        for index in 0..<total {
+            guard let key = keyAtIndex(index) else { continue }
+            guard let domain = Self.domain(forKeyName: Self.toString(key)) else { continue }
+            guard let value = readFloat(key), Self.isPlausibleDiscoveryTemperature(value) else {
                 continue
             }
-            if let v = readFloat(key), v > 10, v < 110 { keys.append(key) }
+            switch domain {
+            case .cpuDie: cpuKeys.append(key)
+            case .gpuDie: gpuKeys.append(key)
+            case .ssd: ssdKeys.append(key)
+            }
         }
-        temperatureKeys = keys
     }
 
     // MARK: - SMC protocol
@@ -97,21 +194,7 @@ final class SMCReader {
 
     func readFloat(_ key: UInt32) -> Double? {
         guard let (type, bytes) = readKey(key) else { return nil }
-        switch type {
-        case "flt ":
-            guard bytes.count >= 4 else { return nil }
-            let bits =
-                UInt32(bytes[0]) | UInt32(bytes[1]) << 8 | UInt32(bytes[2]) << 16
-                | UInt32(bytes[3]) << 24
-            return Double(Float(bitPattern: bits))
-        case "ui16":
-            guard bytes.count >= 2 else { return nil }
-            return Double(UInt16(bytes[0]) << 8 | UInt16(bytes[1]))
-        case "ui8 ":
-            return bytes.first.map(Double.init)
-        default:
-            return nil
-        }
+        return Self.decode(type: type, bytes: bytes)
     }
 
     private func readUInt32(_ key: UInt32) -> UInt32? {
@@ -153,7 +236,7 @@ final class SMCReader {
         return result
     }
 
-    private static func toString(_ value: UInt32) -> String {
+    static func toString(_ value: UInt32) -> String {
         let bytes = [
             UInt8(value >> 24 & 0xff), UInt8(value >> 16 & 0xff), UInt8(value >> 8 & 0xff),
             UInt8(value & 0xff),
@@ -208,7 +291,7 @@ private struct SMCParamStruct {
     var data8: UInt8 = 0
     var data32: UInt32 = 0
     var bytes: SMCBytes = (
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     )
 }

--- a/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
@@ -306,9 +306,11 @@ public final class Sampler {
                     freshGPU?.powerCapPercent = power.gpuPowerCapPercent
                 }
                 if let thermal = smcReader.read(now: now) {
-                    freshGPU?.dieTemperatureC = thermal.dieTemperatureC
-                    freshGPU?.fanRPM = thermal.fanRPM
-                    freshGPU?.fanMaxRPM = thermal.fanMaxRPM
+                    // Prefer the GPU's own cluster sensors; fall back to the
+                    // CPU die max on chips with no GPU-specific keys.
+                    freshGPU?.dieTemperatureC = thermal.gpuDieMaxC ?? thermal.cpuDieMaxC
+                    freshGPU?.fanRPM = thermal.primaryFanRPM
+                    freshGPU?.fanMaxRPM = thermal.primaryFanMaxRPM
                 }
             }
             cachedGPU = freshGPU

--- a/Sources/macperfmonitor-cli/main.swift
+++ b/Sources/macperfmonitor-cli/main.swift
@@ -42,7 +42,7 @@ case "verify-checks":
     let a = Array(arguments.dropFirst(2))
     guard a.count == 3,
         let manifestData = try? Data(contentsOf: URL(fileURLWithPath: a[0])),
-        let sigB64 = try? String(contentsOfFile: a[1]).trimmingCharacters(
+        let sigB64 = try? String(contentsOfFile: a[1], encoding: .utf8).trimmingCharacters(
             in: .whitespacesAndNewlines),
         let sig = Data(base64Encoded: sigB64),
         let keyData = Data(base64Encoded: a[2]),

--- a/Tests/MacPerfMonitorCoreTests/ThermalTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/ThermalTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class ThermalTests: XCTestCase {
+    // MARK: - Key classification
+
+    func testDieKeysClassifyByPrefix() {
+        XCTAssertEqual(SMCReader.domain(forKeyName: "Tp05"), .cpuDie)
+        XCTAssertEqual(SMCReader.domain(forKeyName: "Tp1K"), .cpuDie)
+        XCTAssertEqual(SMCReader.domain(forKeyName: "Te0S"), .cpuDie)
+        XCTAssertEqual(SMCReader.domain(forKeyName: "Tg0D"), .gpuDie)
+        XCTAssertEqual(SMCReader.domain(forKeyName: "Tg1l"), .gpuDie)
+        XCTAssertEqual(SMCReader.domain(forKeyName: "TH0x"), .ssd)
+    }
+
+    /// TV* keys are voltage rails, not die sensors. The SMC enumerates keys
+    /// sorted with uppercase before lowercase, so a TV-accepting discovery
+    /// with a 12-key cap filled every slot with voltage rails on M3 Pro and
+    /// the reported "die temperature" never included a die sensor.
+    func testVoltageRailKeysAreExcluded() {
+        for name in ["TVA0", "TVD0", "TVHE", "TVHF", "TVS0", "TVSx", "TVMD"] {
+            XCTAssertNil(SMCReader.domain(forKeyName: name), name)
+        }
+    }
+
+    /// Case is load-bearing: TG0* (uppercase) keys are battery-adjacent ioft
+    /// readings, TE*/TP* style names are not die sensors, and Th*/Ts* are
+    /// board and skin sensors.
+    func testNonDieFamiliesAreExcluded() {
+        for name in [
+            "TG0B", "TG0V", "TED0", "TFD0", "TB0T", "TW0P", "Ta04", "TaLP",
+            "Th00", "Ts0P", "Tz11", "TCMz", "Tf16", "TR0Z", "F0Ac", "#KEY",
+        ] {
+            XCTAssertNil(SMCReader.domain(forKeyName: name), name)
+        }
+    }
+
+    // MARK: - Plausibility gates
+
+    /// Discovery is strict: calibration offset pairs (0.00 / -3.10), dead
+    /// zones, and sub-ambient voltage readings must never become sampled keys.
+    func testDiscoveryGateRejectsJunk() {
+        for value in [0.0, -3.10, 0.01, 2.63, 9.9, 10.0, 110.0, 130.0] {
+            XCTAssertFalse(SMCReader.isPlausibleDiscoveryTemperature(value), "\(value)")
+        }
+        for value in [10.1, 24.2, 35.0, 53.2, 109.9] {
+            XCTAssertTrue(SMCReader.isPlausibleDiscoveryTemperature(value), "\(value)")
+        }
+    }
+
+    /// Read time is lenient: a known-good key in a cold room still reports,
+    /// while a failed read (0) and garbage stay excluded.
+    func testReadingGateAllowsColdButNotGarbage() {
+        XCTAssertTrue(SMCReader.isPlausibleReading(5.0))
+        XCTAssertTrue(SMCReader.isPlausibleReading(105.0))
+        XCTAssertFalse(SMCReader.isPlausibleReading(0.0))
+        XCTAssertFalse(SMCReader.isPlausibleReading(0.5))
+        XCTAssertFalse(SMCReader.isPlausibleReading(130.0))
+        XCTAssertFalse(SMCReader.isPlausibleReading(-3.10))
+    }
+
+    // MARK: - Value decoding
+
+    func testDecodeFloat() {
+        let bits = Float(42.5).bitPattern
+        let bytes = [
+            UInt8(bits & 0xff), UInt8(bits >> 8 & 0xff),
+            UInt8(bits >> 16 & 0xff), UInt8(bits >> 24 & 0xff),
+        ]
+        XCTAssertEqual(SMCReader.decode(type: "flt ", bytes: bytes), 42.5)
+        XCTAssertNil(SMCReader.decode(type: "flt ", bytes: [0, 0]))
+    }
+
+    /// ioft is 64-bit little-endian fixed point with 16 fraction bits:
+    /// 0x183000 / 65536 = 24.1875.
+    func testDecodeIOFloat() {
+        let bytes: [UInt8] = [0x00, 0x30, 0x18, 0, 0, 0, 0, 0]
+        XCTAssertEqual(SMCReader.decode(type: "ioft", bytes: bytes), 24.1875)
+        XCTAssertNil(SMCReader.decode(type: "ioft", bytes: [0x00, 0x30, 0x18]))
+    }
+
+    func testDecodeIntegersAndUnknown() {
+        XCTAssertEqual(SMCReader.decode(type: "ui16", bytes: [0x96, 0x00]), 38400)
+        XCTAssertEqual(SMCReader.decode(type: "ui8 ", bytes: [9]), 9)
+        XCTAssertNil(SMCReader.decode(type: "hex_", bytes: [0x01]))
+        XCTAssertNil(SMCReader.decode(type: "ui16", bytes: [0x01]))
+    }
+
+    func testFourCCRoundTrip() {
+        XCTAssertEqual(SMCReader.toString(SMCReader.fourCC("F0Ac")), "F0Ac")
+        XCTAssertEqual(SMCReader.fourCC("#KEY"), 0x234B_4559)
+    }
+
+    // MARK: - Sample convenience
+
+    func testPrimaryFanIsTheFastest() {
+        var sample = ThermalSample()
+        XCTAssertNil(sample.primaryFanRPM)
+        sample.fans = [
+            FanSample(rpm: 2317, maxRPM: 6800),
+            FanSample(rpm: 3100, maxRPM: nil),
+        ]
+        XCTAssertEqual(sample.primaryFanRPM, 3100)
+        XCTAssertEqual(sample.primaryFanMaxRPM, 6800)
+    }
+
+    // MARK: - Live hardware (tolerates VMs with no SMC)
+
+    /// The reader must never crash, and anything it reports must be sane.
+    /// On CI virtual machines the AppleSMC service is absent or empty, so a
+    /// nil sample is a pass.
+    func testSMCReaderIsSafeAndConsistent() {
+        let reader = SMCReader()
+        guard let sample = reader.read(now: Date()) else { return }
+        if let max = sample.cpuDieMaxC {
+            XCTAssertTrue(SMCReader.isPlausibleReading(max))
+            if let avg = sample.cpuDieAvgC {
+                XCTAssertLessThanOrEqual(avg, max)
+                XCTAssertTrue(SMCReader.isPlausibleReading(avg))
+            }
+        }
+        if let gpu = sample.gpuDieMaxC { XCTAssertTrue(SMCReader.isPlausibleReading(gpu)) }
+        if let ssd = sample.ssdMaxC { XCTAssertTrue(SMCReader.isPlausibleReading(ssd)) }
+        for fan in sample.fans {
+            XCTAssertGreaterThanOrEqual(fan.rpm, 0)
+            XCTAssertLessThan(fan.rpm, 20000)
+            if let maxRPM = fan.maxRPM { XCTAssertGreaterThan(maxRPM, 0) }
+        }
+        // The throttle must serve the cached sample for an immediate re-read.
+        XCTAssertEqual(reader.read(now: Date()), sample)
+    }
+}

--- a/docs/temperature-design.md
+++ b/docs/temperature-design.md
@@ -1,0 +1,191 @@
+# Temperature monitoring: sources and surfacing design
+
+Research notes from probing an M3 Pro (Mac15,6, macOS 26.6.2) with a standalone
+tool that enumerated every readable temperature source. This doc records what is
+available, what it costs to read, a bug the probe uncovered in the shipping die
+temperature code, and a recommendation for where temperatures belong in the app
+and menu bar.
+
+## Sources inventory (all verified sudoless on macOS 26)
+
+### 1. SMC keys (already shipping in `SMCReader`)
+
+The AppleSMC user client exposes 2295 keys on this machine; 293 are readable
+T* (temperature) or F* (fan) keys. Cost measured at ~119 us per key read with
+key info cached, so a 40-key sweep is ~5 ms. Decoded map for the M3 Pro, by
+prefix:
+
+| Prefix | Meaning | Idle values seen |
+|---|---|---|
+| `Tp**` | P-core die sensors, per cluster (36 keys) | 38 to 53 C |
+| `Te**` | E-core die sensors (13 keys) | 35 to 49 C |
+| `Tg**` | GPU cluster die sensors (20 keys) | 34 to 41 C |
+| `TB0T/TB1T/TB2T` | Battery (matches gas gauge readings) | 23.8 to 24.2 C |
+| `TH0a/TH0b/TH0x` | SSD | ~27.7 C |
+| `TaL*/TaR*` | Airflow left/right | 25 to 31 C |
+| `Ts0P/Ts1P` | Skin/palm rest proximity | 22 to 23 C |
+| `TW0P` | Wireless proximity | ~32 C |
+| `TV**` | Voltage-rail/regulator sensors, NOT die | 0.01 to 59.1 C |
+| `Ta0*` pairs | Calibration offsets (0.00 / -3.10), not real sensors | n/a |
+| `Tz1*` | Unused zones, all 0 | n/a |
+| `Tf**` | Mixed; includes offsets and two ~70 C outliers, treat as unknown | -4.5 to 75.5 C |
+
+Fans: `FNum` reports 2 fans; `F0`/`F1` each expose actual RPM (`Ac`), target
+(`Tg`), min (`Mn` = 2317), max (`Mx` = 6800), plus mode and state bytes. Both
+fans were at 0 RPM at idle (fans-off is normal for M3 Pro under light load).
+The shipping reader only reads fan 0.
+
+Value types are `flt` (little-endian float) plus some `ioft` (64-bit fixed
+point, divide by 65536); `ioft` shows up on `TG0*` and `TR*` keys and the
+shipping decoder does not handle it yet.
+
+### 2. HID temperature services (new, SPI)
+
+`IOHIDEventSystemClient` matched on PrimaryUsagePage 0xff00 / PrimaryUsage 5
+returns 46 services with human-readable names: `PMU tdie1..10` (SoC die),
+`PMU tdev1..8` (board), `NAND CH0 temp` (SSD), `gas gauge battery` (x6), and
+`PMU tcal` (calibration reference at ~52 C, not a display value). Most appear
+twice (two PMU instances); dedupe by name.
+
+Cost measured at ~974 us per read (a mach round trip to hidd per event), about
+8x the SMC path. These are SPI symbols (`IOHIDEventSystemClientCreate` and
+friends): fine for our Developer ID distribution (iStat Menus, Stats, and Hot
+all ship it), not App Store safe, no root or entitlement needed.
+
+Verdict: use SMC for the recurring sample loop (cheaper, one code path we
+already ship). HID's value is naming and cross-checking; worth keeping in the
+probe tool, not worth a second runtime dependency for the same numbers.
+
+### 3. Thermal pressure (public API, free)
+
+`ProcessInfo.processInfo.thermalState` (nominal/fair/serious/critical) plus the
+`thermalStateDidChangeNotification`. Push-based, zero polling cost, public API.
+This is the "is macOS actually throttling" signal that raw temperatures cannot
+give, and we currently do not read it anywhere.
+
+### 4. Already shipping elsewhere
+
+Battery temperature (`BatterySample.temperatureCelsius`), NVMe SMART composite
+temperature (Disk tab), and the GPU tab's die temperature and fan RPM from
+`SMCReader`.
+
+### 5. Not viable
+
+`powermetrics` needs root. IOReport (which we already use for GPU P-states and
+power) exposes no usable temperature channels. There is no public per-sensor
+API.
+
+### Root helper: not needed, deliberately
+
+The probe read every sensor unprivileged (293 of 293 SMC T/F keys, all HID
+services); Apple leaves SMC reads open. The only root-gated tool,
+`powermetrics --samplers thermal`, reports just the pressure level on Apple
+silicon, a strictly worse version of the free `ProcessInfo.thermalState`. The
+one root-only capability nearby is SMC writes (fan control); that is a
+different product, and adding an SMC-write selector to the helper would turn a
+narrow read-mostly surface into a hardware-safety attack surface. Out of
+scope, on purpose. Temperature joins the GPU tab in the "full coverage, no
+helper needed" story.
+
+## Bug found: the shipping die temperature is not the die
+
+`SMCReader.discoverKeys()` accepts prefixes `Tp`/`Te`/`TV` and caps discovery
+at 12 keys. SMC enumerates keys in sorted order, and uppercase sorts before
+lowercase, so every `TV*` key is seen before any `Te*` or `Tp*` key. On the
+M3 Pro, 12 `TV*` voltage-rail sensors pass the plausibility filter (10 to
+110 C), so the cap fills entirely with them: the reported "die temperature" is
+an average of voltage-rail sensors (including two ~59 C regulator readings and
+an 18 C outlier), roughly 33 C at idle while the real die sensors read 38 to
+53 C. It tracks load only incidentally. On earlier chips with fewer `TV*` keys
+the average may have included real die sensors, which is why it looked sane.
+Fix regardless of the rest of this doc: drop `TV` from the accepted prefixes,
+raise the cap, and prefer max over average (users read "CPU temp" as "hottest
+core", and max is what iStat and Stats report).
+
+## Metric definitions (proposed)
+
+- **CPU die**: max of `Tp*` and `Te*` after sanity filters (drop <=10 C,
+  >=110 C). Keep the average as a secondary stat.
+- **GPU die**: max of `Tg*` (`flt` keys only; the `TG0*` `ioft` keys are
+  battery-adjacent readings, note the case). Replaces "GPU shares the die
+  average" with the GPU's own sensors.
+- **SSD**: max of `TH0*`, alongside the existing SMART composite.
+- **Battery**: max of `TB0T/TB1T/TB2T` (agrees with the gas gauge, and we
+  already surface battery temperature).
+- **Fans**: per-fan actual/target/min/max for `FNum` fans, not just fan 0.
+- **Thermal pressure**: the `ProcessInfo` state, observed push-based.
+
+Discovery stays pattern-based (prefix plus sanity filter), never a hardcoded
+per-chip key table: key names shift between M1/M2/M3/M4 generations but the
+prefixes have held. Filters must reject the 0.00/-3.10 offset pairs and dead
+zones. Validate on the M2 Pro before release.
+
+## Cost budget
+
+Sampling set of roughly 75 keys (36 Tp + 13 Te + 20 Tg + 3 TB + 3 TH plus both
+fans) is ~9 ms per sweep at 119 us/key; at the existing 2 s throttle that is
+~0.4% of one core, and a 5 s cadence drops it under 0.2%. Temperatures move
+slowly; 5 s is plenty. Discovery is one enumeration, already the shipping
+pattern. Thermal state is push. Net: no measurable budget impact.
+
+## Where to surface it
+
+In order of recommendation:
+
+1. **Fix the GPU tab numbers first** (the `TV*` bug plus real `Tg*` GPU
+   sensors and both fans). The tab already has the layout; the numbers become
+   honest.
+2. **Menu bar: a new Temperature metric** in the combined item
+   (`MenuBarMetric.temperature`). Headline: CPU die max, colored by thermal
+   pressure state (green nominal, orange serious, red critical), so color
+   means "macOS is throttling", not an arbitrary degree threshold. Detail
+   panel: CPU/GPU/SSD/battery rows with sparklines, per-fan RPM, and the
+   current thermal pressure state. Temperature in the menu bar is the single
+   most-requested reason people install iStat or Stats; this is the headline
+   feature of the work.
+3. **Energy tab: a Thermals section.** Heat belongs with power. Die
+   temperature history chart (CPU and GPU series), fan RPM history, and a
+   thermal pressure event log. The Dashboard stays memory-first; do not add a
+   temperature tile there.
+4. **History**: persist a compact row at the logging cadence: CPU die max/avg,
+   GPU max, SSD, battery, fan RPMs, thermal state. Enables "when did it start
+   running hot" questions, which no competitor answers well. Two rules:
+   downsampling must preserve max as well as avg (a plain average erases the
+   spikes, which are the point), and granularity stays per-domain, not
+   per-sensor (the within-domain spread is a couple of degrees; the per-sensor
+   long tail is the Hardware tab's live view, not history).
+5. **Insights/alerts**: log thermal pressure transitions like pressure events;
+   quiet-by-default alert on sustained serious/critical (mirrors the sustained
+   swap alert). A throttling event with the top CPU process attached is the
+   actionable version of "my fans are loud".
+6. **Hardware tab**: a Sensors group in the inventory tree listing every named
+   sensor with its reading at Refresh time (on-demand fits that tab's model).
+   This is where the long tail (airflow, skin, wireless) lives, keeping the
+   headline surfaces to the six meaningful numbers.
+
+## Phasing
+
+1. **PR 1, correctness:** fix the `TV*` discovery bug in `SMCReader` (drop the
+   `TV` prefix, raise the 12-key cap, report max alongside avg), read both
+   fans, decode `ioft`. Makes the shipping GPU tab numbers honest.
+2. **PR 2, the thermal pipeline:** a domain-based thermal reader (CPU/GPU/SSD/
+   battery/fans/pressure state), `v14-thermal` migration with max-preserving
+   downsample, and the Energy tab Thermals section (history charts plus the
+   thermal pressure event log).
+3. **PR 3, menu bar:** the Temperature metric in the combined item, colored by
+   thermal pressure state, with the detail panel.
+4. **Phase two:** system series in Analytics (Analytics today is per-process
+   only, so this means teaching it a system-series concept, real scope), the
+   sustained-throttling alert with top CPU process attached, and the
+   fan-vs-temp drift observation ("fans work harder for the same temperature
+   than N months ago", the dust signal).
+
+## Open questions
+
+- `Tf*` and `TCMb/TCMz` run hot (67 to 76 C at idle) and are undocumented;
+  exclude until identified.
+- M4/M5 prefix drift: the probe tool (scratchpad, `temp-probe/probe.swift`)
+  should be run on new hardware as it arrives; consider promoting it to a
+  `--probe-sensors` flag on macperfmonitor-cli so users can contribute dumps.
+- Menu bar width: a temperature readout adds to an already configurable item;
+  the existing metric picker handles opt-in, no new mechanism needed.


### PR DESCRIPTION
First of the temperature-monitoring series (design: docs/temperature-design.md, added here).

The headline is a correctness bug found while probing sensors on an M3 Pro: SMC key enumeration is sorted uppercase-first and the old discovery accepted TV* (voltage rail) keys with a 12-key cap, so on M3 every slot filled with voltage rails and the GPU tab's "die temperature" never included a single die sensor (~33 C reported at idle vs 38-53 C actual).

Changes:
- Domain-classified, uncapped discovery: CPU die (Tp*/Te*, max + avg), GPU die (Tg*), SSD (TH0*). TV* excluded outright; case-sensitive prefixes keep the battery-adjacent TG0* keys out.
- ioft (64-bit fixed point) decoding.
- All fans via FNum, not just fan 0 (M3 Pro MacBook Pros have two).
- Split plausibility gates: strict at discovery (rejects the 0.00/-3.10 calibration offset pairs), lenient at read time (cold rooms still report).
- GPUSample.dieTemperatureC now prefers the GPU's own cluster sensors, falling back to CPU die max.
- New ThermalTests: 11 tests covering classification, both gates, all decoders, and a live-hardware safety test that tolerates SMC-less CI VMs.
- Drive-by: fixes the deprecated String(contentsOfFile:) warning in macperfmonitor-cli (build is now warning-free).

Verified: swift build (0 warnings), swift test (457 tests, 0 failures), swift format lint --strict clean; the live test exercised real discovery on an M3 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ