### PR TITLE
Thermal 6/6: fan-drift insight (the dust signal)

### DIFF
--- a/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
@@ -2604,6 +2604,21 @@ final class SamplerModel: ObservableObject {
             let networkConsumers = Array(
                 windowConsumers.sorted { $0.averageNetwork > $1.averageNetwork }.prefix(5))
 
+            // The dust signal: this fortnight's fan/die pairs against the same
+            // pairs six weeks back (hour tier, so two cheap index scans). The
+            // analyzer stays quiet without ~3 days of usable hours per window,
+            // so young databases and fanless Macs contribute nothing.
+            let now = Date()
+            let recentHours =
+                (try? store.fanTempHours(
+                    from: now.addingTimeInterval(-14 * 86_400), to: now)) ?? []
+            let baselineHours =
+                (try? store.fanTempHours(
+                    from: now.addingTimeInterval(-63 * 86_400),
+                    to: now.addingTimeInterval(-35 * 86_400))) ?? []
+            let thermalDrift = ThermalDrift.analyze(
+                recent: recentHours, baseline: baselineHours, baselineWeeksAgo: 6)
+
             bundle.insights = InsightEngine.insights(
                 InsightEngine.Inputs(
                     totalRAM: system?.totalRAM ?? 0,
@@ -2616,7 +2631,8 @@ final class SamplerModel: ObservableObject {
                     rosetta: rosetta,
                     cpu: cpu,
                     cpuConsumers: cpuConsumers,
-                    networkConsumers: networkConsumers
+                    networkConsumers: networkConsumers,
+                    thermalDrift: thermalDrift
                 ))
 
             let ids = Set(bundle.leaks.map(\.identity))

--- a/Sources/MacPerfMonitor/Views/InsightsView.swift
+++ b/Sources/MacPerfMonitor/Views/InsightsView.swift
@@ -210,6 +210,7 @@ extension InsightEngine.Insight {
         case .rosetta: return "cpu"
         case .cpu: return "gauge.with.dots.needle.67percent"
         case .network: return "network"
+        case .thermalDrift: return "fanblades"
         case .allClear: return "checkmark.circle.fill"
         }
     }

--- a/Sources/MacPerfMonitorCore/Analysis/InsightEngine.swift
+++ b/Sources/MacPerfMonitorCore/Analysis/InsightEngine.swift
@@ -30,7 +30,9 @@ public enum InsightEngine {
 
         /// What produced the insight, so the UI can pick an icon per source.
         public enum Kind: String, Sendable {
-            case leak, pressure, attribution, stepChange, swap, rosetta, cpu, network, allClear
+            case leak, pressure, attribution, stepChange, swap, rosetta, cpu, network
+            case thermalDrift
+            case allClear
         }
 
         /// Stable across reloads for the same underlying finding, so SwiftUI
@@ -98,6 +100,10 @@ public enum InsightEngine {
         /// window, for the heavy-network insight. Empty (the default, and the
         /// case when per-app network tracking is off) disables that part.
         public var networkConsumers: [ProcessConsumer]
+        /// Fans-working-harder-at-the-same-temperature finding, computed from
+        /// the hour tier by the caller (see `ThermalDrift`). Nil disables the
+        /// dust insight.
+        public var thermalDrift: ThermalDrift.Finding?
 
         public init(
             now: Date = Date(),
@@ -111,7 +117,8 @@ public enum InsightEngine {
             rosetta: RosettaCost,
             cpu: CPUSample? = nil,
             cpuConsumers: [ProcessConsumer] = [],
-            networkConsumers: [ProcessConsumer] = []
+            networkConsumers: [ProcessConsumer] = [],
+            thermalDrift: ThermalDrift.Finding? = nil
         ) {
             self.now = now
             self.totalRAM = totalRAM
@@ -125,6 +132,7 @@ public enum InsightEngine {
             self.cpu = cpu
             self.cpuConsumers = cpuConsumers
             self.networkConsumers = networkConsumers
+            self.thermalDrift = thermalDrift
         }
     }
 
@@ -165,6 +173,7 @@ public enum InsightEngine {
         found += rosettaInsights(inputs)
         found += cpuInsights(inputs)
         found += networkInsights(inputs)
+        found += thermalDriftInsights(inputs)
 
         guard !found.isEmpty else {
             return [
@@ -191,6 +200,26 @@ public enum InsightEngine {
     }
 
     // MARK: - Sources
+
+    /// The dust signal: fans measurably faster at the same die temperature
+    /// than weeks ago. Advisory, one card, hardware-care rather than software.
+    private static func thermalDriftInsights(_ inputs: Inputs) -> [Insight] {
+        guard let finding = inputs.thermalDrift else { return [] }
+        let percent = Int((finding.increaseFraction * 100).rounded())
+        return [
+            Insight(
+                id: "thermal-drift",
+                kind: .thermalDrift,
+                severity: .advisory,
+                headline: "Fans are working harder than they used to",
+                detail:
+                    "At the same die temperature, the fans now run about \(percent)% faster "
+                    + "than \(finding.baselineWeeksAgo) weeks ago. Dust buildup in the vents "
+                    + "is the usual cause; cleaning them usually brings speeds back down.",
+                metricText: "+\(percent)%"
+            )
+        ]
+    }
 
     private static func leakInsights(_ inputs: Inputs) -> [Insight] {
         inputs.leaks.prefix(3).map { entry in

--- a/Sources/MacPerfMonitorCore/Analysis/ThermalDrift.swift
+++ b/Sources/MacPerfMonitorCore/Analysis/ThermalDrift.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// One hour-tier observation pairing mean fan speed with mean CPU die
+/// temperature, the raw material of the dust signal.
+public struct FanTempHour: Sendable, Equatable {
+    public var date: Date
+    public var fanRPM: Double
+    public var dieC: Double
+
+    public init(date: Date, fanRPM: Double, dieC: Double) {
+        self.date = date
+        self.fanRPM = fanRPM
+        self.dieC = dieC
+    }
+}
+
+/// Detects fans working measurably harder for the same die temperature than
+/// they did weeks ago. Dust buildup in the vents is the usual cause: airflow
+/// drops, so the fan controller spends more rpm to hold the same die
+/// temperature. Comparing rpm *at matched temperature bands* is what makes
+/// this a drift signal rather than a workload signal; a busier month runs
+/// hotter and faster, but not faster-at-the-same-temperature.
+public enum ThermalDrift {
+    public struct Finding: Sendable, Equatable {
+        /// Fractional fan speed increase at matched die temperature (0.25 = 25%).
+        public var increaseFraction: Double
+        /// The absolute rpm increase behind the fraction.
+        public var increaseRPM: Double
+        /// How far back the baseline window reaches, in whole weeks.
+        public var baselineWeeksAgo: Int
+    }
+
+    /// Both windows must carry at least this many usable hours, so a Mac that
+    /// was asleep or idle for most of a window stays quiet.
+    public static let minHoursPerWindow = 72
+    /// Die temperature band width for matching hours between the windows.
+    public static let bandWidthC = 2.5
+    /// Fire only on a clear signal: at least 20 percent faster and at least
+    /// 300 rpm, so idle wobble and rounding never produce a card.
+    public static let minIncreaseFraction = 0.2
+    public static let minIncreaseRPM = 300.0
+    /// Bands where the baseline fans were essentially off are skipped: a ratio
+    /// against near-zero rpm is unstable, and fans-off hours carry no airflow
+    /// information.
+    public static let minBandRPM = 500.0
+
+    public static func analyze(
+        recent: [FanTempHour], baseline: [FanTempHour], baselineWeeksAgo: Int
+    ) -> Finding? {
+        guard recent.count >= minHoursPerWindow, baseline.count >= minHoursPerWindow else {
+            return nil
+        }
+        let recentBands = bands(recent)
+        let baselineBands = bands(baseline)
+        var weightedRecent = 0.0
+        var weightedBaseline = 0.0
+        var weight = 0
+        for (band, base) in baselineBands {
+            guard let current = recentBands[band] else { continue }
+            let baselineMean = base.sum / Double(base.count)
+            guard baselineMean >= minBandRPM else { continue }
+            let recentMean = current.sum / Double(current.count)
+            // Weight each band by the hours it can actually pair, so a band
+            // seen once cannot swing the verdict.
+            let hours = min(base.count, current.count)
+            weightedRecent += recentMean * Double(hours)
+            weightedBaseline += baselineMean * Double(hours)
+            weight += hours
+        }
+        guard weight >= minHoursPerWindow / 3, weightedBaseline > 0 else { return nil }
+        let recentMean = weightedRecent / Double(weight)
+        let baselineMean = weightedBaseline / Double(weight)
+        let increase = recentMean - baselineMean
+        let fraction = increase / baselineMean
+        guard fraction >= minIncreaseFraction, increase >= minIncreaseRPM else { return nil }
+        return Finding(
+            increaseFraction: fraction, increaseRPM: increase,
+            baselineWeeksAgo: baselineWeeksAgo)
+    }
+
+    private static func bands(_ hours: [FanTempHour]) -> [Int: (sum: Double, count: Int)] {
+        var result: [Int: (sum: Double, count: Int)] = [:]
+        for hour in hours {
+            let band = Int((hour.dieC / bandWidthC).rounded(.down))
+            let entry = result[band] ?? (0, 0)
+            result[band] = (entry.sum + hour.fanRPM, entry.count + 1)
+        }
+        return result
+    }
+}

--- a/Sources/MacPerfMonitorCore/Persistence/ThermalEvents.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/ThermalEvents.swift
@@ -33,6 +33,26 @@ public struct ThermalEvent: Sendable, Identifiable, Equatable {
 }
 
 extension SampleStore {
+    /// Hour-tier fan/die pairs for the thermal drift analysis: every
+    /// `system_hour` bucket in the interval that carries both a fan speed and
+    /// a CPU die temperature, oldest first.
+    public func fanTempHours(from: Date, to: Date) throws -> [FanTempHour] {
+        try databasePool.read { db in
+            try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT bucket, fan_rpm_avg, cpu_die_avg FROM system_hour
+                    WHERE bucket >= ? AND bucket < ?
+                      AND fan_rpm_avg IS NOT NULL AND cpu_die_avg IS NOT NULL
+                    ORDER BY bucket ASC
+                    """, arguments: [from.timeIntervalSince1970, to.timeIntervalSince1970]
+            ).map { row in
+                FanTempHour(
+                    date: Date(timeIntervalSince1970: row[0]), fanRPM: row[1], dieC: row[2])
+            }
+        }
+    }
+
     /// Thermal throttling events in the window, most recent first. An event is
     /// recorded each time the thermal pressure state steps up into
     /// serious-or-higher. The dominant process is the largest CPU consumer

--- a/Tests/MacPerfMonitorCoreTests/ThermalDriftTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/ThermalDriftTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class ThermalDriftTests: XCTestCase {
+    private let anchor = Date(timeIntervalSince1970: 1_800_000_000)
+
+    /// `count` hours at the given die temperature and fan speed.
+    private func hours(_ count: Int, dieC: Double, rpm: Double) -> [FanTempHour] {
+        (0..<count).map {
+            FanTempHour(
+                date: anchor.addingTimeInterval(Double($0) * 3600), fanRPM: rpm, dieC: dieC)
+        }
+    }
+
+    func testFiresOnClearSameTemperatureIncrease() throws {
+        // Baseline: 2000 rpm to hold 60 C. Recent: 2600 rpm for the same 60 C.
+        let finding = ThermalDrift.analyze(
+            recent: hours(100, dieC: 60, rpm: 2600),
+            baseline: hours(100, dieC: 60, rpm: 2000),
+            baselineWeeksAgo: 6)
+        let unwrapped = try XCTUnwrap(finding)
+        XCTAssertEqual(unwrapped.increaseFraction, 0.3, accuracy: 0.01)
+        XCTAssertEqual(unwrapped.increaseRPM, 600, accuracy: 1)
+        XCTAssertEqual(unwrapped.baselineWeeksAgo, 6)
+    }
+
+    func testQuietOnSmallIncrease() {
+        XCTAssertNil(
+            ThermalDrift.analyze(
+                recent: hours(100, dieC: 60, rpm: 2200),
+                baseline: hours(100, dieC: 60, rpm: 2000),
+                baselineWeeksAgo: 6))
+    }
+
+    /// A busier month runs hotter AND faster; matched-band comparison must not
+    /// read that as drift. Recent hours are at a higher temperature band whose
+    /// baseline rpm was proportionally higher too.
+    func testWorkloadShiftIsNotDrift() {
+        let baseline = hours(60, dieC: 55, rpm: 1800) + hours(60, dieC: 70, rpm: 3500)
+        let recent = hours(30, dieC: 55, rpm: 1800) + hours(90, dieC: 70, rpm: 3500)
+        XCTAssertNil(
+            ThermalDrift.analyze(recent: recent, baseline: baseline, baselineWeeksAgo: 6))
+    }
+
+    func testQuietWithoutEnoughHours() {
+        XCTAssertNil(
+            ThermalDrift.analyze(
+                recent: hours(20, dieC: 60, rpm: 2600),
+                baseline: hours(100, dieC: 60, rpm: 2000),
+                baselineWeeksAgo: 6))
+        XCTAssertNil(
+            ThermalDrift.analyze(
+                recent: hours(100, dieC: 60, rpm: 2600),
+                baseline: hours(20, dieC: 60, rpm: 2000),
+                baselineWeeksAgo: 6))
+    }
+
+    /// Fans-off baselines carry no airflow information: ratios against near
+    /// zero are noise, and MacBook Air has no fans at all.
+    func testQuietWhenBaselineFansWereOff() {
+        XCTAssertNil(
+            ThermalDrift.analyze(
+                recent: hours(100, dieC: 45, rpm: 400),
+                baseline: hours(100, dieC: 45, rpm: 0),
+                baselineWeeksAgo: 6))
+    }
+
+    /// Non-overlapping temperature bands (a winter/summer ambient shift) have
+    /// nothing to compare and must stay quiet.
+    func testQuietWithoutOverlappingBands() {
+        XCTAssertNil(
+            ThermalDrift.analyze(
+                recent: hours(100, dieC: 75, rpm: 4000),
+                baseline: hours(100, dieC: 50, rpm: 1500),
+                baselineWeeksAgo: 6))
+    }
+
+    func testInsightCardIsAdvisoryAndWorded() throws {
+        let insights = InsightEngine.insights(
+            InsightEngine.Inputs(
+                totalRAM: 16 << 30,
+                currentPressure: .normal,
+                systemHistory: [],
+                leaks: [],
+                events: [],
+                consumers: [],
+                consumerSeries: [:],
+                rosetta: RosettaCost(processCount: 0, totalFootprint: 0),
+                thermalDrift: ThermalDrift.Finding(
+                    increaseFraction: 0.3, increaseRPM: 600, baselineWeeksAgo: 6)))
+        let card = insights.first { $0.kind == .thermalDrift }
+        let unwrapped = try XCTUnwrap(card)
+        XCTAssertEqual(unwrapped.severity, .advisory)
+        XCTAssertEqual(unwrapped.metricText, "+30%")
+        XCTAssertTrue(unwrapped.detail.contains("6 weeks"))
+    }
+
+    // MARK: - Store query
+
+    func testFanTempHoursReadsHourTier() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macperfmonitor-drift-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: tempURL)
+            try? FileManager.default.removeItem(at: tempURL.appendingPathExtension("wal"))
+            try? FileManager.default.removeItem(at: tempURL.appendingPathExtension("shm"))
+        }
+        let store = try SampleStore(url: tempURL)
+        for i in 0..<40 {
+            var sample = Make.system(
+                timestamp: anchor.addingTimeInterval(Double(i) * 6), pressurePercent: 10)
+            sample.cpuDieC = 55
+            sample.fanRPM = 2000
+            try store.insert(systemSample: sample)
+        }
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(600))
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(7200))
+
+        let rows = try store.fanTempHours(
+            from: anchor.addingTimeInterval(-3600), to: anchor.addingTimeInterval(7200))
+        XCTAssertGreaterThanOrEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].dieC, 55, accuracy: 0.001)
+        XCTAssertEqual(rows[0].fanRPM, 2000, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
Last of the temperature series, building on #26.

- ThermalDrift.analyze: pure, conservative comparison of recent vs six-weeks-ago hour-tier fan/die pairs, matched by 2.5 C temperature bands. Workload shifts (hotter and faster) cannot fire it; only faster-at-the-same-temperature can. Gates: 72 usable hours per window, 24+ matched band-hours, fans-off baselines skipped, +20% AND +300 rpm required.
- SampleStore.fanTempHours reads the hour tier (two cheap index scans per insights load).
- One advisory Insight card with a fanblades icon; InsightEngine.Inputs gains an optional thermalDrift finding (default nil keeps all call sites and tests source-compatible).
- 8 new tests: fires on clear increase, quiet on small increase, workload-shift immunity, insufficient hours, fans-off baseline, non-overlapping bands, card severity/wording, and an hour-tier store round trip through Retention.

Note: this insight needs about nine weeks of recorded history before it can ever fire, by design; nobody will see it until the database has lived that long.

Verified: swift build (0 warnings), swift test (478 tests, 0 failures), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ