### PR TITLE
Thermal 4/5: throttling event log and sustained-throttling alert

### DIFF
--- a/Sources/MacPerfMonitor/App/CombinedMenuBarImage.swift
+++ b/Sources/MacPerfMonitor/App/CombinedMenuBarImage.swift
@@ -17,7 +17,9 @@ extension MenuBarMetric {
             ])
         case .cpu:
             return activeKinds.contains(.highCPU)
-        case .gpu, .energy, .temperature, .network, .disk:
+        case .temperature:
+            return activeKinds.contains(.thermalThrottle)
+        case .gpu, .energy, .network, .disk:
             return false
         }
     }

--- a/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
@@ -441,6 +441,10 @@ final class SamplerModel: ObservableObject {
     private var cachedPressureEvents: (at: Date, events: [PressureEvent])?
     private let pressureEventsMaxAge: TimeInterval = 15
 
+    /// Thermal throttling events, same derivation shape and TTL rationale as
+    /// the pressure events. Confined to `readQueue`.
+    private var cachedThermalEvents: (at: Date, events: [ThermalEvent])?
+
     /// The Insights evidence series (2 h raw history per leaking process, 30 min
     /// per top consumer). The leak series only changes when the leak board does,
     /// so it is keyed to the board's timestamp; the consumer series get the
@@ -2395,6 +2399,7 @@ final class SamplerModel: ObservableObject {
         cachedSystemHistory.removeAll(keepingCapacity: false)
         cachedRecentSystemHistory.removeAll(keepingCapacity: false)
         cachedPressureEvents = nil
+        cachedThermalEvents = nil
         cachedLeakSeries = nil
         cachedConsumerSeries = nil
     }
@@ -2465,6 +2470,33 @@ final class SamplerModel: ObservableObject {
             let events = self.cachedPressureEvents(store)
             DispatchQueue.main.async { completion(events) }
         }
+    }
+
+    /// Load the thermal throttling events off the main thread, then deliver
+    /// them back on the main thread. Same shape as `loadPressureEvents`.
+    func loadThermalEvents(completion: @escaping ([ThermalEvent]) -> Void) {
+        guard let store else {
+            completion([])
+            return
+        }
+        readQueue.async {
+            let events = self.cachedThermalEvents(store)
+            DispatchQueue.main.async { completion(events) }
+        }
+    }
+
+    /// `thermalEvents` behind the same short TTL as the pressure events. Must
+    /// run on `readQueue`.
+    private func cachedThermalEvents(_ store: SampleStore) -> [ThermalEvent] {
+        if let hit = cachedThermalEvents,
+            Date().timeIntervalSince(hit.at) < pressureEventsMaxAge
+        {
+            return hit.events
+        }
+        let events =
+            (try? store.thermalEvents(bucket: Self.configuredStandardResInterval())) ?? []
+        cachedThermalEvents = (Date(), events)
+        return events
     }
 
     /// `pressureEvents` behind its short TTL (the derivation scans the 2 h raw

--- a/Sources/MacPerfMonitor/Views/BatteryView.swift
+++ b/Sources/MacPerfMonitor/Views/BatteryView.swift
@@ -26,6 +26,9 @@ struct BatteryView: View {
     /// during the silent 5-second refresh of the same range.
     @State private var loadedRange: HistoryWindow?
     @State private var topEnergy: [ProcessConsumer] = []
+    /// Recent thermal throttling events (2 h raw window), shown under the
+    /// Thermals charts. Reloaded with the rest of the tab.
+    @State private var thermalEvents: [ThermalEvent] = []
     /// The flow diagram's app branches: top energy users averaged over a short
     /// (60s) window, so they track recent draw without reshuffling every tick.
     @State private var flowEnergy: [EnergyFlowProcess] = []
@@ -331,6 +334,12 @@ struct BatteryView: View {
                 FanChart(points: points, xDomain: chartDomain)
                     .frame(height: 90)
                     .chartReloading(awaitingData)
+            }
+            if !thermalEvents.isEmpty {
+                Divider().opacity(0.5)
+                ForEach(thermalEvents.prefix(5)) { event in
+                    ThermalEventRow(event: event)
+                }
             }
             footnote(
                 "Each line is the hottest sensor of its domain: CPU die in orange, GPU die in "
@@ -659,6 +668,9 @@ struct BatteryView: View {
         // ranking is live but smoothed rather than jumping every tick. Fetch a few
         // extra (8, shown 5) so the liveness filter still leaves a full set after a
         // recently-quit app is dropped.
+        model.loadThermalEvents { events in
+            self.thermalEvents = events
+        }
         model.loadRecentEnergyConsumers(seconds: 60, limit: 8) { rows in
             withAnimation(.easeInOut(duration: 0.6)) {
                 self.flowEnergy = rows.map {
@@ -668,6 +680,46 @@ struct BatteryView: View {
                 }
             }
         }
+    }
+}
+
+/// One thermal throttling event: when macOS stepped into a throttling state
+/// and which process was working the CPU hardest at that moment.
+private struct ThermalEventRow: View {
+    let event: ThermalEvent
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "thermometer.high")
+                .foregroundStyle(event.state.color)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Throttling began (\(event.state.label.lowercased()))")
+                    .font(.body.weight(.medium))
+                Text(driverLine)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(event.date.formatted(date: .omitted, time: .standard))
+                    .font(.caption.monospacedDigit())
+                Text(event.date.formatted(.relative(presentation: .named)))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    private var driverLine: String {
+        if let name = event.dominantName {
+            return "Top CPU: \(name) (\(Int(event.dominantCPUPercent.rounded()))%)"
+        }
+        return "No dominant process recorded"
     }
 }
 

--- a/Sources/MacPerfMonitor/Views/CombinedMenuBarContentView.swift
+++ b/Sources/MacPerfMonitor/Views/CombinedMenuBarContentView.swift
@@ -144,6 +144,7 @@ struct CombinedMenuBarContentView: View {
         if kinds.contains(.processCeiling) { labels.append("memory ceiling") }
         if kinds.contains(.leak) { labels.append("possible memory leak") }
         if kinds.contains(.highCPU) { labels.append("sustained high CPU") }
+        if kinds.contains(.thermalThrottle) { labels.append("thermal throttling") }
         return labels.joined(separator: " · ")
     }
 

--- a/Sources/MacPerfMonitor/Views/SettingsView.swift
+++ b/Sources/MacPerfMonitor/Views/SettingsView.swift
@@ -284,6 +284,15 @@ private struct AlertsSettingsView: View {
             }
 
             Section {
+                Toggle("Thermal throttling", isOn: $alertSettings.config.thermalEnabled)
+                caption(
+                    "Notify when macOS keeps slowing work down to shed heat, naming the process "
+                        + "using the most CPU at that moment.")
+            } header: {
+                Text("Thermal Throttling")
+            }
+
+            Section {
                 Toggle("Heavy swap use", isOn: $alertSettings.config.swapEnabled)
                 if alertSettings.config.swapEnabled {
                     gigabyteStepper(

--- a/Sources/MacPerfMonitorCore/Analysis/AlertEngine.swift
+++ b/Sources/MacPerfMonitorCore/Analysis/AlertEngine.swift
@@ -21,6 +21,10 @@ public struct AlertConfig: Sendable, Equatable, Codable {
     public var highGPUThresholdPercent: Int
     /// Total-CPU threshold (percent of capacity, 0...100) for the high-CPU alert.
     public var highCPUThresholdPercent: Int
+    /// Notify when macOS's thermal pressure stays at serious or critical (the
+    /// throttling states) for a sustained period, naming the top CPU process.
+    /// Off by default: fanless Macs throttle routinely under real work.
+    public var thermalEnabled: Bool
 
     public init(
         criticalPressureEnabled: Bool = true,
@@ -32,7 +36,8 @@ public struct AlertConfig: Sendable, Equatable, Codable {
         highCPUEnabled: Bool = false,
         highCPUThresholdPercent: Int = 85,
         highGPUEnabled: Bool = false,
-        highGPUThresholdPercent: Int = 85
+        highGPUThresholdPercent: Int = 85,
+        thermalEnabled: Bool = false
     ) {
         self.criticalPressureEnabled = criticalPressureEnabled
         self.swapEnabled = swapEnabled
@@ -44,6 +49,7 @@ public struct AlertConfig: Sendable, Equatable, Codable {
         self.highCPUThresholdPercent = highCPUThresholdPercent
         self.highGPUEnabled = highGPUEnabled
         self.highGPUThresholdPercent = highGPUThresholdPercent
+        self.thermalEnabled = thermalEnabled
     }
 
     /// Decode every field with a default so a config saved by an older build
@@ -75,6 +81,8 @@ public struct AlertConfig: Sendable, Equatable, Codable {
         highGPUThresholdPercent =
             try c.decodeIfPresent(Int.self, forKey: .highGPUThresholdPercent)
             ?? d.highGPUThresholdPercent
+        thermalEnabled =
+            try c.decodeIfPresent(Bool.self, forKey: .thermalEnabled) ?? d.thermalEnabled
     }
 
     public static let `default` = AlertConfig()
@@ -91,6 +99,7 @@ public struct Alert: Sendable, Equatable, Identifiable {
         case leak
         case highCPU
         case highGPU
+        case thermalThrottle
     }
 
     public var kind: Kind
@@ -117,6 +126,7 @@ public struct Alert: Sendable, Equatable, Identifiable {
         case .leak: return "leak.\(identityKey)"
         case .highCPU: return "cpu.high"
         case .highGPU: return "gpu.high"
+        case .thermalThrottle: return "thermal.throttle"
         }
     }
 
@@ -156,6 +166,12 @@ public final class AlertEngine {
     private var highCPUSince: Date?
     private var gpuArmed = true
     private var highGPUSince: Date?
+    private var thermalArmed = true
+    /// When thermal pressure first reached a throttling state in the current
+    /// spell; nil while nominal or fair. Thermal state moves slowly, so the
+    /// sustain window is longer than CPU's to skip brief excursions.
+    private var throttlingSince: Date?
+    private let sustainedThermalDuration: TimeInterval = 30
     /// Last delivery time per alert id, used to suppress re-fires inside the
     /// cooldown window. Recorded only for alerts that survive the throttle, so
     /// a sustained flap cannot slide the window forward and starve the later
@@ -195,6 +211,7 @@ public final class AlertEngine {
             processes, leakingProcesses: leakingProcesses, config: config, now: now, into: &alerts)
         evaluateCPU(cpu, config: config, now: now, into: &alerts)
         evaluateGPU(gpu, config: config, now: now, into: &alerts)
+        evaluateThermal(system, processes: processes, config: config, now: now, into: &alerts)
         refreshActiveKinds()
         // Throttle notification delivery per alert id: drop any alert whose id
         // was already delivered inside the cooldown window. The armed flags
@@ -224,6 +241,8 @@ public final class AlertEngine {
         highCPUSince = nil
         gpuArmed = true
         highGPUSince = nil
+        thermalArmed = true
+        throttlingSince = nil
         lastFiredAt.removeAll()
         activeKinds.removeAll()
     }
@@ -236,6 +255,7 @@ public final class AlertEngine {
         if !leakFired.isEmpty { kinds.insert(.leak) }
         if !cpuArmed { kinds.insert(.highCPU) }
         if !gpuArmed { kinds.insert(.highGPU) }
+        if !thermalArmed { kinds.insert(.thermalThrottle) }
         activeKinds = kinds
     }
 
@@ -428,6 +448,45 @@ public final class AlertEngine {
         } else {
             highGPUSince = nil
             if percent < threshold * rearmFraction { gpuArmed = true }
+        }
+    }
+
+    /// Fire once when macOS's thermal pressure has stayed at a throttling
+    /// state (serious or critical) for a sustained period, naming the top CPU
+    /// consumer at that moment. The states are discrete, so re-arming is a
+    /// plain drop back to fair-or-better rather than a threshold fraction.
+    private func evaluateThermal(
+        _ system: SystemSample, processes: [ProcessSample], config: AlertConfig, now: Date,
+        into alerts: inout [Alert]
+    ) {
+        guard config.thermalEnabled, let pressure = system.thermalPressure else {
+            thermalArmed = true
+            throttlingSince = nil
+            return
+        }
+        if pressure.isThrottling {
+            let since = throttlingSince ?? now
+            throttlingSince = since
+            if thermalArmed && now.timeIntervalSince(since) >= sustainedThermalDuration {
+                thermalArmed = false
+                let top = Ranking.topByCPU(processes, limit: 1).first
+                var body =
+                    "macOS is slowing work down to shed heat (thermal pressure \(pressure.label.lowercased()))."
+                if let top {
+                    let percent = Int(top.cpuPercent.rounded())
+                    body += " Top CPU: \(top.displayName) at \(percent)%."
+                }
+                alerts.append(
+                    Alert(
+                        kind: .thermalThrottle,
+                        title: "Thermal throttling",
+                        body: body,
+                        identity: top?.id,
+                        date: now))
+            }
+        } else {
+            throttlingSince = nil
+            thermalArmed = true
         }
     }
 }

--- a/Sources/MacPerfMonitorCore/Persistence/ThermalEvents.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/ThermalEvents.swift
@@ -1,0 +1,126 @@
+import Foundation
+import GRDB
+
+/// A moment when macOS's thermal pressure stepped up into serious or critical
+/// (the throttling states), with the process that was the largest CPU consumer
+/// at that instant. The CPU attribution is the actionable half: "my fans are
+/// loud" almost always ends at a process name.
+public struct ThermalEvent: Sendable, Identifiable, Equatable {
+    public var date: Date
+    /// The state pressure rose into (serious or critical).
+    public var state: ThermalPressureState
+    public var dominantIdentity: ProcessIdentity?
+    public var dominantName: String?
+    /// CPU share of the dominant process at the event (Activity Monitor
+    /// convention: percent of one core, so multi-threaded work exceeds 100).
+    public var dominantCPUPercent: Double
+
+    public var id: Date { date }
+
+    public init(
+        date: Date,
+        state: ThermalPressureState,
+        dominantIdentity: ProcessIdentity?,
+        dominantName: String?,
+        dominantCPUPercent: Double
+    ) {
+        self.date = date
+        self.state = state
+        self.dominantIdentity = dominantIdentity
+        self.dominantName = dominantName
+        self.dominantCPUPercent = dominantCPUPercent
+    }
+}
+
+extension SampleStore {
+    /// Thermal throttling events in the window, most recent first. An event is
+    /// recorded each time the thermal pressure state steps up into
+    /// serious-or-higher. The dominant process is the largest CPU consumer
+    /// logged as of the event's tick, with the same carry-forward-within-one-
+    /// heartbeat-bucket attribution as `pressureEvents` (process rows are
+    /// change-gated, so most processes have no row at the exact event second;
+    /// the staleness bound keeps dead processes from being crowned). Like
+    /// pressure events, the window is clamped to raw retention.
+    public func thermalEvents(
+        window: TimeInterval = 2 * 3600, bucket: TimeInterval = 60, now: Date = Date()
+    ) throws -> [ThermalEvent] {
+        let since = now.addingTimeInterval(-min(window, 2 * 3600))
+        return try databasePool.read { db in
+            let sampleRows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT timestamp, thermal_state FROM system_samples
+                    WHERE timestamp >= ? AND thermal_state IS NOT NULL
+                    ORDER BY timestamp ASC
+                    """, arguments: [since.timeIntervalSince1970])
+            var steps: [(ts: Double, state: ThermalPressureState)] = []
+            var previous: ThermalPressureState?
+            for row in sampleRows {
+                guard let state = ThermalPressureState(rawValue: row[1]) else { continue }
+                let ts: Double = row[0]
+                if let prev = previous, state > prev, state.isThrottling {
+                    steps.append((ts, state))
+                }
+                previous = state
+            }
+            guard !steps.isEmpty else { return [] }
+
+            let lastStepTs = steps.map(\.ts).max() ?? since.timeIntervalSince1970
+            let procRows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT ps.timestamp AS ts, p.pid AS pid, p.start_time AS pstart,
+                           p.name AS name, ps.cpu_percent AS cpu
+                    FROM process_samples ps
+                    JOIN processes p ON p.id = ps.process_id
+                    WHERE ps.timestamp >= ? AND ps.timestamp <= ?
+                    ORDER BY ps.timestamp ASC
+                    """, arguments: [since.timeIntervalSince1970, lastStepTs])
+
+            struct Carried {
+                var ts: Double
+                var cpu: Double
+                var name: String
+            }
+            var current: [ProcessIdentity: Carried] = [:]
+            var dominantByTS: [Double: (identity: ProcessIdentity, name: String, cpu: Double)] =
+                [:]
+            var ri = 0
+            let staleWindow = max(bucket, 1)
+            for step in steps {
+                while ri < procRows.count, (procRows[ri]["ts"] as Double) <= step.ts {
+                    let pid: Int32 = procRows[ri]["pid"]
+                    let start: Double = procRows[ri]["pstart"]
+                    let id = ProcessIdentity(
+                        pid: pid, startTime: Date(timeIntervalSince1970: start))
+                    current[id] = Carried(
+                        ts: procRows[ri]["ts"], cpu: procRows[ri]["cpu"],
+                        name: procRows[ri]["name"])
+                    ri += 1
+                }
+                let floorTs = step.ts - staleWindow
+                var best: (identity: ProcessIdentity, name: String, cpu: Double)?
+                for (id, c) in current where c.ts >= floorTs {
+                    if best == nil || c.cpu > best!.cpu {
+                        best = (identity: id, name: c.name, cpu: c.cpu)
+                    }
+                }
+                dominantByTS[step.ts] = best
+            }
+
+            return
+                steps
+                .map { step in
+                    let dominant = dominantByTS[step.ts]
+                    return ThermalEvent(
+                        date: Date(timeIntervalSince1970: step.ts),
+                        state: step.state,
+                        dominantIdentity: dominant?.identity,
+                        dominantName: dominant?.name,
+                        dominantCPUPercent: dominant?.cpu ?? 0
+                    )
+                }
+                .sorted { $0.date > $1.date }
+        }
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/ThermalEventsTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/ThermalEventsTests.swift
@@ -1,0 +1,175 @@
+import GRDB
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class ThermalEventsTests: XCTestCase {
+    private var tempURL: URL!
+    private var store: SampleStore!
+
+    private let startTime = Date(timeIntervalSince1970: 1_000_000)
+
+    override func setUpWithError() throws {
+        tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macperfmonitor-tevents-\(UUID().uuidString).sqlite")
+        store = try SampleStore(url: tempURL)
+    }
+
+    override func tearDownWithError() throws {
+        store = nil
+        try? FileManager.default.removeItem(at: tempURL)
+        try? FileManager.default.removeItem(at: tempURL.appendingPathExtension("wal"))
+        try? FileManager.default.removeItem(at: tempURL.appendingPathExtension("shm"))
+    }
+
+    private func insertTick(_ timestamp: Date, state: ThermalPressureState?) throws {
+        let burner = Make.process(
+            timestamp: timestamp, pid: 1000, startTime: startTime, name: "Burner", cpu: 312)
+        let idle = Make.process(
+            timestamp: timestamp, pid: 2000, startTime: startTime, name: "Idle", cpu: 2)
+        var system = Make.system(timestamp: timestamp, pressurePercent: 10)
+        system.thermalPressure = state
+        try store.insert(
+            Sampler.Snapshot(system: system, processes: [burner, idle], unreadableProcessCount: 0))
+    }
+
+    /// Events are recorded on each upward step into a throttling state,
+    /// attributed to the top CPU process, most recent first.
+    func testThermalEventsRecordThrottleStepsWithTopCPUProcess() throws {
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        try insertTick(base, state: .nominal)
+        try insertTick(base.addingTimeInterval(2), state: .fair)  // not throttling: no event
+        try insertTick(base.addingTimeInterval(4), state: .serious)  // event
+        try insertTick(base.addingTimeInterval(6), state: .serious)  // no step
+        try insertTick(base.addingTimeInterval(8), state: .critical)  // event
+
+        let events = try store.thermalEvents(now: base.addingTimeInterval(8))
+
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events[0].date, base.addingTimeInterval(8))
+        XCTAssertEqual(events[0].state, .critical)
+        XCTAssertEqual(events[0].dominantName, "Burner")
+        XCTAssertEqual(events[0].dominantCPUPercent, 312, accuracy: 0.001)
+        XCTAssertEqual(events[1].state, .serious)
+    }
+
+    /// A recovery followed by a new climb is a fresh event; ticks with no
+    /// recorded state (older builds) neither step nor reset the tracker.
+    func testRecoveryRearmsAndNilStatesAreSkipped() throws {
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        try insertTick(base, state: .serious)  // first sample: no previous, no event
+        try insertTick(base.addingTimeInterval(2), state: .nominal)
+        try insertTick(base.addingTimeInterval(4), state: nil)
+        try insertTick(base.addingTimeInterval(6), state: .serious)  // event
+
+        let events = try store.thermalEvents(now: base.addingTimeInterval(6))
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].date, base.addingTimeInterval(6))
+    }
+
+    func testNoEventsWhenNeverThrottling() throws {
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        try insertTick(base, state: .nominal)
+        try insertTick(base.addingTimeInterval(2), state: .fair)
+        try insertTick(base.addingTimeInterval(4), state: .nominal)
+        XCTAssertTrue(try store.thermalEvents(now: base.addingTimeInterval(4)).isEmpty)
+    }
+}
+
+// MARK: - Sustained thermal alert
+
+final class ThermalAlertTests: XCTestCase {
+    private func system(_ state: ThermalPressureState?, at date: Date) -> SystemSample {
+        var sample = Make.system(timestamp: date, pressurePercent: 10)
+        sample.thermalPressure = state
+        return sample
+    }
+
+    private func burner(at date: Date) -> ProcessSample {
+        Make.process(timestamp: date, pid: 42, name: "Burner", cpu: 250)
+    }
+
+    func testThermalAlertFiresOnlyAfterSustainedThrottlingThenRearms() {
+        let engine = AlertEngine(refireCooldown: 0)
+        let config = AlertConfig(thermalEnabled: true)
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // Serious, but not yet sustained: no alert, though the kind is not
+        // active either (armed until fired).
+        var fired = engine.evaluate(
+            system: system(.serious, at: base), processes: [burner(at: base)], config: config,
+            now: base)
+        XCTAssertTrue(fired.isEmpty)
+
+        // Still serious 30 s later: fires once, naming the top CPU process.
+        let sustained = base.addingTimeInterval(30)
+        fired = engine.evaluate(
+            system: system(.serious, at: sustained), processes: [burner(at: sustained)],
+            config: config, now: sustained)
+        XCTAssertEqual(fired.count, 1)
+        XCTAssertEqual(fired[0].kind, .thermalThrottle)
+        XCTAssertEqual(fired[0].id, "thermal.throttle")
+        XCTAssertTrue(fired[0].body.contains("Burner"))
+        XCTAssertNotNil(fired[0].identity)
+        XCTAssertTrue(engine.activeKinds.contains(.thermalThrottle))
+
+        // Continuing to throttle does not re-fire.
+        let later = sustained.addingTimeInterval(10)
+        fired = engine.evaluate(
+            system: system(.critical, at: later), processes: [burner(at: later)], config: config,
+            now: later)
+        XCTAssertTrue(fired.isEmpty)
+
+        // Recovery clears the active kind and re-arms; a new sustained spell
+        // fires again.
+        let recovered = later.addingTimeInterval(10)
+        _ = engine.evaluate(
+            system: system(.nominal, at: recovered), processes: [], config: config, now: recovered)
+        XCTAssertFalse(engine.activeKinds.contains(.thermalThrottle))
+        let again = recovered.addingTimeInterval(10)
+        _ = engine.evaluate(
+            system: system(.serious, at: again), processes: [], config: config, now: again)
+        let againSustained = again.addingTimeInterval(30)
+        fired = engine.evaluate(
+            system: system(.serious, at: againSustained), processes: [], config: config,
+            now: againSustained)
+        XCTAssertEqual(fired.count, 1)
+    }
+
+    /// A brief excursion into serious never alerts, and fair never counts as
+    /// throttling at all.
+    func testBriefOrFairThrottlingStaysQuiet() {
+        let engine = AlertEngine(refireCooldown: 0)
+        let config = AlertConfig(thermalEnabled: true)
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+        _ = engine.evaluate(
+            system: system(.serious, at: base), processes: [], config: config, now: base)
+        // Back to nominal before the sustain window elapses.
+        let recovered = base.addingTimeInterval(10)
+        var fired = engine.evaluate(
+            system: system(.nominal, at: recovered), processes: [], config: config, now: recovered)
+        XCTAssertTrue(fired.isEmpty)
+
+        // Fair for minutes: still quiet.
+        var t = recovered
+        for _ in 0..<10 {
+            t = t.addingTimeInterval(30)
+            fired = engine.evaluate(
+                system: system(.fair, at: t), processes: [], config: config, now: t)
+            XCTAssertTrue(fired.isEmpty)
+        }
+        XCTAssertFalse(engine.activeKinds.contains(.thermalThrottle))
+    }
+
+    func testThermalAlertDisabledByDefault() {
+        let engine = AlertEngine(refireCooldown: 0)
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        _ = engine.evaluate(system: system(.critical, at: base), processes: [], now: base)
+        let sustained = base.addingTimeInterval(60)
+        let fired = engine.evaluate(
+            system: system(.critical, at: sustained), processes: [], now: sustained)
+        XCTAssertTrue(fired.isEmpty)
+        XCTAssertFalse(engine.activeKinds.contains(.thermalThrottle))
+    }
+}


### PR DESCRIPTION
Fourth of the temperature series, building on #24.

- ThermalEvent + SampleStore.thermalEvents(window:bucket:now:): upward steps into serious/critical, attributed to the top CPU process with the pressureEvents carry-forward rule. Listed (latest 5) under the Energy tab's Thermals charts with state, process, CPU share, and time.
- AlertConfig.thermalEnabled (off by default), Alert.Kind.thermalThrottle, and an evaluateThermal modeled on the sustained-GPU evaluator: fires once after 30 s of sustained throttling, names and attaches the top CPU process, re-arms on recovery to fair or better. Old saved configs decode with the default.
- Settings gains a Thermal Throttling section; the temperature menu bar readout goes into its alarm treatment while the condition is active, and the combined panel's alarm line says "thermal throttling".
- 6 new tests: event derivation with attribution, recovery re-arm and nil-state skipping, quiet when never throttling, sustained-fire-once-then-rearm, brief/fair spells stay quiet, disabled by default.

Verified: swift build (0 warnings), swift test (470 tests, 0 failures), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ