### PR TITLE
Thermal follow-up: Sensors section in the Hardware explorer

### DIFF
--- a/Sources/MacPerfMonitorCore/Hardware/HardwareInventory.swift
+++ b/Sources/MacPerfMonitorCore/Hardware/HardwareInventory.swift
@@ -67,6 +67,9 @@ public enum HardwareInventory {
             dataTypes: ["SPPowerDataType"],
             native: { HardwareNativeReaders.battery(parentID: $0, systemImage: $1) }),
         HardwareSectionSpec(
+            id: "sensors", title: "Sensors", systemImage: "thermometer.medium",
+            native: { HardwareNativeReaders.sensors(parentID: $0, systemImage: $1) }),
+        HardwareSectionSpec(
             id: "network", title: "Network", systemImage: "network",
             dataTypes: ["SPNetworkDataType", "SPEthernetDataType"]),
         HardwareSectionSpec(

--- a/Sources/MacPerfMonitorCore/Hardware/HardwareNativeReaders.swift
+++ b/Sources/MacPerfMonitorCore/Hardware/HardwareNativeReaders.swift
@@ -718,6 +718,54 @@ enum HardwareNativeReaders {
         return result
     }
 
+    // MARK: - Sensors
+
+    /// Every readable temperature sensor the SMC exposes, grouped by domain,
+    /// plus the fans. Values are one refresh-time snapshot, matching the rest
+    /// of the explorer; the live thermal story lives on the Energy tab. This
+    /// is the long tail's home: airflow, skin, wireless, voltage rails, and
+    /// every individual die sensor behind the headline figures.
+    static func sensors(parentID: String, systemImage: String) -> Result {
+        var result = Result()
+        let inventory = SMCReader().sensorInventory()
+        guard !inventory.sensors.isEmpty || !inventory.fans.isEmpty else { return result }
+
+        let grouped = Dictionary(grouping: inventory.sensors, by: \.group)
+        for group in SMCReader.sensorGroupOrder {
+            guard let readings = grouped[group], !readings.isEmpty else { continue }
+            let hottest = readings.map(\.celsius).max() ?? 0
+            let count = readings.count == 1 ? "1 sensor" : "\(readings.count) sensors"
+            let slug = group.lowercased().replacingOccurrences(of: " ", with: "-")
+            result.nodes.append(
+                HardwareNode(
+                    id: "\(parentID)/\(slug)",
+                    title: group,
+                    subtitle: "\(count) \u{00B7} hottest \(Int(hottest.rounded()))\u{00B0}C",
+                    systemImage: "thermometer.medium",
+                    properties: readings.sorted { $0.key < $1.key }.map {
+                        HardwareProperty($0.key, String(format: "%.1f\u{00B0}C", $0.celsius))
+                    }))
+        }
+
+        if !inventory.fans.isEmpty {
+            let spinning = inventory.fans.filter { $0.rpm > 0 }.count
+            result.nodes.append(
+                HardwareNode(
+                    id: "\(parentID)/fans",
+                    title: "Fans",
+                    subtitle: spinning == 0
+                        ? "\(inventory.fans.count) \u{00B7} all off"
+                        : "\(spinning) of \(inventory.fans.count) spinning",
+                    systemImage: "fanblades",
+                    properties: inventory.fans.enumerated().map { index, fan in
+                        var value = fan.rpm == 0 ? "Off" : "\(fan.rpm) rpm"
+                        if let maxRPM = fan.maxRPM { value += " (maximum \(maxRPM) rpm)" }
+                        return HardwareProperty("Fan \(index + 1)", value)
+                    }))
+        }
+        return result
+    }
+
     // MARK: - Software
 
     static func software(parentID: String, systemImage: String) -> Result {

--- a/Sources/MacPerfMonitorCore/Sampling/SMCReader.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/SMCReader.swift
@@ -148,6 +148,62 @@ final class SMCReader {
         return FanSample(rpm: Int(rpm.rounded()), maxRPM: maxRPM)
     }
 
+    // MARK: - Full inventory (Hardware explorer)
+
+    /// One named temperature reading from the full SMC enumeration.
+    struct SensorReading: Sendable, Equatable {
+        var key: String
+        var celsius: Double
+        var group: String
+    }
+
+    /// Every readable temperature key with a plausible value, grouped by
+    /// domain, plus the fans. A full enumeration costs a few hundred
+    /// milliseconds, so this is for the on-demand Hardware inventory, never
+    /// the sampling tick; callers create a throwaway reader on their own
+    /// queue and let it deinit.
+    func sensorInventory() -> (sensors: [SensorReading], fans: [FanSample]) {
+        guard open() else { return ([], []) }
+        var sensors: [SensorReading] = []
+        if let total = readUInt32(Self.fourCC("#KEY")), total > 0 {
+            for index in 0..<total {
+                guard let key = keyAtIndex(index) else { continue }
+                let name = Self.toString(key)
+                guard name.hasPrefix("T") else { continue }
+                guard let value = readFloat(key), Self.isPlausibleReading(value) else { continue }
+                sensors.append(
+                    SensorReading(
+                        key: name, celsius: value, group: Self.sensorGroup(forKeyName: name)))
+            }
+        }
+        var fanCount = readFloat(Self.fourCC("FNum")).map { Int($0) } ?? 0
+        if fanCount == 0, (readFloat(Self.fourCC("F0Mx")) ?? 0) > 0 { fanCount = 1 }
+        return (sensors, (0..<fanCount).compactMap(readFan))
+    }
+
+    /// Human grouping for the full key set. Broader than `domain(forKeyName:)`,
+    /// which only admits keys safe to fold into headline die figures; here
+    /// everything readable is shown, honestly labelled. Ordering for display
+    /// lives in `sensorGroupOrder`.
+    static func sensorGroup(forKeyName name: String) -> String {
+        if name.hasPrefix("Tp") { return "CPU die (P cores)" }
+        if name.hasPrefix("Te") { return "CPU die (E cores)" }
+        if name.hasPrefix("Tg") { return "GPU clusters" }
+        if name.hasPrefix("TH0") { return "SSD" }
+        if name.hasPrefix("TB") { return "Battery" }
+        if name.hasPrefix("Ta") { return "Airflow" }
+        if name.hasPrefix("Ts") { return "Skin and board" }
+        if name.hasPrefix("Th") { return "Skin and board" }
+        if name.hasPrefix("TW") { return "Wireless" }
+        if name.hasPrefix("TV") { return "Voltage rails" }
+        return "Other"
+    }
+
+    static let sensorGroupOrder = [
+        "CPU die (P cores)", "CPU die (E cores)", "GPU clusters", "SSD", "Battery",
+        "Airflow", "Skin and board", "Wireless", "Voltage rails", "Other",
+    ]
+
     // MARK: - Connection
 
     private func open() -> Bool {

--- a/Tests/MacPerfMonitorCoreTests/ThermalTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/ThermalTests.swift
@@ -105,6 +105,44 @@ final class ThermalTests: XCTestCase {
         XCTAssertEqual(sample.primaryFanMaxRPM, 6800)
     }
 
+    // MARK: - Inventory grouping (Hardware explorer)
+
+    func testSensorGroupsCoverTheProbedFamilies() {
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Tp0C"), "CPU die (P cores)")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Te0S"), "CPU die (E cores)")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Tg0D"), "GPU clusters")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TH0x"), "SSD")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TB0T"), "Battery")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TaLP"), "Airflow")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Ts0P"), "Skin and board")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Th0a"), "Skin and board")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TW0P"), "Wireless")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TVHE"), "Voltage rails")
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TCMz"), "Other")
+        // Every group name has a display position.
+        let names = [
+            "Tp00", "Te00", "Tg00", "TH0a", "TB1T", "TaRF", "Ts00", "TW0P", "TVS0", "Tf16",
+        ]
+        for name in names {
+            XCTAssertTrue(
+                SMCReader.sensorGroupOrder.contains(SMCReader.sensorGroup(forKeyName: name)), name)
+        }
+    }
+
+    /// The full enumeration must be safe anywhere and internally consistent
+    /// where hardware exists (a VM returns empty and that is a pass).
+    func testSensorInventoryIsSafeAndConsistent() {
+        let inventory = SMCReader().sensorInventory()
+        for sensor in inventory.sensors {
+            XCTAssertTrue(SMCReader.isPlausibleReading(sensor.celsius), sensor.key)
+            XCTAssertTrue(sensor.key.hasPrefix("T"), sensor.key)
+            XCTAssertEqual(sensor.group, SMCReader.sensorGroup(forKeyName: sensor.key))
+        }
+        for fan in inventory.fans {
+            XCTAssertGreaterThanOrEqual(fan.rpm, 0)
+        }
+    }
+
     // MARK: - Live hardware (tolerates VMs with no SMC)
 
     /// The reader must never crash, and anything it reports must be sane.


### PR DESCRIPTION
Completes the last surfacing item from docs/temperature-design.md: the per-sensor long tail's home.

- New Sensors section in the Hardware tree: every readable SMC temperature key grouped by domain (CPU die P/E, GPU clusters, SSD, battery, airflow, skin and board, wireless, voltage rails, Other), plus a Fans node. Group subtitles carry sensor count and hottest reading; keys list with one-decimal values. Refresh-time snapshot, search/copy/report all inherited from the explorer.
- SMCReader.sensorInventory(): full on-demand enumeration on a throwaway connection, never on the sampling tick. Display grouping (sensorGroup) is deliberately broader than the strict headline-domain classifier: the inventory shows everything readable, honestly labelled (voltage rails included, clearly named, exactly what the headline figures exclude).
- 2 new tests: grouping policy across the probed families, and a live-inventory safety test that passes empty on SMC-less CI VMs.

Verified: swift build (0 warnings), swift test (480 green), lint clean, and visually on an M3 Pro: 11 groups, 234 sensors, both fans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ