### PR TITLE
Thermal 5/6: system Temperature chart in the Analytics grid

### DIFF
--- a/Sources/MacPerfMonitor/Charts/PerfSeriesBuilder.swift
+++ b/Sources/MacPerfMonitor/Charts/PerfSeriesBuilder.swift
@@ -171,7 +171,7 @@ enum PerfSeriesBuilder {
     ) -> [PerfMetric: [PerfPoint]]? {
         guard bucketWidth > 0, points.count > 2 else {
             return Dictionary(
-                uniqueKeysWithValues: PerfMetric.allCases.map {
+                uniqueKeysWithValues: PerfMetric.processMetrics.map {
                     ($0, $0.points(from: points))
                 })
         }
@@ -262,6 +262,8 @@ enum PerfSeriesBuilder {
                 } else {
                     value = nil
                 }
+            case .dieTemperature:
+                value = nil
             }
             if let value { accumulator.append(PerfPoint(date: date, value: value)) }
             previous = point
@@ -311,6 +313,8 @@ enum PerfSeriesBuilder {
                 } else {
                     value = nil
                 }
+            case .dieTemperature:
+                value = nil
             }
             previous = point
 

--- a/Sources/MacPerfMonitor/Export/TraceExport.swift
+++ b/Sources/MacPerfMonitor/Export/TraceExport.swift
@@ -77,7 +77,7 @@ final class TraceProjectionWorker: @unchecked Sendable {
                 uniqueKeysWithValues: document.processes.map { ($0.identity, $0) })
 
             var grid: [PerfMetric: [TracePreparedSeries]] = Dictionary(
-                uniqueKeysWithValues: PerfMetric.allCases.map { ($0, []) })
+                uniqueKeysWithValues: PerfMetric.processMetrics.map { ($0, []) })
             var focused: [TracePreparedSeries] = []
             var stats: [TracePreparedStat] = []
             let visibleSpan = domain.upperBound.timeIntervalSince(domain.lowerBound)
@@ -116,7 +116,7 @@ final class TraceProjectionWorker: @unchecked Sendable {
                         let projected = PerfSeriesBuilder.traceDownsampled(
                             slice, bucketWidth: width, isCancelled: cancelled)
                     else { return }
-                    for metric in PerfMetric.allCases {
+                    for metric in PerfMetric.processMetrics {
                         guard let points = projected[metric], !points.isEmpty else { continue }
                         grid[metric, default: []].append(
                             TracePreparedSeries(
@@ -191,11 +191,11 @@ struct TraceViewerPreparation: Sendable {
             fullDomain.upperBound.timeIntervalSince(fullDomain.lowerBound)
             / Double(Self.maximumGridPoints)
         var prepared: [PerfMetric: [TracePreparedSeries]] = Dictionary(
-            uniqueKeysWithValues: PerfMetric.allCases.map { ($0, []) })
+            uniqueKeysWithValues: PerfMetric.processMetrics.map { ($0, []) })
         for series in document.processes where activeSet.contains(series.identity) {
             let projected = PerfSeriesBuilder.traceDownsampled(
                 series.points[...], bucketWidth: width)
-            for metric in PerfMetric.allCases {
+            for metric in PerfMetric.processMetrics {
                 guard let points = projected[metric], !points.isEmpty else { continue }
                 prepared[metric, default: []].append(
                     TracePreparedSeries(

--- a/Sources/MacPerfMonitor/Views/PerformanceMetric.swift
+++ b/Sources/MacPerfMonitor/Views/PerformanceMetric.swift
@@ -10,8 +10,15 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
     case network
     case fileDescriptors
     case diskIO
+    case dieTemperature
 
     var id: String { rawValue }
+
+    /// The per-process metrics. `dieTemperature` is a system-wide series (CPU
+    /// and GPU die, the whole Mac): its cell charts system history rather than
+    /// the selected processes, so trace export/import and every per-process
+    /// loop iterate this list instead of `allCases`.
+    static let processMetrics: [PerfMetric] = [.memory, .cpu, .network, .fileDescriptors, .diskIO]
 
     var label: String {
         switch self {
@@ -20,6 +27,7 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
         case .network: return "Network"
         case .fileDescriptors: return "File descriptors"
         case .diskIO: return "Disk I/O"
+        case .dieTemperature: return "Temperature"
         }
     }
 
@@ -31,6 +39,7 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
         case .network: return "Network"
         case .fileDescriptors: return "Files"
         case .diskIO: return "Disk"
+        case .dieTemperature: return "Temp"
         }
     }
 
@@ -41,6 +50,7 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
         case .network: return "network"
         case .fileDescriptors: return "doc.on.doc"
         case .diskIO: return "internaldrive"
+        case .dieTemperature: return "thermometer.medium"
         }
     }
 
@@ -52,6 +62,7 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
         case .network: return "Download + upload throughput (per-app tracking required)"
         case .fileDescriptors: return "Open files, sockets, and pipes"
         case .diskIO: return "Read + write throughput between ticks"
+        case .dieTemperature: return "CPU and GPU die, hottest sensor (whole Mac)"
         }
     }
 
@@ -65,6 +76,9 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
         case .network: return 1
         case .fileDescriptors: return 10
         case .diskIO: return 1
+        // Die sensors idle in the 30s to 50s; a 60 floor keeps a cool Mac's
+        // line low in the plot instead of auto-fit magnifying idle noise.
+        case .dieTemperature: return 60
         }
     }
 
@@ -82,6 +96,8 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
             return String(format: "%.0f", v)
         case .diskIO:
             return "\(ByteFormat.string(Self.clampedByteCount(v)))/s"
+        case .dieTemperature:
+            return String(format: "%.0f°C", v)
         }
     }
 
@@ -124,6 +140,10 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
                 out.append(PerfPoint(date: cur.date, value: (readDelta + writeDelta) / dt))
             }
             return out
+        case .dieTemperature:
+            // System metric: its series come from system history, never from a
+            // per-process projection.
+            return []
         }
     }
 
@@ -170,6 +190,8 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
                 previous = point
             }
             return output
+        case .dieTemperature:
+            return []
         }
     }
 
@@ -182,6 +204,7 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
         case .network: return s.networkBytesPerSec
         case .fileDescriptors: return Double(s.fdTotal)
         case .diskIO: return Double(s.diskBytesRead &+ s.diskBytesWritten)
+        case .dieTemperature: return 0
         }
     }
 
@@ -193,6 +216,7 @@ enum PerfMetric: String, CaseIterable, Identifiable, Sendable {
         case .network: return ByteFormat.rate(s.networkBytesPerSec)
         case .fileDescriptors: return "\(s.fdTotal)"
         case .diskIO: return ByteFormat.string(s.diskBytesRead &+ s.diskBytesWritten)
+        case .dieTemperature: return ""
         }
     }
 }

--- a/Sources/MacPerfMonitor/Views/PerformanceMonitorView.swift
+++ b/Sources/MacPerfMonitor/Views/PerformanceMonitorView.swift
@@ -46,6 +46,10 @@ struct PerformanceMonitorView: View {
     /// Raw per-process points backing every metric; the chart derives the
     /// selected metric (and the disk rate) from these on the fly.
     @State private var rawSeries: [ProcessIdentity: [ProcessHistoryPoint]] = [:]
+    /// System history backing the temperature cell (CPU and GPU die). Loaded
+    /// alongside the per-process series for the same span; on aggregate spans
+    /// the points carry the bucket max, so zoomed-out charts keep the spikes.
+    @State private var thermalHistory: [SystemHistoryPoint] = []
 
     /// The chart-ready series per metric, rebuilt only when the underlying data
     /// changes (`rebuildChartSeries()`), never during a body evaluation. Deriving
@@ -222,7 +226,8 @@ struct PerformanceMonitorView: View {
         VStack(spacing: 12) {
             if trackPerAppNetwork {
                 // Per-app network is on, so the per-process network chart is
-                // meaningful: a 3 + 2 grid with a filler to keep cells equal width.
+                // meaningful: a 3 + 3 grid, with the temperature cell (when the
+                // machine has thermal data) taking the filler slot.
                 HStack(spacing: 12) {
                     metricCell(.memory)
                     metricCell(.cpu)
@@ -231,11 +236,16 @@ struct PerformanceMonitorView: View {
                 HStack(spacing: 12) {
                     metricCell(.fileDescriptors)
                     metricCell(.diskIO)
-                    Color.clear.frame(maxWidth: .infinity, maxHeight: .infinity)
+                    if showsThermalCell {
+                        metricCell(.dieTemperature)
+                    } else {
+                        Color.clear.frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
                 }
             } else {
                 // Without per-app data the network chart would be a flat zero, so
-                // omit it and keep the original 2 x 2 grid.
+                // omit it and keep the 2-wide grid, with temperature (when
+                // present) on its own row.
                 HStack(spacing: 12) {
                     metricCell(.memory)
                     metricCell(.cpu)
@@ -243,6 +253,12 @@ struct PerformanceMonitorView: View {
                 HStack(spacing: 12) {
                     metricCell(.fileDescriptors)
                     metricCell(.diskIO)
+                }
+                if showsThermalCell {
+                    HStack(spacing: 12) {
+                        metricCell(.dieTemperature)
+                        Color.clear.frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
                 }
             }
         }
@@ -952,6 +968,11 @@ struct PerformanceMonitorView: View {
         let domain = visibleDomain
         let visibleSpan = domain.upperBound.timeIntervalSince(domain.lowerBound)
         let bucketWidth = visibleSpan / Double(Self.maxPointsFocused)
+        if metric == .dieTemperature {
+            focusedSeries = thermalSeries(domain: domain, bucketWidth: bucketWidth)
+            rebuildFocusedStats()
+            return
+        }
         let detail = activeDetail
         focusedSeries = selected.compactMap {
             buildSeries(
@@ -1064,15 +1085,70 @@ struct PerformanceMonitorView: View {
         let bucketWidth = visibleSpan / Double(Self.maxPointsPerSeries)
         let detail = activeDetail
         var result: [PerfMetric: [PerfSeries]] = [:]
-        for metric in PerfMetric.allCases {
+        for metric in PerfMetric.processMetrics {
             result[metric] = selected.compactMap {
                 buildSeries(
                     id: $0, metric: metric, domain: domain,
                     bucketWidth: bucketWidth, detail: detail)
             }
         }
+        result[.dieTemperature] = thermalSeries(domain: domain, bucketWidth: bucketWidth)
         seriesByMetric = result
         rebuildFocusedSeries()
+    }
+
+    // MARK: - System temperature series
+
+    /// Synthetic identities for the two system series, so the temperature cell
+    /// rides the same `PerfSeries` machinery (colors, scrubbing, focus, stats)
+    /// as the per-process charts. Negative pids cannot collide with a real
+    /// process.
+    private static let cpuDieIdentity = ProcessIdentity(
+        pid: -1, startTime: Date(timeIntervalSince1970: 0))
+    private static let gpuDieIdentity = ProcessIdentity(
+        pid: -2, startTime: Date(timeIntervalSince1970: 0))
+
+    private func thermalSeries(
+        domain: ClosedRange<Date>, bucketWidth: TimeInterval
+    ) -> [PerfSeries] {
+        func series(
+            _ id: ProcessIdentity, _ name: String, _ color: Color,
+            _ value: (SystemHistoryPoint) -> Double?
+        ) -> PerfSeries? {
+            let points = PerfSeriesBuilder.downsample(
+                thermalPoints(in: domain, value: value), bucketWidth: bucketWidth)
+            guard !points.isEmpty else { return nil }
+            return PerfSeries(id: id, name: name, color: color, points: points)
+        }
+        return [
+            series(Self.cpuDieIdentity, "CPU die", ThermalStyle.cpu) { $0.cpuDieC },
+            series(Self.gpuDieIdentity, "GPU die", ThermalStyle.gpu) { $0.gpuDieC },
+        ].compactMap { $0 }
+    }
+
+    /// The thermal points inside `domain` with one sample of edge padding on
+    /// each side, so lines extend past the plot edges like the process series.
+    private func thermalPoints(
+        in domain: ClosedRange<Date>, value: (SystemHistoryPoint) -> Double?
+    ) -> [PerfPoint] {
+        let all = thermalHistory.compactMap { point in
+            value(point).map { PerfPoint(date: point.date, value: $0) }
+        }
+        guard !all.isEmpty else { return [] }
+        var first = all.startIndex
+        while first < all.endIndex, all[first].date < domain.lowerBound { first += 1 }
+        var last = all.endIndex - 1
+        while last >= all.startIndex, all[last].date > domain.upperBound { last -= 1 }
+        let paddedFirst = max(all.startIndex, first - 1)
+        let paddedLast = min(all.endIndex - 1, last + 1)
+        guard paddedFirst <= paddedLast else { return [] }
+        return Array(all[paddedFirst...paddedLast])
+    }
+
+    /// True once any thermal sample exists in the loaded window, so Macs with
+    /// no readable SMC (or pre-thermal databases) keep the original grid.
+    private var showsThermalCell: Bool {
+        !(seriesByMetric[.dieTemperature] ?? []).isEmpty
     }
 
     /// Slice one process's backing points to `domain` (preferring the fetched
@@ -1120,6 +1196,22 @@ struct PerformanceMonitorView: View {
             return
         }
         let domain = visibleDomain
+        if metric == .dieTemperature {
+            typealias ThermalSource = (
+                id: ProcessIdentity, name: String, color: Color,
+                value: (SystemHistoryPoint) -> Double?
+            )
+            let sources: [ThermalSource] = [
+                (Self.cpuDieIdentity, "CPU die", ThermalStyle.cpu, { $0.cpuDieC }),
+                (Self.gpuDieIdentity, "GPU die", ThermalStyle.gpu, { $0.gpuDieC }),
+            ]
+            focusedStats = sources.compactMap { id, name, color, value in
+                let points = thermalPoints(in: domain, value: value)
+                    .filter { domain.contains($0.date) }
+                return SeriesStat(points: points, id: id, name: name, color: color)
+            }
+            return
+        }
         let detail = activeDetail
         focusedStats = selected.compactMap { id in
             let points = windowPoints(id: id, metric: metric, domain: domain, detail: detail)
@@ -1132,6 +1224,7 @@ struct PerformanceMonitorView: View {
 
     private func reload(spinner: Bool = false) {
         now = latestSampleDate
+        reloadThermal()
         if span.isLive {
             // Seed immediately from the in-memory trail so there is something to
             // draw at once...
@@ -1196,11 +1289,47 @@ struct PerformanceMonitorView: View {
         }
     }
 
+    /// Load the system history behind the temperature cell for the active span.
+    /// The live span reads the raw store (persistence may lag the newest tick;
+    /// `appendTick` stitches the live edge on top either way).
+    private func reloadThermal() {
+        let requested = span
+        if let window = requested.window {
+            model.loadSystemHistory(window, downsampledTo: nil) { points in
+                guard requested == self.span else { return }
+                self.thermalHistory = points
+                self.rebuildChartSeries()
+            }
+        } else {
+            model.loadRecentSystemHistory(seconds: requested.seconds + 30) { points in
+                guard requested == self.span else { return }
+                self.thermalHistory = points
+                self.rebuildChartSeries()
+            }
+        }
+    }
+
     /// Append the current live sample of each selected process to the right edge
     /// of its series, trimming to the active window. Drives both the live stream
     /// and the fresh right edge of the historical spans between reloads.
     private func appendTick() {
         var changed = false
+        if let live = model.liveSystem, live.cpuDieC != nil,
+            thermalHistory.last.map({ live.timestamp > $0.date }) ?? true
+        {
+            var point = SystemHistoryPoint(
+                date: live.timestamp, pressurePercent: live.pressurePercent,
+                appMemory: live.appMemory, wired: live.wired, compressed: live.compressed,
+                cachedFiles: live.cachedFiles, swapUsed: live.swapUsed)
+            point.cpuDieC = live.cpuDieC
+            point.gpuDieC = live.gpuDieC
+            let cutoff = now.addingTimeInterval(-span.seconds)
+            thermalHistory.append(point)
+            if thermalHistory.first.map({ $0.date < cutoff }) ?? false {
+                thermalHistory.removeAll { $0.date < cutoff }
+            }
+            changed = true
+        }
         for id in selected {
             // Read the newest point from the in-memory trail, which advances at the
             // scan cadence (~high-res), not `latest.processes` (the coarser table


### PR DESCRIPTION
Fifth of the temperature series, building on #25.

- PerfMetric.dieTemperature: the first system-wide series in Analytics. CPU die and GPU die render as two fixed series with synthetic negative-pid identities, so focus, zoom, scrubbing, the stats overlay, and the shared timeline all work with no changes to PerformanceChart.
- PerfMetric.processMetrics keeps every per-process path (trace export/import, series-builder loops, picker) five-metric; .mpmtrace format untouched, old traces render identically.
- Span-aware loading: historical spans read systemHistory (aggregate tiers serve *_max, so long ranges keep spikes); live span reads the recent raw window; appendTick stitches the live edge.
- The cell appears only when thermal data exists (SMC-less Macs and pre-thermal databases keep the original grid, including the 2x2 no-network layout).

Verified: swift build (0 warnings), swift test (470 green), lint clean, and visually on an M3 Pro: the six-cell grid renders the Temperature cell live, CPU die swinging 60-80 C under repeated compiles, GPU die ~50 C, timeline-aligned with the other cells. Focus/zoom on the temperature cell compiles and follows the shared path but was not exercised by automation; worth one manual click before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ