### PR TITLE
Thermal 3/4: Temperature metric in the combined menu bar item

### DIFF
--- a/Sources/MacPerfMonitor/App/CombinedMenuBarConfiguration.swift
+++ b/Sources/MacPerfMonitor/App/CombinedMenuBarConfiguration.swift
@@ -6,6 +6,7 @@ enum MenuBarMetric: String, CaseIterable, Codable, Identifiable {
     case cpu
     case gpu
     case energy
+    case temperature
     case network
     case disk
 
@@ -17,6 +18,7 @@ enum MenuBarMetric: String, CaseIterable, Codable, Identifiable {
         case .cpu: return "CPU"
         case .gpu: return "GPU"
         case .energy: return "Energy"
+        case .temperature: return "Temperature"
         case .network: return "Network"
         case .disk: return "Disk"
         }
@@ -28,6 +30,7 @@ enum MenuBarMetric: String, CaseIterable, Codable, Identifiable {
         case .cpu: return "CPU"
         case .gpu: return "GPU"
         case .energy: return "BAT"
+        case .temperature: return "TMP"
         case .network: return "NET"
         case .disk: return "DSK"
         }
@@ -39,6 +42,7 @@ enum MenuBarMetric: String, CaseIterable, Codable, Identifiable {
         case .cpu: return "cpu"
         case .gpu: return "display"
         case .energy: return "bolt.fill"
+        case .temperature: return "thermometer.medium"
         case .network: return "network"
         case .disk: return "internaldrive"
         }

--- a/Sources/MacPerfMonitor/App/CombinedMenuBarImage.swift
+++ b/Sources/MacPerfMonitor/App/CombinedMenuBarImage.swift
@@ -17,7 +17,7 @@ extension MenuBarMetric {
             ])
         case .cpu:
             return activeKinds.contains(.highCPU)
-        case .gpu, .energy, .network, .disk:
+        case .gpu, .energy, .temperature, .network, .disk:
             return false
         }
     }
@@ -56,6 +56,11 @@ enum CombinedMenuBarReadouts {
             }
             let watts = battery.systemPowerWatts
             return (watts > 0 ? "\(Int(watts.rounded()))W" : "--", nil)
+        case .temperature:
+            // The hottest CPU die sensor; bare degree sign to keep the strip
+            // narrow (the panel spells out the domains and units).
+            let value = (model.liveSystem?.cpuDieC).map { "\(Int($0.rounded()))°" } ?? "--"
+            return (value, nil)
         case .network:
             guard let rates = model.smoothedNetworkRates else { return ("--↓", "--↑") }
             return (
@@ -236,7 +241,13 @@ enum CombinedMenuBarImage {
         let compactValue =
             readout.value.hasSuffix("%") ? String(readout.value.dropLast()) : readout.value
         let value = attributed(compactValue, font: font, color: color)
-        let sampleText = readout.value.hasSuffix("%") ? "100" : "199W"
+        // Width-stability sample per unit family, so a cell never jitters as
+        // digits change: percent readouts size against "100", temperature
+        // against "100°", wattage against "199W".
+        let sampleText =
+            readout.value.hasSuffix("%")
+            ? "100"
+            : readout.value.hasSuffix("°") ? "100°" : "199W"
         let sample = attributed(sampleText, font: font, color: color)
         let width = ceil(max(value.size().width, sample.size().width, label.size().width)) + 1
         return CellLayout(width: width) { x, height in

--- a/Sources/MacPerfMonitor/App/CombinedStatusItemController.swift
+++ b/Sources/MacPerfMonitor/App/CombinedStatusItemController.swift
@@ -296,16 +296,22 @@ final class CombinedStatusItemController: NSObject {
         case .network: return .network
         case .disk: return .disk
         case .gpu: return .gpu
+        case .temperature: return nil
         }
     }
 
     private func reconcileGPUSampling() {
-        let panelLive = popover?.isShown == true && currentPanel == .gpu
+        // Temperature rides the GPU/SMC read path, so a visible temperature
+        // readout or panel keeps that path live exactly like the GPU ones.
+        let panelLive =
+            popover?.isShown == true && (currentPanel == .gpu || currentPanel == .temperature)
         if panelLive != gpuPanelLive {
             gpuPanelLive = panelLive
             if panelLive { model.addGPUConsumer() } else { model.removeGPUConsumer() }
         }
-        let shouldSample = configuration.selectedMetrics.contains(.gpu) || panelLive
+        let shouldSample =
+            configuration.selectedMetrics.contains(.gpu)
+            || configuration.selectedMetrics.contains(.temperature) || panelLive
         guard shouldSample != gpuSamplingActive else { return }
         gpuSamplingActive = shouldSample
         model.setGPUSamplingEnabled(shouldSample)

--- a/Sources/MacPerfMonitor/Charts/TemperatureChart.swift
+++ b/Sources/MacPerfMonitor/Charts/TemperatureChart.swift
@@ -1,12 +1,26 @@
 import MacPerfMonitorCore
 import SwiftUI
 
-/// Shared colors for the thermal surfaces, so the Energy tab and any future
-/// menu bar panel tell the same story.
+/// Shared colors for the thermal surfaces, so the Energy tab and the menu bar
+/// panel tell the same story.
 enum ThermalStyle {
     static let cpu = Color.orange
     static let gpu = Color.red
     static let fan = Color.teal
+}
+
+extension ThermalPressureState {
+    /// Display tint keyed to macOS's verdict, never to a degree threshold: a
+    /// hot number in green is a Mac working as designed; an orange or red one
+    /// is macOS actually slowing work down.
+    var color: Color {
+        switch self {
+        case .nominal: return .green
+        case .fair: return .yellow
+        case .serious: return .orange
+        case .critical: return .red
+        }
+    }
 }
 
 /// CPU and GPU die temperature over the selected window. The thermal fields

--- a/Sources/MacPerfMonitor/Onboarding/OnboardingView.swift
+++ b/Sources/MacPerfMonitor/Onboarding/OnboardingView.swift
@@ -487,6 +487,7 @@ private struct OnboardingMenuBarStep: View {
         case .cpu: return "Total CPU, every core, and top CPU processes."
         case .gpu: return "GPU activity, power, memory, and temperature."
         case .energy: return "Charge, power flow, and top energy users."
+        case .temperature: return "CPU and GPU die temperature, fan speed, and throttling."
         case .network: return "Download, upload, latency, and top network apps."
         case .disk: return "Physical read and write activity, devices, and top processes."
         }

--- a/Sources/MacPerfMonitor/Views/CombinedMenuBarContentView.swift
+++ b/Sources/MacPerfMonitor/Views/CombinedMenuBarContentView.swift
@@ -161,6 +161,8 @@ struct CombinedMenuBarContentView: View {
             NetworkMenuBarContentView(dismiss: dismiss, embedded: true)
         case .disk:
             DiskMenuBarContentView(dismiss: dismiss)
+        case .temperature:
+            TemperatureMenuBarContentView(embedded: true)
         }
     }
 
@@ -242,6 +244,8 @@ struct CombinedMenuBarContentView: View {
         case .disk: return .diskUsage
         case .gpu: return .gpu
         case .pressure: return .dashboard
+        // The Thermals section lives on the Energy tab.
+        case .temperature: return .battery
         }
     }
 

--- a/Sources/MacPerfMonitor/Views/TemperatureMenuBarContentView.swift
+++ b/Sources/MacPerfMonitor/Views/TemperatureMenuBarContentView.swift
@@ -1,0 +1,111 @@
+import Charts
+import MacPerfMonitorCore
+import SwiftUI
+
+/// The Temperature panel in the combined menu bar item: the hottest CPU die
+/// sensor as the headline, tinted by macOS's thermal pressure verdict, a live
+/// sparkline, and the per-domain readings. No process list: temperatures
+/// belong to domains, and the Energy tab's Thermals section holds the history.
+struct TemperatureMenuBarContentView: View {
+    @EnvironmentObject private var model: SamplerModel
+    @EnvironmentObject private var menuClock: MenuClock
+
+    var embedded = false
+
+    var body: some View {
+        _ = menuClock.tick
+        return
+            panel
+            .onAppear { if !embedded { menuClock.open() } }
+            .onDisappear { if !embedded { menuClock.close() } }
+    }
+
+    private var panel: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let system = model.liveSystem, system.cpuDieC != nil {
+                header(system)
+                sparkline
+                Divider()
+                details(system)
+            } else {
+                Text("Reading sensors\u{2026}")
+                    .font(.callout).foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center).padding(.vertical, 8)
+            }
+            if !embedded { MenuVersionFooter() }
+        }
+        .padding(embedded ? 0 : 12)
+        .frame(width: embedded ? nil : 300)
+    }
+
+    private func header(_ system: SystemSample) -> some View {
+        let pressure = system.thermalPressure ?? .nominal
+        return HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text("CPU die").font(.caption).foregroundStyle(.secondary)
+                Text(pressure.isThrottling ? "Throttling (\(pressure.label))" : pressure.label)
+                    .font(.headline)
+                    .foregroundStyle(pressure.isThrottling ? pressure.color : .primary)
+            }
+            Spacer()
+            Text((system.cpuDieC).map { "\(Int($0.rounded()))°C" } ?? "--")
+                .font(.system(.title, design: .rounded).weight(.semibold))
+                .foregroundStyle(pressure.color)
+                .monospacedDigit()
+        }
+    }
+
+    /// The recent CPU die trend from the in-memory system ring, the same
+    /// live-window shape as the GPU panel's utilization sparkline.
+    private var sparkline: some View {
+        let capacity = 60
+        let values = model.systemHistory.elements().suffix(capacity).compactMap(\.cpuDieC)
+        let points = Array(values.enumerated())
+        return Chart(points, id: \.offset) { point in
+            let x = LiveChartGeometry.normalizedSlot(
+                index: point.offset, count: points.count, capacity: capacity)
+            AreaMark(x: .value("t", x), y: .value("c", point.element))
+                .foregroundStyle(ThermalStyle.cpu.opacity(0.18))
+            LineMark(x: .value("t", x), y: .value("c", point.element))
+                .foregroundStyle(ThermalStyle.cpu)
+                .interpolationMethod(.linear)
+        }
+        .chartYScale(domain: 20...sparklineTop)
+        .chartXScale(domain: 0...1)
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .frame(height: 38)
+        .opacity(points.count > 1 ? 1 : 0)
+    }
+
+    private var sparklineTop: Double {
+        let peak = model.systemHistory.elements().suffix(60).compactMap(\.cpuDieC).max() ?? 60
+        return max(60, (peak / 10).rounded(.up) * 10 + 10)
+    }
+
+    private func details(_ system: SystemSample) -> some View {
+        Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 10, verticalSpacing: 5) {
+            if let gpu = system.gpuDieC {
+                detail("GPU die", "\(Int(gpu.rounded()))°C")
+            }
+            if let ssd = system.ssdTemperatureC {
+                detail("SSD", "\(Int(ssd.rounded()))°C")
+            }
+            if system.batteryPresent, system.batteryTemperatureCelsius > 0 {
+                detail("Battery", "\(Int(system.batteryTemperatureCelsius.rounded()))°C")
+            }
+            if let fan = system.fanRPM {
+                detail("Fans", fan == 0 ? "Off" : "\(Int(fan.rounded())) rpm")
+            }
+            detail("Thermal pressure", (system.thermalPressure ?? .nominal).label)
+        }
+    }
+
+    private func detail(_ label: String, _ value: String) -> some View {
+        GridRow {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            Text(value).font(.caption.monospacedDigit()).gridColumnAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+}


### PR DESCRIPTION
Third of the temperature series, building on #23.

- New MenuBarMetric.temperature, opt-in via Settings and onboarding like the other six (no defaults migration: existing users keep their current strip).
- Strip readout: hottest CPU die sensor as "61°", with a "100°" width sample so the cell width never jitters.
- Detail panel: headline CPU die figure tinted by ThermalPressureState (green nominal, yellow fair, orange serious, red critical), a live sparkline from the in-memory system ring, and rows for GPU die, SSD, battery, fans, and the pressure verdict. "Open" routes to the Energy tab's Thermals section.
- reconcileGPUSampling treats a selected temperature metric (or its open panel) as a GPU consumer, so the SMC path stays live with recording off.
- All eight compiler-enforced MenuBarMetric switches extended; no MenuListKind (temperatures have no process list).

Verified: swift build (0 warnings), swift test (464 tests green), lint clean, and visually on an M3 Pro: the live strip renders "RAM 49 CPU 32 GPU 26 TMP 77°" under build load. The panel view compiles and follows the GPU panel's exact structure but its popover interaction was not exercised by automation; worth one manual click before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ