### PR TITLE
Thermal 2/4: record thermal history, Thermals section on the Energy tab

### DIFF
--- a/Sources/MacPerfMonitor/Charts/TemperatureChart.swift
+++ b/Sources/MacPerfMonitor/Charts/TemperatureChart.swift
@@ -1,0 +1,111 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// Shared colors for the thermal surfaces, so the Energy tab and any future
+/// menu bar panel tell the same story.
+enum ThermalStyle {
+    static let cpu = Color.orange
+    static let gpu = Color.red
+    static let fan = Color.teal
+}
+
+/// CPU and GPU die temperature over the selected window. The thermal fields
+/// are optional (nil marks a tick that did not read the SMC), so each series
+/// carries only the points that have a value: `TrendChart`'s gap splitting
+/// leaves unsampled stretches blank instead of drawing a misleading 0 degree
+/// floor. On aggregate ranges the points already carry the bucket max, so the
+/// line is "how hot did it get", never a smoothed average.
+struct TemperatureChart: View {
+    let points: [SystemHistoryPoint]
+    var xDomain: ClosedRange<Date>? = nil
+    var showsTimeAxis = false
+
+    private var cpuPoints: [TrendPoint] {
+        points.compactMap { point in
+            point.cpuDieC.map { TrendPoint(date: point.date, value: $0) }
+        }
+    }
+
+    private var gpuPoints: [TrendPoint] {
+        points.compactMap { point in
+            point.gpuDieC.map { TrendPoint(date: point.date, value: $0) }
+        }
+    }
+
+    private var accessibilitySummary: String {
+        guard let cpu = cpuPoints.last else {
+            return "No temperature samples in the shown window."
+        }
+        var parts = [String(format: "CPU die %.0f degrees", cpu.value)]
+        if let gpu = gpuPoints.last {
+            parts.append(String(format: "GPU die %.0f degrees", gpu.value))
+        }
+        if let peak = cpuPoints.map(\.value).max() {
+            parts.append(String(format: "window peak %.0f degrees", peak))
+        }
+        return "Latest " + parts.joined(separator: ", ") + "."
+    }
+
+    var body: some View {
+        TrendChart(
+            series: [
+                TrendSeries(points: cpuPoints, color: ThermalStyle.cpu, filled: true),
+                TrendSeries(
+                    points: gpuPoints, color: ThermalStyle.gpu, filled: false, lineWidth: 1.8),
+            ],
+            xDomain: xDomain,
+            yDomain: temperatureDomain,
+            yFormat: { String(format: "%.0f°C", $0) },
+            showsTimeAxis: showsTimeAxis
+        )
+        .accessibilityLabel("Die temperature trend")
+        .accessibilityValue(accessibilitySummary)
+    }
+
+    /// A stable floor-to-headroom domain: starting the axis at 0 wastes half
+    /// the plot (die sensors never read near 0), while a tight auto-fit makes
+    /// idle noise look dramatic. 20 to a rounded-up peak keeps small wiggles
+    /// small and real spikes visible.
+    private var temperatureDomain: ClosedRange<Double>? {
+        let values = cpuPoints.map(\.value) + gpuPoints.map(\.value)
+        guard let peak = values.max() else { return nil }
+        let top = max(60, (peak / 10).rounded(.up) * 10 + 10)
+        return 20...top
+    }
+}
+
+/// Fan speed over the selected window, gap-aware like the temperature chart.
+/// Fanless Macs simply never produce points, and the panel hides this chart.
+struct FanChart: View {
+    let points: [SystemHistoryPoint]
+    var xDomain: ClosedRange<Date>? = nil
+    var showsTimeAxis = false
+
+    private var fanPoints: [TrendPoint] {
+        points.compactMap { point in
+            point.fanRPM.map { TrendPoint(date: point.date, value: $0) }
+        }
+    }
+
+    private var accessibilitySummary: String {
+        guard let latest = fanPoints.last else {
+            return "No fan samples in the shown window."
+        }
+        if latest.value == 0 { return "Fans currently off." }
+        return String(format: "Fans currently %.0f rpm.", latest.value)
+    }
+
+    var body: some View {
+        TrendChart(
+            series: [
+                TrendSeries(points: fanPoints, color: ThermalStyle.fan, filled: true)
+            ],
+            xDomain: xDomain,
+            yFormat: { String(format: "%.0f rpm", max($0, 0)) },
+            showsTimeAxis: showsTimeAxis,
+            leftGutter: 56
+        )
+        .accessibilityLabel("Fan speed trend")
+        .accessibilityValue(accessibilitySummary)
+    }
+}

--- a/Sources/MacPerfMonitor/Views/BatteryView.swift
+++ b/Sources/MacPerfMonitor/Views/BatteryView.swift
@@ -44,7 +44,14 @@ struct BatteryView: View {
                 .padding(20)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .onAppear { reload() }
+        .onAppear {
+            reload()
+            // Keep the GPU/SMC read path live while the tab is visible so the
+            // thermal panel tracks in real time even when recording is off.
+            // Balanced by onDisappear; TabGate unmounts the tab when hidden.
+            model.addGPUConsumer()
+        }
+        .onDisappear { model.removeGPUConsumer() }
         .onChange(of: range) { reload() }
         .onChange(of: model.displayProcessesVersion) {
             if appState.mainWindowVisible { reload() }
@@ -79,6 +86,7 @@ struct BatteryView: View {
         MainRailLayout {
             pageHeader(subtitle: "on power adapter")
             desktopEnergyFlowPanel
+            thermalPanel
             topEnergyPanel
         } rail: {
             desktopPowerPanel
@@ -152,6 +160,7 @@ struct BatteryView: View {
             headlineNumbers(battery)
             energyFlowPanel(battery)
             chargeTimelinePanel(battery)
+            thermalPanel
             topEnergyPanel
         } rail: {
             healthPanel(battery)
@@ -299,6 +308,60 @@ struct BatteryView: View {
                 .font(.callout.weight(.medium))
                 .foregroundStyle(.primary)
         }
+    }
+
+    // MARK: - Thermals
+
+    /// Die temperature and fan history with the current readings, shared by
+    /// the laptop and desktop layouts. Heat sits with power on purpose: this
+    /// tab already answers "what is working the Mac hardest", and the thermal
+    /// record answers "and what did that cost".
+    private var thermalPanel: some View {
+        BatteryPanel("Thermals", systemImage: "thermometer.medium") {
+            TemperatureChart(points: points, xDomain: chartDomain, showsTimeAxis: true)
+                .frame(height: 150)
+                .chartReloading(awaitingData)
+            if let status = thermalStatus {
+                Text(status)
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.primary)
+            }
+            if hasFanHistory {
+                Divider().opacity(0.5)
+                FanChart(points: points, xDomain: chartDomain)
+                    .frame(height: 90)
+                    .chartReloading(awaitingData)
+            }
+            footnote(
+                "Each line is the hottest sensor of its domain: CPU die in orange, GPU die in "
+                    + "red. Longer ranges keep the peaks, not the average, so spikes stay "
+                    + "visible. The status follows macOS's own thermal pressure verdict, the "
+                    + "signal that the system is actually slowing work down.")
+        }
+    }
+
+    /// "CPU 47°C · GPU 41°C · SSD 29°C · Fans off · Nominal", omitting parts
+    /// that have no reading. Nil until the first thermal sample lands.
+    private var thermalStatus: String? {
+        guard let system = model.liveSystem else { return nil }
+        var parts: [String] = []
+        if let cpu = system.cpuDieC { parts.append("CPU \(Int(cpu.rounded()))°C") }
+        if let gpu = system.gpuDieC { parts.append("GPU \(Int(gpu.rounded()))°C") }
+        if let ssd = system.ssdTemperatureC { parts.append("SSD \(Int(ssd.rounded()))°C") }
+        if let fan = system.fanRPM {
+            parts.append(fan == 0 ? "Fans off" : "Fans \(Int(fan.rounded())) rpm")
+        }
+        guard !parts.isEmpty else { return nil }
+        if let pressure = system.thermalPressure {
+            parts.append(pressure.label)
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// Hide the fan chart outright on fanless Macs (MacBook Air) rather than
+    /// drawing an empty plot under a real temperature chart.
+    private var hasFanHistory: Bool {
+        points.contains { $0.fanRPM != nil } || model.liveSystem?.fanRPM != nil
     }
 
     /// A one-line plain-language summary of the current power state, shown under
@@ -562,7 +625,12 @@ struct BatteryView: View {
                 batteryCharge: system.batteryCharge,
                 batteryPowerWatts: system.batteryPowerWatts,
                 batteryHealthPercent: system.batteryHealthPercent,
-                batteryTemperatureCelsius: system.batteryTemperatureCelsius
+                batteryTemperatureCelsius: system.batteryTemperatureCelsius,
+                cpuDieC: system.cpuDieC,
+                gpuDieC: system.gpuDieC,
+                ssdTemperatureC: system.ssdTemperatureC,
+                fanRPM: system.fanRPM,
+                thermalPressure: system.thermalPressure
             )
             if let last = pts.last {
                 if live.date > last.date { pts.append(live) }

--- a/Sources/MacPerfMonitorCore/Models/SystemSample.swift
+++ b/Sources/MacPerfMonitorCore/Models/SystemSample.swift
@@ -97,6 +97,17 @@ public struct SystemSample: Sendable, Codable {
     public var gpuUtilization: Double?
     public var gpuPowerWatts: Double?
     public var anePowerWatts: Double?
+    // Thermal figures (v14), read from the SMC on the same ticks as the GPU
+    // figures. Optional for the same reason: "not sampled" stays distinct
+    // from 0. cpuDieC and gpuDieC are the hottest sensor of their domain;
+    // fanRPM is the fastest fan.
+    public var cpuDieC: Double?
+    public var gpuDieC: Double?
+    public var ssdTemperatureC: Double?
+    public var fanRPM: Double?
+    /// macOS's own thermal pressure verdict, read every tick (public API, no
+    /// SMC involved), so throttling history survives even without sensors.
+    public var thermalPressure: ThermalPressureState?
 
     public init(
         timestamp: Date,
@@ -143,7 +154,12 @@ public struct SystemSample: Sendable, Codable {
         bootVolumeFreeBytes: UInt64? = nil,
         gpuUtilization: Double? = nil,
         gpuPowerWatts: Double? = nil,
-        anePowerWatts: Double? = nil
+        anePowerWatts: Double? = nil,
+        cpuDieC: Double? = nil,
+        gpuDieC: Double? = nil,
+        ssdTemperatureC: Double? = nil,
+        fanRPM: Double? = nil,
+        thermalPressure: ThermalPressureState? = nil
     ) {
         self.timestamp = timestamp
         self.totalRAM = totalRAM
@@ -190,5 +206,10 @@ public struct SystemSample: Sendable, Codable {
         self.gpuUtilization = gpuUtilization
         self.gpuPowerWatts = gpuPowerWatts
         self.anePowerWatts = anePowerWatts
+        self.cpuDieC = cpuDieC
+        self.gpuDieC = gpuDieC
+        self.ssdTemperatureC = ssdTemperatureC
+        self.fanRPM = fanRPM
+        self.thermalPressure = thermalPressure
     }
 }

--- a/Sources/MacPerfMonitorCore/Models/ThermalPressureState.swift
+++ b/Sources/MacPerfMonitorCore/Models/ThermalPressureState.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// macOS's own thermal pressure verdict, mirrored from
+/// `ProcessInfo.thermalState`. This is the honest "is the system actually
+/// throttling" signal that raw temperatures cannot give: color and alerts key
+/// off this, never off an arbitrary degree threshold. Raw values are stable
+/// and persisted (higher is worse).
+public enum ThermalPressureState: Int, Sendable, Codable, Comparable, CaseIterable {
+    case nominal = 0
+    case fair = 1
+    case serious = 2
+    case critical = 3
+
+    public init(_ state: ProcessInfo.ThermalState) {
+        switch state {
+        case .nominal: self = .nominal
+        case .fair: self = .fair
+        case .serious: self = .serious
+        case .critical: self = .critical
+        @unknown default: self = .critical
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .nominal: return "Nominal"
+        case .fair: return "Fair"
+        case .serious: return "Serious"
+        case .critical: return "Critical"
+        }
+    }
+
+    /// True once macOS is visibly slowing work down (fair is only light
+    /// fan-and-scheduling adjustment; serious and critical throttle).
+    public var isThrottling: Bool { self >= .serious }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}

--- a/Sources/MacPerfMonitorCore/Persistence/Database.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/Database.swift
@@ -179,6 +179,15 @@ public enum MacPerfMonitorDatabase {
         migrator.registerMigration("v13-gpu") { db in
             try db.execute(sql: Schema.v13)
         }
+        // Thermal: per-domain die temperatures (hottest sensor), the fastest
+        // fan, and macOS's thermal pressure verdict on the system rows. All
+        // nullable like the GPU columns: a tick that did not read the SMC
+        // stores nothing, not 0. Rollups keep max as well as avg because the
+        // spikes are the point of thermal history; a plain average would
+        // erase exactly the moments users go looking for.
+        migrator.registerMigration("v14-thermal") { db in
+            try db.execute(sql: Schema.v14)
+        }
         return migrator
     }
 }
@@ -546,6 +555,34 @@ enum Schema {
         ALTER TABLE process_minute ADD COLUMN gpu_max REAL NOT NULL DEFAULT 0;
         ALTER TABLE process_hour ADD COLUMN gpu_avg REAL NOT NULL DEFAULT 0;
         ALTER TABLE process_hour ADD COLUMN gpu_max REAL NOT NULL DEFAULT 0;
+        """
+
+    static let v14 = """
+        ALTER TABLE system_samples ADD COLUMN cpu_die REAL;
+        ALTER TABLE system_samples ADD COLUMN gpu_die REAL;
+        ALTER TABLE system_samples ADD COLUMN ssd_temp REAL;
+        ALTER TABLE system_samples ADD COLUMN fan_rpm REAL;
+        ALTER TABLE system_samples ADD COLUMN thermal_state INTEGER;
+
+        ALTER TABLE system_minute ADD COLUMN cpu_die_avg REAL;
+        ALTER TABLE system_minute ADD COLUMN cpu_die_max REAL;
+        ALTER TABLE system_minute ADD COLUMN gpu_die_avg REAL;
+        ALTER TABLE system_minute ADD COLUMN gpu_die_max REAL;
+        ALTER TABLE system_minute ADD COLUMN ssd_temp_avg REAL;
+        ALTER TABLE system_minute ADD COLUMN ssd_temp_max REAL;
+        ALTER TABLE system_minute ADD COLUMN fan_rpm_avg REAL;
+        ALTER TABLE system_minute ADD COLUMN fan_rpm_max REAL;
+        ALTER TABLE system_minute ADD COLUMN thermal_state_max INTEGER;
+
+        ALTER TABLE system_hour ADD COLUMN cpu_die_avg REAL;
+        ALTER TABLE system_hour ADD COLUMN cpu_die_max REAL;
+        ALTER TABLE system_hour ADD COLUMN gpu_die_avg REAL;
+        ALTER TABLE system_hour ADD COLUMN gpu_die_max REAL;
+        ALTER TABLE system_hour ADD COLUMN ssd_temp_avg REAL;
+        ALTER TABLE system_hour ADD COLUMN ssd_temp_max REAL;
+        ALTER TABLE system_hour ADD COLUMN fan_rpm_avg REAL;
+        ALTER TABLE system_hour ADD COLUMN fan_rpm_max REAL;
+        ALTER TABLE system_hour ADD COLUMN thermal_state_max INTEGER;
         """
 }
 

--- a/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
@@ -87,6 +87,13 @@ extension Array where Element == SystemHistoryPoint {
                 guard !present.isEmpty else { return nil }
                 return present.reduce(0, +) / Double(present.count)
             }
+            // Peak over only the points that carry a value; all-nil stays nil
+            // so the chart gaps. Temperatures use this rather than omean: a
+            // plain average erases the spikes, which are the point of thermal
+            // history.
+            func omax(_ value: (SystemHistoryPoint) -> Double?) -> Double? {
+                slice.compactMap(value).max()
+            }
             result.append(
                 SystemHistoryPoint(
                     // Grid-anchored start of the bucket: a fixed point that does
@@ -127,7 +134,20 @@ extension Array where Element == SystemHistoryPoint {
                     // Free space wants its low water mark, not its average: the
                     // moment the disk nearly filled is the moment that matters.
                     bootFreeBytes: slice.compactMap(\.bootFreeBytes).min(),
-                    bootTotalBytes: slice.compactMap(\.bootTotalBytes).last
+                    bootTotalBytes: slice.compactMap(\.bootTotalBytes).last,
+                    // Carry the GPU figures through: omitting them defaulted
+                    // them to nil and blanked the GPU tab's history on any
+                    // downsampled range, the same class of drop the battery
+                    // and disk scalars had. Bursty like CPU, so average.
+                    gpuUtilization: omean { $0.gpuUtilization },
+                    gpuPowerWatts: omean { $0.gpuPowerWatts },
+                    anePowerWatts: omean { $0.anePowerWatts },
+                    cpuDieC: omax { $0.cpuDieC },
+                    gpuDieC: omax { $0.gpuDieC },
+                    ssdTemperatureC: omax { $0.ssdTemperatureC },
+                    fanRPM: omax { $0.fanRPM },
+                    // Worst pressure in the bucket, for the same reason.
+                    thermalPressure: slice.compactMap(\.thermalPressure).max()
                 ))
             i = j
         }

--- a/Sources/MacPerfMonitorCore/Persistence/Retention.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/Retention.swift
@@ -295,7 +295,7 @@ public enum Retention {
 
         try db.execute(
             sql: """
-                INSERT INTO system_minute (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total, gpu_util_avg, gpu_util_max, gpu_power_avg, gpu_power_max, ane_power_avg, ane_power_max)
+                INSERT INTO system_minute (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total, gpu_util_avg, gpu_util_max, gpu_power_avg, gpu_power_max, ane_power_avg, ane_power_max, cpu_die_avg, cpu_die_max, gpu_die_avg, gpu_die_max, ssd_temp_avg, ssd_temp_max, fan_rpm_avg, fan_rpm_max, thermal_state_max)
                 SELECT CAST(timestamp / \(b) AS INTEGER) * \(b) AS b,
                        AVG(pressure_percent), MAX(pressure_percent),
                        CAST(AVG(app_memory) AS INTEGER), CAST(AVG(wired) AS INTEGER),
@@ -312,7 +312,10 @@ public enum Retention {
                        AVG(disk_util), MAX(disk_util),
                        CAST(AVG(boot_free) AS INTEGER), MIN(boot_free), MAX(boot_total),
                        AVG(gpu_util), MAX(gpu_util), AVG(gpu_power), MAX(gpu_power),
-                       AVG(ane_power), MAX(ane_power)
+                       AVG(ane_power), MAX(ane_power),
+                       AVG(cpu_die), MAX(cpu_die), AVG(gpu_die), MAX(gpu_die),
+                       AVG(ssd_temp), MAX(ssd_temp), AVG(fan_rpm), MAX(fan_rpm),
+                       MAX(thermal_state)
                 FROM system_samples
                 WHERE timestamp >= ? AND timestamp < ?
                 GROUP BY b
@@ -347,7 +350,12 @@ public enum Retention {
                   boot_total = excluded.boot_total,
                   gpu_util_avg = excluded.gpu_util_avg, gpu_util_max = excluded.gpu_util_max,
                   gpu_power_avg = excluded.gpu_power_avg, gpu_power_max = excluded.gpu_power_max,
-                  ane_power_avg = excluded.ane_power_avg, ane_power_max = excluded.ane_power_max
+                  ane_power_avg = excluded.ane_power_avg, ane_power_max = excluded.ane_power_max,
+                  cpu_die_avg = excluded.cpu_die_avg, cpu_die_max = excluded.cpu_die_max,
+                  gpu_die_avg = excluded.gpu_die_avg, gpu_die_max = excluded.gpu_die_max,
+                  ssd_temp_avg = excluded.ssd_temp_avg, ssd_temp_max = excluded.ssd_temp_max,
+                  fan_rpm_avg = excluded.fan_rpm_avg, fan_rpm_max = excluded.fan_rpm_max,
+                  thermal_state_max = excluded.thermal_state_max
                 """, arguments: [watermark, completeUpTo])
 
         try setMeta(db, "minute_watermark", completeUpTo)
@@ -403,7 +411,7 @@ public enum Retention {
 
         try db.execute(
             sql: """
-                INSERT INTO system_hour (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total, gpu_util_avg, gpu_util_max, gpu_power_avg, gpu_power_max, ane_power_avg, ane_power_max)
+                INSERT INTO system_hour (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total, gpu_util_avg, gpu_util_max, gpu_power_avg, gpu_power_max, ane_power_avg, ane_power_max, cpu_die_avg, cpu_die_max, gpu_die_avg, gpu_die_max, ssd_temp_avg, ssd_temp_max, fan_rpm_avg, fan_rpm_max, thermal_state_max)
                 SELECT CAST(bucket / 3600 AS INTEGER) * 3600 AS b,
                        SUM(pressure_avg * samples) / SUM(samples), MAX(pressure_max),
                        CAST(SUM(app_avg * samples) / SUM(samples) AS INTEGER),
@@ -444,7 +452,20 @@ public enum Retention {
                        MAX(gpu_power_max),
                        SUM(ane_power_avg * samples)
                            / SUM(CASE WHEN ane_power_avg IS NOT NULL THEN samples END),
-                       MAX(ane_power_max)
+                       MAX(ane_power_max),
+                       SUM(cpu_die_avg * samples)
+                           / SUM(CASE WHEN cpu_die_avg IS NOT NULL THEN samples END),
+                       MAX(cpu_die_max),
+                       SUM(gpu_die_avg * samples)
+                           / SUM(CASE WHEN gpu_die_avg IS NOT NULL THEN samples END),
+                       MAX(gpu_die_max),
+                       SUM(ssd_temp_avg * samples)
+                           / SUM(CASE WHEN ssd_temp_avg IS NOT NULL THEN samples END),
+                       MAX(ssd_temp_max),
+                       SUM(fan_rpm_avg * samples)
+                           / SUM(CASE WHEN fan_rpm_avg IS NOT NULL THEN samples END),
+                       MAX(fan_rpm_max),
+                       MAX(thermal_state_max)
                 FROM system_minute
                 WHERE bucket >= ? AND bucket < ?
                 GROUP BY b
@@ -479,7 +500,12 @@ public enum Retention {
                   boot_total = excluded.boot_total,
                   gpu_util_avg = excluded.gpu_util_avg, gpu_util_max = excluded.gpu_util_max,
                   gpu_power_avg = excluded.gpu_power_avg, gpu_power_max = excluded.gpu_power_max,
-                  ane_power_avg = excluded.ane_power_avg, ane_power_max = excluded.ane_power_max
+                  ane_power_avg = excluded.ane_power_avg, ane_power_max = excluded.ane_power_max,
+                  cpu_die_avg = excluded.cpu_die_avg, cpu_die_max = excluded.cpu_die_max,
+                  gpu_die_avg = excluded.gpu_die_avg, gpu_die_max = excluded.gpu_die_max,
+                  ssd_temp_avg = excluded.ssd_temp_avg, ssd_temp_max = excluded.ssd_temp_max,
+                  fan_rpm_avg = excluded.fan_rpm_avg, fan_rpm_max = excluded.fan_rpm_max,
+                  thermal_state_max = excluded.thermal_state_max
                 """, arguments: [watermark, completeUpTo])
 
         try setMeta(db, "hour_watermark", completeUpTo)

--- a/Sources/MacPerfMonitorCore/Persistence/SampleStore.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/SampleStore.swift
@@ -273,9 +273,10 @@ public final class SampleStore {
                  battery_cycles, battery_temp, net_in, net_out,
                  disk_read, disk_write, disk_read_iops, disk_write_iops,
                  disk_read_latency, disk_write_latency, disk_util, boot_free, boot_total,
-                 gpu_util, gpu_power, ane_power)
+                 gpu_util, gpu_power, ane_power,
+                 cpu_die, gpu_die, ssd_temp, fan_rpm, thermal_state)
                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-                        ?,?,?,?,?,?,?,?)
+                        ?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """)
         try statement.execute(
             arguments: [
@@ -298,6 +299,8 @@ public final class SampleStore {
                 s.diskReadLatencyMs, s.diskWriteLatencyMs, s.diskUtilizationPercent,
                 s.bootVolumeFreeBytes.map(SQLInt.store), s.bootVolumeTotalBytes.map(SQLInt.store),
                 s.gpuUtilization, s.gpuPowerWatts, s.anePowerWatts,
+                s.cpuDieC, s.gpuDieC, s.ssdTemperatureC, s.fanRPM,
+                s.thermalPressure?.rawValue,
             ])
     }
 
@@ -523,7 +526,16 @@ public final class SampleStore {
             diskWriteLatencyMs: row["disk_write_latency"],
             diskUtilizationPercent: row["disk_util"],
             bootVolumeTotalBytes: (row["boot_total"] as Int64?).map(SQLInt.read),
-            bootVolumeFreeBytes: (row["boot_free"] as Int64?).map(SQLInt.read)
+            bootVolumeFreeBytes: (row["boot_free"] as Int64?).map(SQLInt.read),
+            gpuUtilization: row["gpu_util"],
+            gpuPowerWatts: row["gpu_power"],
+            anePowerWatts: row["ane_power"],
+            cpuDieC: row["cpu_die"],
+            gpuDieC: row["gpu_die"],
+            ssdTemperatureC: row["ssd_temp"],
+            fanRPM: row["fan_rpm"],
+            thermalPressure: (row["thermal_state"] as Int?)
+                .flatMap { ThermalPressureState(rawValue: $0) }
         )
     }
 

--- a/Sources/MacPerfMonitorCore/Persistence/SystemHistory.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/SystemHistory.swift
@@ -44,6 +44,16 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
     public var diskUtilizationPercent: Double?
     public var bootFreeBytes: UInt64?
     public var bootTotalBytes: UInt64?
+    // Thermal figures (v14); nil on ticks that did not read the SMC. On
+    // aggregate ranges these carry the bucket MAX, not the average: "how hot
+    // did it get" is the question thermal history answers, and averaging
+    // erases exactly the spikes users go looking for.
+    public var cpuDieC: Double?
+    public var gpuDieC: Double?
+    public var ssdTemperatureC: Double?
+    public var fanRPM: Double?
+    /// Worst thermal pressure in the interval.
+    public var thermalPressure: ThermalPressureState?
 
     public var id: Date { date }
 
@@ -73,7 +83,12 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
         bootTotalBytes: UInt64? = nil,
         gpuUtilization: Double? = nil,
         gpuPowerWatts: Double? = nil,
-        anePowerWatts: Double? = nil
+        anePowerWatts: Double? = nil,
+        cpuDieC: Double? = nil,
+        gpuDieC: Double? = nil,
+        ssdTemperatureC: Double? = nil,
+        fanRPM: Double? = nil,
+        thermalPressure: ThermalPressureState? = nil
     ) {
         self.date = date
         self.pressurePercent = pressurePercent
@@ -101,6 +116,11 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
         self.gpuUtilization = gpuUtilization
         self.gpuPowerWatts = gpuPowerWatts
         self.anePowerWatts = anePowerWatts
+        self.cpuDieC = cpuDieC
+        self.gpuDieC = gpuDieC
+        self.ssdTemperatureC = ssdTemperatureC
+        self.fanRPM = fanRPM
+        self.thermalPressure = thermalPressure
     }
 }
 
@@ -144,7 +164,8 @@ extension SampleStore {
                            battery_charge, battery_power, battery_health, battery_temp, net_in, net_out,
                            disk_read, disk_write, disk_read_iops, disk_write_iops,
                            disk_read_latency, disk_write_latency, disk_util, boot_free, boot_total,
-                           gpu_util, gpu_power, ane_power
+                           gpu_util, gpu_power, ane_power,
+                           cpu_die, gpu_die, ssd_temp, fan_rpm, thermal_state
                     FROM system_samples
                     WHERE timestamp >= ?
                     ORDER BY timestamp ASC
@@ -164,7 +185,8 @@ extension SampleStore {
                            disk_read_avg, disk_write_avg, disk_read_iops_avg, disk_write_iops_avg,
                            disk_read_latency_avg, disk_write_latency_avg, disk_util_avg,
                            boot_free_min, boot_total,
-                           gpu_util_avg, gpu_power_avg, ane_power_avg
+                           gpu_util_avg, gpu_power_avg, ane_power_avg,
+                           cpu_die_max, gpu_die_max, ssd_temp_max, fan_rpm_max, thermal_state_max
                     FROM \(table)
                     WHERE bucket >= ?
                     ORDER BY bucket ASC
@@ -205,7 +227,12 @@ extension SampleStore {
             bootTotalBytes: (row[22] as Int64?).map(SQLInt.read),
             gpuUtilization: row[23],
             gpuPowerWatts: row[24],
-            anePowerWatts: row[25]
+            anePowerWatts: row[25],
+            cpuDieC: row[26],
+            gpuDieC: row[27],
+            ssdTemperatureC: row[28],
+            fanRPM: row[29],
+            thermalPressure: (row[30] as Int?).flatMap { ThermalPressureState(rawValue: $0) }
         )
     }
 }

--- a/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
@@ -153,6 +153,7 @@ public final class Sampler {
     /// ticks. Their values do not benefit from polling above 1 Hz, and each call
     /// crosses into IOKit or the SMC driver.
     private var cachedGPU: GPUSample?
+    private var cachedThermal: ThermalSample?
     private var lastGPUReadAt: Date?
 
     /// Per-process facts that never change for a given pid+startTime: the
@@ -295,6 +296,9 @@ public final class Sampler {
             lastGPUReadAt.map({ now.timeIntervalSince($0) >= gpuReadInterval }) ?? true
         {
             var freshGPU = gpuReader.read()
+            // Thermal rides the GPU cadence but does not depend on the GPU
+            // reader succeeding; SMCReader throttles itself internally.
+            if let thermal = smcReader.read(now: now) { cachedThermal = thermal }
             if freshGPU != nil {
                 if let power = powerReader.read(now: now) {
                     freshGPU?.gpuPowerWatts = power.gpuWatts
@@ -305,7 +309,7 @@ public final class Sampler {
                     freshGPU?.throttled = power.gpuThrottled
                     freshGPU?.powerCapPercent = power.gpuPowerCapPercent
                 }
-                if let thermal = smcReader.read(now: now) {
+                if let thermal = cachedThermal {
                     // Prefer the GPU's own cluster sensors; fall back to the
                     // CPU die max on chips with no GPU-specific keys.
                     freshGPU?.dieTemperatureC = thermal.gpuDieMaxC ?? thermal.cpuDieMaxC
@@ -317,9 +321,10 @@ public final class Sampler {
             lastGPUReadAt = now
         }
         let gpu = readGPU ? cachedGPU : nil
+        let thermal = readGPU ? cachedThermal : nil
         let system = sampleSystem(
             now: now, wallDeltaSeconds: wallDeltaSeconds, cpuLoad: cpu.totalUsage, battery: battery,
-            network: network, disk: disk, bootVolume: bootVolume, gpu: gpu)
+            network: network, disk: disk, bootVolume: bootVolume, gpu: gpu, thermal: thermal)
         lastSystemTime = now
         return (system, cpu, battery, network, disk, gpu)
     }
@@ -760,6 +765,7 @@ public final class Sampler {
         cachedBattery = nil
         lastBatteryReadAt = nil
         cachedGPU = nil
+        cachedThermal = nil
         lastGPUReadAt = nil
         networkReader.reset()
         diskReader.reset()
@@ -777,7 +783,7 @@ public final class Sampler {
     private func sampleSystem(
         now: Date, wallDeltaSeconds: TimeInterval, cpuLoad: Double, battery: BatterySample?,
         network: NetworkSample?, disk: DiskSample?, bootVolume: BootVolumeReader.Capacity?,
-        gpu: GPUSample? = nil
+        gpu: GPUSample? = nil, thermal: ThermalSample? = nil
     ) -> SystemSample {
         let totalRAM = memoryReader.totalRAM
         let vm = memoryReader.sampleVM()
@@ -875,7 +881,14 @@ public final class Sampler {
             bootVolumeFreeBytes: bootVolume?.freeBytes,
             gpuUtilization: gpu?.utilization,
             gpuPowerWatts: gpu?.gpuPowerWatts,
-            anePowerWatts: gpu?.anePowerWatts
+            anePowerWatts: gpu?.anePowerWatts,
+            cpuDieC: thermal?.cpuDieMaxC,
+            gpuDieC: thermal?.gpuDieMaxC,
+            ssdTemperatureC: thermal?.ssdMaxC,
+            fanRPM: thermal?.primaryFanRPM.map(Double.init),
+            // Public API, no SMC involved: read every tick so the throttling
+            // record survives even when no thermal surface is active.
+            thermalPressure: ThermalPressureState(ProcessInfo.processInfo.thermalState)
         )
     }
 

--- a/Tests/MacPerfMonitorCoreTests/ThermalHistoryTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/ThermalHistoryTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+/// The v14 thermal columns round-trip through the store and keep their peaks
+/// through every tier: raw rows, the minute and hour rollups, and the chart
+/// downsampler. Max preservation is the design invariant: thermal history
+/// exists to answer "how hot did it get", and any tier that averages a spike
+/// away breaks the feature.
+final class ThermalHistoryTests: XCTestCase {
+    private var tempURL: URL!
+    private var store: SampleStore!
+    private let anchor = Date(timeIntervalSince1970: 1_800_000_000)
+
+    override func setUpWithError() throws {
+        tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macperfmonitor-thermal-test-\(UUID().uuidString).sqlite")
+        store = try SampleStore(url: tempURL)
+    }
+
+    override func tearDownWithError() throws {
+        store = nil
+        try? FileManager.default.removeItem(at: tempURL)
+        try? FileManager.default.removeItem(at: tempURL.appendingPathExtension("wal"))
+        try? FileManager.default.removeItem(at: tempURL.appendingPathExtension("shm"))
+    }
+
+    private func thermalSample(
+        at date: Date, cpu: Double? = nil, gpu: Double? = nil, ssd: Double? = nil,
+        fan: Double? = nil, pressure: ThermalPressureState? = nil
+    ) -> SystemSample {
+        var sample = Make.system(timestamp: date, pressurePercent: 10)
+        sample.cpuDieC = cpu
+        sample.gpuDieC = gpu
+        sample.ssdTemperatureC = ssd
+        sample.fanRPM = fan
+        sample.thermalPressure = pressure
+        return sample
+    }
+
+    // MARK: - Raw round trip
+
+    func testThermalFiguresRoundTrip() throws {
+        let now = Date()
+        var sampled = thermalSample(
+            at: now.addingTimeInterval(-2), cpu: 53.2, gpu: 41.0, ssd: 29.5, fan: 2317,
+            pressure: .serious)
+        sampled.gpuUtilization = 83
+        sampled.gpuPowerWatts = 3.5
+        sampled.anePowerWatts = 0.25
+        let unsampled = Make.system(timestamp: now, pressurePercent: 10)
+        try store.insert(systemSample: sampled)
+        try store.insert(systemSample: unsampled)
+
+        let history = try store.systemHistory(.fiveMinutes, now: now)
+        XCTAssertEqual(history.count, 2)
+        XCTAssertEqual(history[0].cpuDieC ?? -1, 53.2, accuracy: 0.001)
+        XCTAssertEqual(history[0].gpuDieC ?? -1, 41.0, accuracy: 0.001)
+        XCTAssertEqual(history[0].ssdTemperatureC ?? -1, 29.5, accuracy: 0.001)
+        XCTAssertEqual(history[0].fanRPM ?? -1, 2317, accuracy: 0.001)
+        XCTAssertEqual(history[0].thermalPressure, .serious)
+        // A tick that did not read the SMC stays distinct from a measured 0.
+        XCTAssertNil(history[1].cpuDieC)
+        XCTAssertNil(history[1].fanRPM)
+        XCTAssertNil(history[1].thermalPressure)
+    }
+
+    /// `decodeSystem` (latest-sample and since-queries) must carry the thermal
+    /// fields, and the GPU fields it previously dropped on read.
+    func testLatestSystemSampleDecodesThermalAndGPU() throws {
+        let now = Date()
+        var sample = thermalSample(at: now, cpu: 47.0, fan: 0, pressure: .nominal)
+        sample.gpuUtilization = 61
+        sample.gpuPowerWatts = 2.75
+        sample.anePowerWatts = 0.5
+        try store.insert(systemSample: sample)
+
+        let latest = try XCTUnwrap(store.latestSystemSample())
+        XCTAssertEqual(latest.cpuDieC ?? -1, 47.0, accuracy: 0.001)
+        XCTAssertEqual(latest.fanRPM ?? -1, 0, accuracy: 0.001)
+        XCTAssertEqual(latest.thermalPressure, .nominal)
+        XCTAssertEqual(latest.gpuUtilization ?? -1, 61, accuracy: 0.001)
+        XCTAssertEqual(latest.gpuPowerWatts ?? -1, 2.75, accuracy: 0.001)
+        XCTAssertEqual(latest.anePowerWatts ?? -1, 0.5, accuracy: 0.001)
+    }
+
+    // MARK: - Rollups
+
+    func testMinuteRollupKeepsTheSpike() throws {
+        // A one-tick 95 degree spike inside a minute of 40 degree samples.
+        for i in 0..<10 {
+            try store.insert(
+                systemSample: thermalSample(
+                    at: anchor.addingTimeInterval(Double(i) * 6),
+                    cpu: i == 4 ? 95 : 40, gpu: 35, fan: Double(1000 + i * 100),
+                    pressure: i == 4 ? .critical : .nominal))
+        }
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(600))
+
+        let points = try store.systemHistory(.oneDay, now: anchor.addingTimeInterval(600))
+        XCTAssertGreaterThanOrEqual(points.count, 1)
+        // The aggregate read serves the bucket max, so the spike survives.
+        XCTAssertEqual(points.map { $0.cpuDieC ?? 0 }.max() ?? 0, 95, accuracy: 0.001)
+        XCTAssertEqual(points.first?.gpuDieC ?? 0, 35, accuracy: 0.001)
+        XCTAssertEqual(points.compactMap(\.thermalPressure).max(), .critical)
+    }
+
+    func testHourRollupKeepsTheSpike() throws {
+        for i in 0..<40 {
+            try store.insert(
+                systemSample: thermalSample(
+                    at: anchor.addingTimeInterval(Double(i) * 6),
+                    cpu: i == 20 ? 88 : 42, pressure: .fair))
+        }
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(600))
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(7200))
+
+        let points = try store.systemHistory(.sevenDays, now: anchor.addingTimeInterval(7200))
+        XCTAssertGreaterThanOrEqual(points.count, 1)
+        XCTAssertEqual(points.map { $0.cpuDieC ?? 0 }.max() ?? 0, 88, accuracy: 0.001)
+        XCTAssertEqual(points.first?.thermalPressure, .fair)
+    }
+
+    /// Ticks with no SMC read must not collapse a bucket to null: AVG/MAX skip
+    /// nulls, so a bucket with any reading keeps it.
+    func testRollupIgnoresUnsampledTicks() throws {
+        try store.insert(systemSample: thermalSample(at: anchor, cpu: 50))
+        try store.insert(systemSample: thermalSample(at: anchor.addingTimeInterval(6)))
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(600))
+
+        let points = try store.systemHistory(.oneDay, now: anchor.addingTimeInterval(600))
+        XCTAssertEqual(points.map { $0.cpuDieC ?? 0 }.max() ?? 0, 50, accuracy: 0.001)
+    }
+
+    // MARK: - Chart downsampler
+
+    private func historyPoint(index: Int) -> SystemHistoryPoint {
+        SystemHistoryPoint(
+            date: anchor.addingTimeInterval(Double(index) * 5), pressurePercent: 10,
+            appMemory: 1, wired: 1, compressed: 1, cachedFiles: 1, swapUsed: 0)
+    }
+
+    func testChartDownsampleKeepsThermalPeaksAndGPUSeries() {
+        let span: TimeInterval = 3600
+        var points: [SystemHistoryPoint] = []
+        for i in 0..<720 {
+            var point = historyPoint(index: i)
+            point.gpuUtilization = 50
+            point.cpuDieC = i == 360 ? 96 : 40
+            point.gpuDieC = 35
+            point.fanRPM = Double(i)
+            point.thermalPressure = i == 360 ? .serious : .nominal
+            points.append(point)
+        }
+        let thinned = points.chartDownsampled(span: span, to: 100)
+        XCTAssertLessThanOrEqual(thinned.count, 102)
+        // The one-tick thermal spike survives max-preserving buckets.
+        let peaks: [Double] = thinned.compactMap { $0.cpuDieC }
+        XCTAssertEqual(peaks.max() ?? 0, 96, accuracy: 0.001)
+        let worst: ThermalPressureState? = thinned.compactMap { $0.thermalPressure }.max()
+        XCTAssertEqual(worst, ThermalPressureState.serious)
+        // The GPU series is carried through instead of being dropped to nil.
+        XCTAssertEqual(thinned.compactMap { $0.gpuUtilization }.count, thinned.count)
+        // All-nil stays nil: no thermal reading must not become a 0 line.
+        let bare = (0..<720).map(historyPoint(index:))
+        XCTAssertTrue(bare.chartDownsampled(span: span, to: 100).allSatisfy { $0.cpuDieC == nil })
+    }
+
+    func testThermalPressureStateOrderingAndLabels() {
+        XCTAssertLessThan(ThermalPressureState.nominal, .fair)
+        XCTAssertLessThan(ThermalPressureState.fair, .serious)
+        XCTAssertLessThan(ThermalPressureState.serious, .critical)
+        XCTAssertFalse(ThermalPressureState.fair.isThrottling)
+        XCTAssertTrue(ThermalPressureState.serious.isThrottling)
+        let mapped = ThermalPressureState(ProcessInfo.processInfo.thermalState)
+        XCTAssertGreaterThanOrEqual(mapped.rawValue, 0)
+    }
+}


### PR DESCRIPTION
Second of the temperature series, building on #22.

- v14 migration: cpu_die / gpu_die / ssd_temp / fan_rpm / thermal_state on system_samples (nullable, like the GPU columns: not-sampled stays distinct from 0), with avg+max rollups in system_minute and system_hour. Thermal pressure rolls up as MAX (worst state in the bucket).
- Max preservation end to end: rollups keep MAX, the aggregate history read serves the *_max columns, and chartDownsampled gains a max-preserving reducer for the thermal fields. Averaging a spike away would erase exactly what thermal history is for.
- Sampler: ThermalSample folds into SystemSample on the GPU gate; ProcessInfo.thermalState (new ThermalPressureState model) is read every tick so throttling history records even without SMC surfaces.
- Energy tab: a Thermals panel on laptop and desktop layouts with CPU/GPU die history, a live status line, and a fan chart hidden on fanless Macs. The tab holds a GPU consumer while visible.
- Fixes two pre-existing read-path drops: decodeSystem never decoded the v13 GPU columns, and chartDownsampled dropped the GPU series on ranges over the point cap (blank 24 hr GPU chart).
- 7 new tests: raw round trip, decode fix, minute/hour spike preservation, null-skipping rollups, downsampler max+carry-through, pressure ordering.

Verified: swift build (0 warnings), swift test (464 tests, 0 failures), lint clean, and live on an M3 Pro: thermal rows landing in the app's real history DB every persist tick with plausible values (CPU die 74-79 C under build load, fans off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ