### PR TITLE
Thermal follow-up: temperature charts on the GPU tab and Processes header

### DIFF
--- a/Sources/MacPerfMonitor/Views/GPUView.swift
+++ b/Sources/MacPerfMonitor/Views/GPUView.swift
@@ -29,6 +29,13 @@ struct GPUView: View {
         KeyPathComparator(\ProcessNode.process.gpuPercentValue, order: .reverse)
     ]
     @State private var aiWorkloads: [AIWorkloadRow] = []
+    /// Point-based backing for the temperature chart. Unlike the columnar
+    /// feeds above, temperatures need gap-correct optionals (rows recorded
+    /// before the thermal columns existed must gap, not draw a 0 line), so
+    /// this panel takes the same points path as the Disk and Energy tabs.
+    /// Appended on the thermal cadence, not the dial rate, so the SwiftUI
+    /// chart re-renders about every 5 s and stays out of the live budget.
+    @State private var thermalPoints: [SystemHistoryPoint] = []
 
     var body: some View {
         ScrollView {
@@ -37,6 +44,7 @@ struct GPUView: View {
                 headlineCards
                 utilizationPanel
                 powerPanel
+                temperaturePanel
                 processesPanel
             } rail: {
                 devicePanel
@@ -61,6 +69,7 @@ struct GPUView: View {
         .onReceive(liveTicks) { _ in
             guard appState.mainWindowVisible, let model else { return }
             timeline.append(model.liveSystem, gpu: model.latestGPU)
+            appendThermalPoint(model)
         }
         .onReceive(tableTicks) { _ in
             if appState.mainWindowVisible { rebuildRows() }
@@ -88,7 +97,30 @@ struct GPUView: View {
             guard range == requested else { return }
             timeline.replace(
                 points, span: requested.seconds, live: model.liveSystem, gpu: model.latestGPU)
+            thermalPoints = points
             loadedRange = requested
+        }
+    }
+
+    /// Append the live thermal reading, but only when a fresh SMC sample has
+    /// actually landed (the reader throttles to ~5 s), so the points-based
+    /// chart below re-renders at the thermal cadence rather than the dial rate.
+    private func appendThermalPoint(_ model: SamplerModel) {
+        guard let live = model.liveSystem, live.cpuDieC != nil else { return }
+        if let last = thermalPoints.last {
+            guard live.timestamp.timeIntervalSince(last.date) >= 4 else { return }
+        }
+        var point = SystemHistoryPoint(
+            date: live.timestamp, pressurePercent: live.pressurePercent,
+            appMemory: live.appMemory, wired: live.wired, compressed: live.compressed,
+            cachedFiles: live.cachedFiles, swapUsed: live.swapUsed)
+        point.cpuDieC = live.cpuDieC
+        point.gpuDieC = live.gpuDieC
+        point.fanRPM = live.fanRPM
+        thermalPoints.append(point)
+        let cutoff = Date().addingTimeInterval(-range.seconds)
+        if thermalPoints.first.map({ $0.date < cutoff }) ?? false {
+            thermalPoints.removeAll { $0.date < cutoff }
         }
     }
 
@@ -187,6 +219,30 @@ struct GPUView: View {
                 }
                 Text(
                     "From the chip's energy counters (the same source as powermetrics), averaged over each tick. Neural Engine power is the signal that a Core ML model is running: it reads zero when the ANE is idle."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var temperaturePanel: some View {
+        GPUPanel("Temperature", systemImage: "thermometer.medium") {
+            VStack(alignment: .leading, spacing: 8) {
+                TemperatureChart(
+                    points: thermalPoints,
+                    xDomain: LiveChartGeometry.trailingDomain(
+                        latest: thermalPoints.last?.date, span: range.seconds),
+                    showsTimeAxis: true
+                )
+                .frame(height: 140)
+                HStack(spacing: 22) {
+                    liveStat("GPU DIE", timeline.temperatureText, NSColor(ThermalStyle.gpu))
+                    liveStat("FAN", timeline.fanText, NSColor.labelColor)
+                    Spacer()
+                }
+                Text(
+                    "Each line is the hottest sensor of its domain: CPU die in orange, GPU die in red. High numbers under load are normal; the Energy tab keeps the long-term thermal record and the throttling log."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Sources/MacPerfMonitor/Views/MetricCard.swift
+++ b/Sources/MacPerfMonitor/Views/MetricCard.swift
@@ -8,12 +8,14 @@ enum MetricUnit {
     case bytes
     case percent
     case watts
+    case celsius
 
     func format(_ value: Double) -> String {
         switch self {
         case .bytes: return ByteFormat.string(UInt64(max(0, value.rounded())))
         case .percent: return "\(Int(value.rounded()))%"
         case .watts: return String(format: "%.2f W", value)
+        case .celsius: return "\(Int(value.rounded()))°C"
         }
     }
 }
@@ -505,6 +507,9 @@ struct MetricDetailChart: View {
         case .percent: return 100
         case .bytes: return max(peak * 1.12, 1)
         case .watts: return max(peak * 1.2, 1)
+        // Die sensors top out near 110; a fixed ceiling keeps the danger zone
+        // in a stable place instead of rescaling with each window.
+        case .celsius: return 110
         }
     }
 

--- a/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
+++ b/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
@@ -47,6 +47,9 @@ struct SystemHeaderView: View {
                 if cards.count > 1 {
                     MetricCard(data: cards[1]).frame(maxWidth: .infinity)
                 }
+                if live.hasTemperature {
+                    MetricCard(data: temperatureCard).frame(maxWidth: .infinity)
+                }
             }
             // Cap the row at the tallest card's natural height (the core grid) so it
             // sizes to content instead of grabbing a share of the window.
@@ -69,6 +72,29 @@ struct SystemHeaderView: View {
         model.loadRecentSystemHistory(seconds: 2 * 3600) { points in
             live.replace(points, live: model.liveSystem, cpu: model.smoothedCPU)
         }
+    }
+
+    /// The die-temperature card, live-fed like the total-CPU card. Only added
+    /// to the row once a temperature has actually been seen.
+    private var temperatureCard: MetricCardData {
+        MetricCardData(
+            label: "CPU die",
+            unit: .celsius,
+            yDomain: 0...110,
+            help:
+                "The hottest CPU die sensor. The colour follows macOS's thermal pressure: "
+                + "green means hot but working as designed. Click for details.",
+            explanation: MetricExplanation(
+                meaning:
+                    "The hottest of the CPU die's temperature sensors, the figure people mean "
+                    + "by \u{201C}CPU temperature\u{201D}. High numbers under load are normal on "
+                    + "Apple silicon; the colour turns orange or red only when macOS itself "
+                    + "reports thermal pressure, the signal that it is slowing work down.",
+                calculation:
+                    "Every P-core and E-core cluster sensor the SMC exposes is read on a short "
+                    + "throttle, and the card shows the maximum. The trend behind it is the "
+                    + "same two-hour window as the other header cards."),
+            live: live.temperatureFeed)
     }
 
     // MARK: - Coverage
@@ -168,19 +194,23 @@ final class ProcessHeaderStore: ObservableObject {
     let usageFeed = MetricCardFeed()
     let loadFeed = MetricCardFeed()
     let coreFeed = CoreGridFeed()
+    let temperatureFeed = MetricCardFeed()
+    /// True once any die-temperature sample has been seen, so the header only
+    /// grows the fourth card on machines that actually report one.
+    @Published private(set) var hasTemperature = false
 
     func replace(_ points: [SystemHistoryPoint], live: SystemSample?, cpu: CPUSample?) {
         window.replace(points)
         if let live { window.append(Self.point(from: live)) }
-        publish(cpu)
+        publish(cpu, system: live)
     }
 
     func append(_ system: SystemSample?, cpu: CPUSample?) {
         if let system { window.append(Self.point(from: system)) }
-        publish(cpu)
+        publish(cpu, system: system)
     }
 
-    private func publish(_ cpu: CPUSample?) {
+    private func publish(_ cpu: CPUSample?, system: SystemSample?) {
         let level = CPULevel(fraction: cpu?.totalUsage ?? 0)
         usageFeed.publish(
             value: cpu.map { "\(Int(($0.totalUsage * 100).rounded()))%" },
@@ -190,6 +220,15 @@ final class ProcessHeaderStore: ObservableObject {
             value: cpu.map { String(format: "%.2f", $0.loadAverage1) }, tint: .labelColor,
             column: nil, xDomain: nil, yDomain: nil)
         coreFeed.publish(cpu?.cores ?? [])
+        // The temperature card: hottest die sensor, tinted by macOS's own
+        // thermal pressure verdict (green means "hot but working as designed").
+        let die = system?.cpuDieC ?? window.peakLatestCPUDie
+        if die != nil, !hasTemperature { hasTemperature = true }
+        let pressure = system?.thermalPressure ?? .nominal
+        temperatureFeed.publish(
+            value: die.map { "\(Int($0.rounded()))°C" },
+            tint: NSColor(pressure.color), column: LiveColumn(window, .cpuDieC), scale: 1,
+            xDomain: window.xDomain, yDomain: 0...110)
     }
 
     private static func point(from s: SystemSample) -> SystemHistoryPoint {
@@ -201,7 +240,17 @@ final class ProcessHeaderStore: ObservableObject {
             compressed: s.compressed,
             cachedFiles: s.cachedFiles,
             swapUsed: s.swapUsed,
-            cpuLoad: s.cpuLoad
+            cpuLoad: s.cpuLoad,
+            cpuDieC: s.cpuDieC
         )
+    }
+}
+
+extension SystemHistoryWindow {
+    /// The newest non-zero die temperature, so the header card still shows a
+    /// figure between SMC reads (live ticks carry thermal only on GPU-read
+    /// ticks) and right after a DB seed.
+    fileprivate var peakLatestCPUDie: Double? {
+        values(.cpuDieC).reversed().first { $0 > 1 }
     }
 }

--- a/Sources/MacPerfMonitorCore/Util/SystemHistoryWindow.swift
+++ b/Sources/MacPerfMonitorCore/Util/SystemHistoryWindow.swift
@@ -33,6 +33,10 @@ public struct SystemHistoryWindow {
         case gpuUtilization
         case gpuPowerWatts
         case anePowerWatts
+        /// Hottest CPU die sensor. Like the GPU columns, unsampled ticks store
+        /// 0 (the columnar store is non-optional); consumers with a floored
+        /// y-domain should treat near-zero as "not sampled".
+        case cpuDieC
     }
 
     /// Timestamps as `timeIntervalSinceReferenceDate`, oldest first.
@@ -144,6 +148,7 @@ public struct SystemHistoryWindow {
         columns[Column.gpuUtilization.rawValue].append(point.gpuUtilization ?? 0)
         columns[Column.gpuPowerWatts.rawValue].append(point.gpuPowerWatts ?? 0)
         columns[Column.anePowerWatts.rawValue].append(point.anePowerWatts ?? 0)
+        columns[Column.cpuDieC.rawValue].append(point.cpuDieC ?? 0)
         latest = point
     }
 


### PR DESCRIPTION
Follow-up to the thermal series (#22-#27).

- GPU tab: a Temperature panel (CPU die + GPU die over the selected range, live GPU-die/fan read-outs, range picker shared with the rest of the tab). Points-based deliberately: pre-v14 history rows gap instead of drawing a 0 line, and the chart re-renders on the ~5 s thermal cadence, not the dial rate, so the 1.4.0 live-pipeline budget is untouched.
- Processes header: a fourth MetricCard, CPU die, live-fed at the dial rate via a new cpuDieC window column and a new .celsius MetricUnit (fixed 0-110 detail scale). Tint follows the thermal pressure verdict. Appears only once a temperature has been seen, so SMC-less machines and menubar-only sessions keep the original header.
- Known transient: the header sparkline shows a zero-floor segment for raw rows recorded before v14; the raw tier holds 2 hours, so it ages out within 2 hours of first running this build and never returns.

Verified: swift build (0 warnings), swift test (478 green), lint clean, and visually on an M3 Pro (screenshots in session): GPU tab panel with both die lines and correct gaps; header card reading 81 C in green under build load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ