### PR TITLE
Record every sensor domain so the Hardware charts survive a restart

### DIFF
--- a/Sources/MacPerfMonitor/Views/HardwareOverviewView.swift
+++ b/Sources/MacPerfMonitor/Views/HardwareOverviewView.swift
@@ -356,7 +356,10 @@ struct HardwareOverviewView: View {
             guard appState.mainWindowVisible else { return }
             sensorLive.sweepIfDue(floor: detailGroup == nil ? 5 : 2)
         }
-        .onAppear { sensorLive.sweepIfDue() }
+        .onAppear {
+            sensorLive.seedFromHistory(sampler)
+            sensorLive.sweepIfDue()
+        }
         .sheet(item: $detailGroup) { selection in
             SensorDetailSheet(store: sensorLive, groupName: selection.name)
         }
@@ -427,6 +430,39 @@ private final class SensorLiveStore: ObservableObject {
     private let reader = SensorInventoryReader()
     private var lastSweep: Date?
     private var inFlight = false
+    private var didSeed = false
+
+    /// Seed every chart from the recorded history so a restart resumes the
+    /// trend instead of starting blank. Groups with no persisted column, and a
+    /// database that predates them, simply stay empty and fill from the live
+    /// sweeps. Safe to call repeatedly; only the first call reads.
+    func seedFromHistory(_ model: SamplerModel) {
+        guard !didSeed else { return }
+        didSeed = true
+        model.loadRecentSystemHistory(seconds: Self.chartSpan) { [weak self] points in
+            guard let self, !points.isEmpty else { return }
+            var seeded: [String: [MetricSample]] = [:]
+            for group in HardwareFacts.SensorGroup.displayOrder {
+                let series = points.compactMap { point in
+                    HardwareFacts.SensorGroup.recordedValue(group, in: point)
+                        .map { MetricSample(date: point.date, value: $0) }
+                }
+                if !series.isEmpty { seeded[group] = series }
+            }
+            let fanSeries = points.compactMap { point in
+                point.fanRPM.map { MetricSample(date: point.date, value: $0) }
+            }
+            if !fanSeries.isEmpty { seeded[Self.fansKey] = fanSeries }
+            guard !seeded.isEmpty else { return }
+            // Live sweeps may have landed while the read was in flight; keep
+            // any samples newer than the seed rather than dropping them.
+            for (key, series) in seeded {
+                let seedEnd = series.last?.date ?? .distantPast
+                let live = (self.samples[key] ?? []).filter { $0.date > seedEnd }
+                self.samples[key] = series + live
+            }
+        }
+    }
 
     /// `floor` is the minimum interval between SMC sweeps: the card row uses
     /// 5 s, and the open detail sheet tightens it so its rows track closer to

--- a/Sources/MacPerfMonitorCore/Hardware/SensorInventoryReader.swift
+++ b/Sources/MacPerfMonitorCore/Hardware/SensorInventoryReader.swift
@@ -15,6 +15,37 @@ public struct SensorValue: Sendable, Equatable, Identifiable {
     public var id: String { key }
 }
 
+extension HardwareFacts.SensorGroup {
+    /// The recorded series for a display group, so a sensor chart can seed
+    /// itself from the log instead of starting empty on every launch. Nil for
+    /// groups with no persisted column (nothing is invented).
+    public static func recordedValue(
+        _ group: String, in point: SystemHistoryPoint
+    ) -> Double? {
+        switch group {
+        case SMCReader.groupCPUPCores: return point.cpuPCoreDieC
+        case SMCReader.groupCPUECores: return point.cpuECoreDieC
+        case SMCReader.groupGPU: return point.gpuDieC
+        case SMCReader.groupSSD: return point.ssdTemperatureC
+        case SMCReader.groupBattery:
+            return point.batteryTemperatureCelsius > 0 ? point.batteryTemperatureCelsius : nil
+        case SMCReader.groupAirflow: return point.airflowC
+        case SMCReader.groupSkin: return point.skinC
+        case SMCReader.groupWireless: return point.wirelessC
+        case SMCReader.groupVoltageRails: return point.voltageRailC
+        case SMCReader.groupOther: return point.otherSensorC
+        default: return nil
+        }
+    }
+
+    /// The fan series' key in the same lookup, kept beside the groups so the
+    /// Fans chart seeds the same way.
+    public static let fansKey = "Fans"
+
+    /// Every display group, in the order surfaces should present them.
+    public static let displayOrder: [String] = SMCReader.sensorGroupOrder
+}
+
 public final class SensorInventoryReader {
     private let reader = SMCReader()
 

--- a/Sources/MacPerfMonitorCore/Models/SystemSample.swift
+++ b/Sources/MacPerfMonitorCore/Models/SystemSample.swift
@@ -105,6 +105,17 @@ public struct SystemSample: Sendable, Codable {
     public var gpuDieC: Double?
     public var ssdTemperatureC: Double?
     public var fanRPM: Double?
+    // Per-domain hottest readings (v15), so the Hardware tab's sensor charts
+    // read their trend back from the log instead of starting empty on every
+    // launch. The die, GPU, SSD, battery and fan figures above already cover
+    // their own domains; these are the rest of the sensor groups.
+    public var cpuPCoreDieC: Double?
+    public var cpuECoreDieC: Double?
+    public var airflowC: Double?
+    public var skinC: Double?
+    public var wirelessC: Double?
+    public var voltageRailC: Double?
+    public var otherSensorC: Double?
     /// macOS's own thermal pressure verdict, read every tick (public API, no
     /// SMC involved), so throttling history survives even without sensors.
     public var thermalPressure: ThermalPressureState?
@@ -159,7 +170,14 @@ public struct SystemSample: Sendable, Codable {
         gpuDieC: Double? = nil,
         ssdTemperatureC: Double? = nil,
         fanRPM: Double? = nil,
-        thermalPressure: ThermalPressureState? = nil
+        thermalPressure: ThermalPressureState? = nil,
+        cpuPCoreDieC: Double? = nil,
+        cpuECoreDieC: Double? = nil,
+        airflowC: Double? = nil,
+        skinC: Double? = nil,
+        wirelessC: Double? = nil,
+        voltageRailC: Double? = nil,
+        otherSensorC: Double? = nil
     ) {
         self.timestamp = timestamp
         self.totalRAM = totalRAM
@@ -211,5 +229,12 @@ public struct SystemSample: Sendable, Codable {
         self.ssdTemperatureC = ssdTemperatureC
         self.fanRPM = fanRPM
         self.thermalPressure = thermalPressure
+        self.cpuPCoreDieC = cpuPCoreDieC
+        self.cpuECoreDieC = cpuECoreDieC
+        self.airflowC = airflowC
+        self.skinC = skinC
+        self.wirelessC = wirelessC
+        self.voltageRailC = voltageRailC
+        self.otherSensorC = otherSensorC
     }
 }

--- a/Sources/MacPerfMonitorCore/Persistence/Database.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/Database.swift
@@ -188,6 +188,14 @@ public enum MacPerfMonitorDatabase {
         migrator.registerMigration("v14-thermal") { db in
             try db.execute(sql: Schema.v14)
         }
+        // Per-domain sensor temperatures: the rest of the sensor groups the
+        // Hardware tab charts (P and E core die separately, airflow, skin,
+        // wireless, voltage rails, and the unidentified tail). Without these
+        // those charts could only ever show the current session, losing their
+        // trend on every restart. Max rollups, like the other thermal columns.
+        migrator.registerMigration("v15-sensor-domains") { db in
+            try db.execute(sql: Schema.v15)
+        }
         return migrator
     }
 }
@@ -583,6 +591,32 @@ enum Schema {
         ALTER TABLE system_hour ADD COLUMN fan_rpm_avg REAL;
         ALTER TABLE system_hour ADD COLUMN fan_rpm_max REAL;
         ALTER TABLE system_hour ADD COLUMN thermal_state_max INTEGER;
+        """
+
+    static let v15 = """
+        ALTER TABLE system_samples ADD COLUMN cpu_p_die REAL;
+        ALTER TABLE system_samples ADD COLUMN cpu_e_die REAL;
+        ALTER TABLE system_samples ADD COLUMN airflow_temp REAL;
+        ALTER TABLE system_samples ADD COLUMN skin_temp REAL;
+        ALTER TABLE system_samples ADD COLUMN wireless_temp REAL;
+        ALTER TABLE system_samples ADD COLUMN vrail_temp REAL;
+        ALTER TABLE system_samples ADD COLUMN other_temp REAL;
+
+        ALTER TABLE system_minute ADD COLUMN cpu_p_die_max REAL;
+        ALTER TABLE system_minute ADD COLUMN cpu_e_die_max REAL;
+        ALTER TABLE system_minute ADD COLUMN airflow_temp_max REAL;
+        ALTER TABLE system_minute ADD COLUMN skin_temp_max REAL;
+        ALTER TABLE system_minute ADD COLUMN wireless_temp_max REAL;
+        ALTER TABLE system_minute ADD COLUMN vrail_temp_max REAL;
+        ALTER TABLE system_minute ADD COLUMN other_temp_max REAL;
+
+        ALTER TABLE system_hour ADD COLUMN cpu_p_die_max REAL;
+        ALTER TABLE system_hour ADD COLUMN cpu_e_die_max REAL;
+        ALTER TABLE system_hour ADD COLUMN airflow_temp_max REAL;
+        ALTER TABLE system_hour ADD COLUMN skin_temp_max REAL;
+        ALTER TABLE system_hour ADD COLUMN wireless_temp_max REAL;
+        ALTER TABLE system_hour ADD COLUMN vrail_temp_max REAL;
+        ALTER TABLE system_hour ADD COLUMN other_temp_max REAL;
         """
 }
 

--- a/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
@@ -147,7 +147,14 @@ extension Array where Element == SystemHistoryPoint {
                     ssdTemperatureC: omax { $0.ssdTemperatureC },
                     fanRPM: omax { $0.fanRPM },
                     // Worst pressure in the bucket, for the same reason.
-                    thermalPressure: slice.compactMap(\.thermalPressure).max()
+                    thermalPressure: slice.compactMap(\.thermalPressure).max(),
+                    cpuPCoreDieC: omax { $0.cpuPCoreDieC },
+                    cpuECoreDieC: omax { $0.cpuECoreDieC },
+                    airflowC: omax { $0.airflowC },
+                    skinC: omax { $0.skinC },
+                    wirelessC: omax { $0.wirelessC },
+                    voltageRailC: omax { $0.voltageRailC },
+                    otherSensorC: omax { $0.otherSensorC }
                 ))
             i = j
         }

--- a/Sources/MacPerfMonitorCore/Persistence/Retention.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/Retention.swift
@@ -295,7 +295,7 @@ public enum Retention {
 
         try db.execute(
             sql: """
-                INSERT INTO system_minute (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total, gpu_util_avg, gpu_util_max, gpu_power_avg, gpu_power_max, ane_power_avg, ane_power_max, cpu_die_avg, cpu_die_max, gpu_die_avg, gpu_die_max, ssd_temp_avg, ssd_temp_max, fan_rpm_avg, fan_rpm_max, thermal_state_max)
+                INSERT INTO system_minute (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total, gpu_util_avg, gpu_util_max, gpu_power_avg, gpu_power_max, ane_power_avg, ane_power_max, cpu_die_avg, cpu_die_max, gpu_die_avg, gpu_die_max, ssd_temp_avg, ssd_temp_max, fan_rpm_avg, fan_rpm_max, thermal_state_max, cpu_p_die_max, cpu_e_die_max, airflow_temp_max, skin_temp_max, wireless_temp_max, vrail_temp_max, other_temp_max)
                 SELECT CAST(timestamp / \(b) AS INTEGER) * \(b) AS b,
                        AVG(pressure_percent), MAX(pressure_percent),
                        CAST(AVG(app_memory) AS INTEGER), CAST(AVG(wired) AS INTEGER),
@@ -315,7 +315,9 @@ public enum Retention {
                        AVG(ane_power), MAX(ane_power),
                        AVG(cpu_die), MAX(cpu_die), AVG(gpu_die), MAX(gpu_die),
                        AVG(ssd_temp), MAX(ssd_temp), AVG(fan_rpm), MAX(fan_rpm),
-                       MAX(thermal_state)
+                       MAX(thermal_state),
+                       MAX(cpu_p_die), MAX(cpu_e_die), MAX(airflow_temp), MAX(skin_temp),
+                       MAX(wireless_temp), MAX(vrail_temp), MAX(other_temp)
                 FROM system_samples
                 WHERE timestamp >= ? AND timestamp < ?
                 GROUP BY b
@@ -355,7 +357,14 @@ public enum Retention {
                   gpu_die_avg = excluded.gpu_die_avg, gpu_die_max = excluded.gpu_die_max,
                   ssd_temp_avg = excluded.ssd_temp_avg, ssd_temp_max = excluded.ssd_temp_max,
                   fan_rpm_avg = excluded.fan_rpm_avg, fan_rpm_max = excluded.fan_rpm_max,
-                  thermal_state_max = excluded.thermal_state_max
+                  thermal_state_max = excluded.thermal_state_max,
+                  cpu_p_die_max = excluded.cpu_p_die_max,
+                  cpu_e_die_max = excluded.cpu_e_die_max,
+                  airflow_temp_max = excluded.airflow_temp_max,
+                  skin_temp_max = excluded.skin_temp_max,
+                  wireless_temp_max = excluded.wireless_temp_max,
+                  vrail_temp_max = excluded.vrail_temp_max,
+                  other_temp_max = excluded.other_temp_max
                 """, arguments: [watermark, completeUpTo])
 
         try setMeta(db, "minute_watermark", completeUpTo)
@@ -411,7 +420,7 @@ public enum Retention {
 
         try db.execute(
             sql: """
-                INSERT INTO system_hour (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total, gpu_util_avg, gpu_util_max, gpu_power_avg, gpu_power_max, ane_power_avg, ane_power_max, cpu_die_avg, cpu_die_max, gpu_die_avg, gpu_die_max, ssd_temp_avg, ssd_temp_max, fan_rpm_avg, fan_rpm_max, thermal_state_max)
+                INSERT INTO system_hour (bucket, pressure_avg, pressure_max, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg, cpu_max, samples, battery_charge_avg, battery_power_avg, battery_health_avg, battery_cycles_max, battery_temp_avg, net_in_avg, net_in_max, net_out_avg, net_out_max, disk_read_avg, disk_read_max, disk_write_avg, disk_write_max, disk_read_iops_avg, disk_read_iops_max, disk_write_iops_avg, disk_write_iops_max, disk_read_latency_avg, disk_read_latency_max, disk_write_latency_avg, disk_write_latency_max, disk_util_avg, disk_util_max, boot_free_avg, boot_free_min, boot_total, gpu_util_avg, gpu_util_max, gpu_power_avg, gpu_power_max, ane_power_avg, ane_power_max, cpu_die_avg, cpu_die_max, gpu_die_avg, gpu_die_max, ssd_temp_avg, ssd_temp_max, fan_rpm_avg, fan_rpm_max, thermal_state_max, cpu_p_die_max, cpu_e_die_max, airflow_temp_max, skin_temp_max, wireless_temp_max, vrail_temp_max, other_temp_max)
                 SELECT CAST(bucket / 3600 AS INTEGER) * 3600 AS b,
                        SUM(pressure_avg * samples) / SUM(samples), MAX(pressure_max),
                        CAST(SUM(app_avg * samples) / SUM(samples) AS INTEGER),
@@ -465,7 +474,10 @@ public enum Retention {
                        SUM(fan_rpm_avg * samples)
                            / SUM(CASE WHEN fan_rpm_avg IS NOT NULL THEN samples END),
                        MAX(fan_rpm_max),
-                       MAX(thermal_state_max)
+                       MAX(thermal_state_max),
+                       MAX(cpu_p_die_max), MAX(cpu_e_die_max), MAX(airflow_temp_max),
+                       MAX(skin_temp_max), MAX(wireless_temp_max), MAX(vrail_temp_max),
+                       MAX(other_temp_max)
                 FROM system_minute
                 WHERE bucket >= ? AND bucket < ?
                 GROUP BY b
@@ -505,7 +517,14 @@ public enum Retention {
                   gpu_die_avg = excluded.gpu_die_avg, gpu_die_max = excluded.gpu_die_max,
                   ssd_temp_avg = excluded.ssd_temp_avg, ssd_temp_max = excluded.ssd_temp_max,
                   fan_rpm_avg = excluded.fan_rpm_avg, fan_rpm_max = excluded.fan_rpm_max,
-                  thermal_state_max = excluded.thermal_state_max
+                  thermal_state_max = excluded.thermal_state_max,
+                  cpu_p_die_max = excluded.cpu_p_die_max,
+                  cpu_e_die_max = excluded.cpu_e_die_max,
+                  airflow_temp_max = excluded.airflow_temp_max,
+                  skin_temp_max = excluded.skin_temp_max,
+                  wireless_temp_max = excluded.wireless_temp_max,
+                  vrail_temp_max = excluded.vrail_temp_max,
+                  other_temp_max = excluded.other_temp_max
                 """, arguments: [watermark, completeUpTo])
 
         try setMeta(db, "hour_watermark", completeUpTo)

--- a/Sources/MacPerfMonitorCore/Persistence/SampleStore.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/SampleStore.swift
@@ -274,9 +274,11 @@ public final class SampleStore {
                  disk_read, disk_write, disk_read_iops, disk_write_iops,
                  disk_read_latency, disk_write_latency, disk_util, boot_free, boot_total,
                  gpu_util, gpu_power, ane_power,
-                 cpu_die, gpu_die, ssd_temp, fan_rpm, thermal_state)
+                 cpu_die, gpu_die, ssd_temp, fan_rpm, thermal_state,
+                 cpu_p_die, cpu_e_die, airflow_temp, skin_temp, wireless_temp, vrail_temp,
+                 other_temp)
                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-                        ?,?,?,?,?,?,?,?,?,?,?,?,?)
+                        ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """)
         try statement.execute(
             arguments: [
@@ -301,6 +303,8 @@ public final class SampleStore {
                 s.gpuUtilization, s.gpuPowerWatts, s.anePowerWatts,
                 s.cpuDieC, s.gpuDieC, s.ssdTemperatureC, s.fanRPM,
                 s.thermalPressure?.rawValue,
+                s.cpuPCoreDieC, s.cpuECoreDieC, s.airflowC, s.skinC, s.wirelessC,
+                s.voltageRailC, s.otherSensorC,
             ])
     }
 
@@ -535,7 +539,14 @@ public final class SampleStore {
             ssdTemperatureC: row["ssd_temp"],
             fanRPM: row["fan_rpm"],
             thermalPressure: (row["thermal_state"] as Int?)
-                .flatMap { ThermalPressureState(rawValue: $0) }
+                .flatMap { ThermalPressureState(rawValue: $0) },
+            cpuPCoreDieC: row["cpu_p_die"],
+            cpuECoreDieC: row["cpu_e_die"],
+            airflowC: row["airflow_temp"],
+            skinC: row["skin_temp"],
+            wirelessC: row["wireless_temp"],
+            voltageRailC: row["vrail_temp"],
+            otherSensorC: row["other_temp"]
         )
     }
 

--- a/Sources/MacPerfMonitorCore/Persistence/SystemHistory.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/SystemHistory.swift
@@ -54,6 +54,15 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
     public var fanRPM: Double?
     /// Worst thermal pressure in the interval.
     public var thermalPressure: ThermalPressureState?
+    // Per-domain hottest readings (v15), the recorded series behind the
+    // Hardware tab's sensor charts.
+    public var cpuPCoreDieC: Double?
+    public var cpuECoreDieC: Double?
+    public var airflowC: Double?
+    public var skinC: Double?
+    public var wirelessC: Double?
+    public var voltageRailC: Double?
+    public var otherSensorC: Double?
 
     public var id: Date { date }
 
@@ -88,7 +97,14 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
         gpuDieC: Double? = nil,
         ssdTemperatureC: Double? = nil,
         fanRPM: Double? = nil,
-        thermalPressure: ThermalPressureState? = nil
+        thermalPressure: ThermalPressureState? = nil,
+        cpuPCoreDieC: Double? = nil,
+        cpuECoreDieC: Double? = nil,
+        airflowC: Double? = nil,
+        skinC: Double? = nil,
+        wirelessC: Double? = nil,
+        voltageRailC: Double? = nil,
+        otherSensorC: Double? = nil
     ) {
         self.date = date
         self.pressurePercent = pressurePercent
@@ -121,6 +137,13 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
         self.ssdTemperatureC = ssdTemperatureC
         self.fanRPM = fanRPM
         self.thermalPressure = thermalPressure
+        self.cpuPCoreDieC = cpuPCoreDieC
+        self.cpuECoreDieC = cpuECoreDieC
+        self.airflowC = airflowC
+        self.skinC = skinC
+        self.wirelessC = wirelessC
+        self.voltageRailC = voltageRailC
+        self.otherSensorC = otherSensorC
     }
 }
 
@@ -165,7 +188,9 @@ extension SampleStore {
                            disk_read, disk_write, disk_read_iops, disk_write_iops,
                            disk_read_latency, disk_write_latency, disk_util, boot_free, boot_total,
                            gpu_util, gpu_power, ane_power,
-                           cpu_die, gpu_die, ssd_temp, fan_rpm, thermal_state
+                           cpu_die, gpu_die, ssd_temp, fan_rpm, thermal_state,
+                           cpu_p_die, cpu_e_die, airflow_temp, skin_temp, wireless_temp,
+                           vrail_temp, other_temp
                     FROM system_samples
                     WHERE timestamp >= ?
                     ORDER BY timestamp ASC
@@ -186,7 +211,9 @@ extension SampleStore {
                            disk_read_latency_avg, disk_write_latency_avg, disk_util_avg,
                            boot_free_min, boot_total,
                            gpu_util_avg, gpu_power_avg, ane_power_avg,
-                           cpu_die_max, gpu_die_max, ssd_temp_max, fan_rpm_max, thermal_state_max
+                           cpu_die_max, gpu_die_max, ssd_temp_max, fan_rpm_max, thermal_state_max,
+                           cpu_p_die_max, cpu_e_die_max, airflow_temp_max, skin_temp_max,
+                           wireless_temp_max, vrail_temp_max, other_temp_max
                     FROM \(table)
                     WHERE bucket >= ?
                     ORDER BY bucket ASC
@@ -232,7 +259,14 @@ extension SampleStore {
             gpuDieC: row[27],
             ssdTemperatureC: row[28],
             fanRPM: row[29],
-            thermalPressure: (row[30] as Int?).flatMap { ThermalPressureState(rawValue: $0) }
+            thermalPressure: (row[30] as Int?).flatMap { ThermalPressureState(rawValue: $0) },
+            cpuPCoreDieC: row[31],
+            cpuECoreDieC: row[32],
+            airflowC: row[33],
+            skinC: row[34],
+            wirelessC: row[35],
+            voltageRailC: row[36],
+            otherSensorC: row[37]
         )
     }
 }

--- a/Sources/MacPerfMonitorCore/Sampling/SMCReader.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/SMCReader.swift
@@ -16,6 +16,17 @@ struct ThermalSample: Sendable, Equatable {
     /// average: "CPU temperature" means the hottest core to a user.
     var cpuDieMaxC: Double?
 
+    /// Per-display-group hottest readings, recorded so the Hardware tab's
+    /// sensor charts have history to read back after a restart.
+    var cpuPCoreMaxC: Double?
+    var cpuECoreMaxC: Double?
+    var batteryMaxC: Double?
+    var airflowMaxC: Double?
+    var skinMaxC: Double?
+    var wirelessMaxC: Double?
+    var voltageRailMaxC: Double?
+    var otherMaxC: Double?
+
     /// Average across the CPU die sensors, the secondary trend figure.
     var cpuDieAvgC: Double?
 
@@ -41,44 +52,80 @@ struct ThermalSample: Sendable, Equatable {
 /// table: key names drift between M1/M2/M3/M4 generations but the prefixes
 /// have held. See docs/temperature-design.md for the probed key inventory.
 final class SMCReader {
-    /// The temperature domain a discovered key's readings belong to.
-    enum SensorDomain: Sendable, Equatable {
-        case cpuDie
-        case gpuDie
-        case ssd
-    }
 
     private var connection: io_connect_t = 0
     private var didOpen = false
-    private var didDiscover = false
-    private var cpuKeys: [UInt32] = []
-    private var gpuKeys: [UInt32] = []
-    private var ssdKeys: [UInt32] = []
     private var fanCount = 0
     private var cached = ThermalSample()
     private var lastRead: Date?
     private let minInterval: TimeInterval = 5.0
-    /// Full-inventory discovery cache (`sensorInventory`), separate from the
-    /// sampling key sets above: every readable temperature key, not just the
-    /// headline domains.
-    private var inventoryKeys: [(key: UInt32, name: String)]?
-    private var inventoryFanCount = 0
+    /// Every readable temperature key with its display group, discovered once
+    /// and shared by the sampling read and the full inventory. One list, so a
+    /// sensor is classified the same way wherever it surfaces.
+    private var groupedKeys: [(key: UInt32, name: String, group: String)]?
+    /// The slow-moving domains' last readings, refreshed on their own longer
+    /// cadence (see `slowInterval`) and carried between sweeps.
+    private var slowMaxima: [String: Double] = [:]
+    private var lastSlowRead: Date?
+    /// Airflow, skin, wireless, rails and the unidentified tail move over
+    /// minutes, not seconds, and there are ~190 of them against ~75 die keys:
+    /// sweeping the lot every read cost 37 ms a time (measured on an M3 Pro),
+    /// which would have pushed the app's time-averaged CPU from 1.3% toward
+    /// the 2% budget. They get a 30 s cadence; the figures a user watches move
+    /// at the full read rate.
+    private let slowInterval: TimeInterval = 30
 
     deinit {
         if connection != 0 { IOServiceClose(connection) }
     }
 
+    /// The per-domain hottest readings for one tick. Every display group is
+    /// carried, not just the die figures: the recorded history behind the
+    /// Hardware tab's sensor charts is built from these, so the trends survive
+    /// a restart.
     func read(now: Date) -> ThermalSample? {
         if let lastRead, now.timeIntervalSince(lastRead) < minInterval { return cached }
         guard open() else { return nil }
-        if !didDiscover { discoverKeys() }
+        discover()
+
+        let slowDue = lastSlowRead.map { now.timeIntervalSince($0) >= slowInterval } ?? true
+        var maxima: [String: Double] = [:]
+        var slow: [String: Double] = [:]
+        var cpuValues: [Double] = []
+        for entry in groupedKeys ?? [] {
+            let isFast = Self.isFastGroup(entry.group)
+            guard isFast || slowDue else { continue }
+            guard let value = readFloat(entry.key), Self.isPlausibleReading(value) else { continue }
+            if isFast {
+                maxima[entry.group] = Swift.max(maxima[entry.group] ?? value, value)
+                if entry.group == Self.groupCPUPCores || entry.group == Self.groupCPUECores {
+                    cpuValues.append(value)
+                }
+            } else {
+                slow[entry.group] = Swift.max(slow[entry.group] ?? value, value)
+            }
+        }
+        if slowDue {
+            slowMaxima = slow
+            lastSlowRead = now
+        }
+        maxima.merge(slowMaxima) { current, _ in current }
 
         var sample = ThermalSample()
-        let cpu = temperatures(of: cpuKeys)
-        sample.cpuDieMaxC = cpu.max()
-        if !cpu.isEmpty { sample.cpuDieAvgC = cpu.reduce(0, +) / Double(cpu.count) }
-        sample.gpuDieMaxC = temperatures(of: gpuKeys).max()
-        sample.ssdMaxC = temperatures(of: ssdKeys).max()
+        sample.cpuPCoreMaxC = maxima[Self.groupCPUPCores]
+        sample.cpuECoreMaxC = maxima[Self.groupCPUECores]
+        sample.cpuDieMaxC = [sample.cpuPCoreMaxC, sample.cpuECoreMaxC].compactMap { $0 }.max()
+        if !cpuValues.isEmpty {
+            sample.cpuDieAvgC = cpuValues.reduce(0, +) / Double(cpuValues.count)
+        }
+        sample.gpuDieMaxC = maxima[Self.groupGPU]
+        sample.ssdMaxC = maxima[Self.groupSSD]
+        sample.batteryMaxC = maxima[Self.groupBattery]
+        sample.airflowMaxC = maxima[Self.groupAirflow]
+        sample.skinMaxC = maxima[Self.groupSkin]
+        sample.wirelessMaxC = maxima[Self.groupWireless]
+        sample.voltageRailMaxC = maxima[Self.groupVoltageRails]
+        sample.otherMaxC = maxima[Self.groupOther]
         sample.fans = (0..<fanCount).compactMap(readFan)
         cached = sample
         lastRead = now
@@ -87,18 +134,22 @@ final class SMCReader {
 
     // MARK: - Classification policy
 
-    /// Which domain an SMC key's readings belong to, or nil for keys that must
-    /// never feed a die figure. `TV*` keys are voltage-rail sensors, not die:
-    /// the SMC enumerates keys sorted with uppercase before lowercase, so a
-    /// `TV`-accepting discovery with a small cap used to fill every slot with
-    /// voltage rails on chips with many `TV*` keys (M3 Pro has 12+ plausible
-    /// ones) and never reach a single `Te*`/`Tp*` die sensor. Case matters
-    /// throughout: `Tg*` is the GPU, while `TG0*` keys are battery-adjacent.
-    static func domain(forKeyName name: String) -> SensorDomain? {
-        if name.hasPrefix("Tp") || name.hasPrefix("Te") { return .cpuDie }
-        if name.hasPrefix("Tg") { return .gpuDie }
-        if name.hasPrefix("TH0") { return .ssd }
-        return nil
+    /// True for the groups that may feed a die temperature figure. `TV*` keys
+    /// are voltage-rail sensors, not die: the SMC enumerates keys sorted with
+    /// uppercase before lowercase, so a `TV`-accepting discovery with a small
+    /// cap used to fill every slot with voltage rails on chips with many `TV*`
+    /// keys (M3 Pro has 12+ plausible ones) and never reach a single
+    /// `Te*`/`Tp*` die sensor. Case matters throughout: `Tg*` is the GPU,
+    /// while `TG0*` keys are battery-adjacent.
+    static func isDieGroup(_ group: String) -> Bool {
+        group == groupCPUPCores || group == groupCPUECores || group == groupGPU
+    }
+
+    /// The domains read on every sampling pass: the ones a user watches move
+    /// second to second, and few enough keys to be cheap. The rest ride
+    /// `slowInterval`.
+    static func isFastGroup(_ group: String) -> Bool {
+        isDieGroup(group) || group == groupSSD || group == groupBattery
     }
 
     /// Discovery gate: strict, so calibration offsets (0.00 / -3.10 pairs),
@@ -140,13 +191,6 @@ final class SMCReader {
 
     // MARK: - Reading
 
-    private func temperatures(of keys: [UInt32]) -> [Double] {
-        keys.compactMap { key in
-            guard let value = readFloat(key), Self.isPlausibleReading(value) else { return nil }
-            return value
-        }
-    }
-
     private func readFan(_ index: Int) -> FanSample? {
         guard let rpm = readFloat(Self.fourCC("F\(index)Ac")) else { return nil }
         let maxRPM = readFloat(Self.fourCC("F\(index)Mx")).map { Int($0.rounded()) }
@@ -164,61 +208,54 @@ final class SMCReader {
 
     /// Every readable temperature key with a plausible value, grouped by
     /// domain, plus the fans. The first call pays the full enumeration (a few
-    /// hundred milliseconds, so never on the sampling tick); repeat calls on
-    /// the same reader re-read just the discovered keys (tens of
-    /// milliseconds), which is what lets a visible sensor surface stay live.
-    /// Callers keep one reader confined to their own queue.
+    /// hundred milliseconds); repeat calls on the same reader re-read just the
+    /// discovered keys (tens of milliseconds), which is what lets a visible
+    /// sensor surface stay live. Callers keep one reader confined to their own
+    /// queue.
     func sensorInventory() -> (sensors: [SensorReading], fans: [FanSample]) {
         guard open() else { return ([], []) }
-        if inventoryKeys == nil {
-            var discovered: [(key: UInt32, name: String)] = []
-            if let total = readUInt32(Self.fourCC("#KEY")), total > 0 {
-                for index in 0..<total {
-                    guard let key = keyAtIndex(index) else { continue }
-                    let name = Self.toString(key)
-                    guard name.hasPrefix("T") else { continue }
-                    guard let value = readFloat(key), Self.isPlausibleReading(value) else {
-                        continue
-                    }
-                    discovered.append((key, name))
-                }
-            }
-            inventoryKeys = discovered
-            var fans = readFloat(Self.fourCC("FNum")).map { Int($0) } ?? 0
-            if fans == 0, (readFloat(Self.fourCC("F0Mx")) ?? 0) > 0 { fans = 1 }
-            inventoryFanCount = fans
-        }
-        let sensors = (inventoryKeys ?? []).compactMap { entry -> SensorReading? in
+        discover()
+        let sensors = (groupedKeys ?? []).compactMap { entry -> SensorReading? in
             guard let value = readFloat(entry.key), Self.isPlausibleReading(value) else {
                 return nil
             }
-            return SensorReading(
-                key: entry.name, celsius: value, group: Self.sensorGroup(forKeyName: entry.name))
+            return SensorReading(key: entry.name, celsius: value, group: entry.group)
         }
-        return (sensors, (0..<inventoryFanCount).compactMap(readFan))
+        return (sensors, (0..<fanCount).compactMap(readFan))
     }
 
-    /// Human grouping for the full key set. Broader than `domain(forKeyName:)`,
-    /// which only admits keys safe to fold into headline die figures; here
-    /// everything readable is shown, honestly labelled. Ordering for display
-    /// lives in `sensorGroupOrder`.
+    static let groupCPUPCores = "CPU die (P cores)"
+    static let groupCPUECores = "CPU die (E cores)"
+    static let groupGPU = "GPU clusters"
+    static let groupSSD = "SSD"
+    static let groupBattery = "Battery"
+    static let groupAirflow = "Airflow"
+    static let groupSkin = "Skin and board"
+    static let groupWireless = "Wireless"
+    static let groupVoltageRails = "Voltage rails"
+    static let groupOther = "Other"
+
+    /// Human grouping for the full key set: every readable sensor is placed,
+    /// honestly labelled, including the rails and the unidentified tail that
+    /// must never reach a die figure. Ordering for display lives in
+    /// `sensorGroupOrder`.
     static func sensorGroup(forKeyName name: String) -> String {
-        if name.hasPrefix("Tp") { return "CPU die (P cores)" }
-        if name.hasPrefix("Te") { return "CPU die (E cores)" }
-        if name.hasPrefix("Tg") { return "GPU clusters" }
-        if name.hasPrefix("TH0") { return "SSD" }
-        if name.hasPrefix("TB") { return "Battery" }
-        if name.hasPrefix("Ta") { return "Airflow" }
-        if name.hasPrefix("Ts") { return "Skin and board" }
-        if name.hasPrefix("Th") { return "Skin and board" }
-        if name.hasPrefix("TW") { return "Wireless" }
-        if name.hasPrefix("TV") { return "Voltage rails" }
-        return "Other"
+        if name.hasPrefix("Tp") { return groupCPUPCores }
+        if name.hasPrefix("Te") { return groupCPUECores }
+        if name.hasPrefix("Tg") { return groupGPU }
+        if name.hasPrefix("TH0") { return groupSSD }
+        if name.hasPrefix("TB") { return groupBattery }
+        if name.hasPrefix("Ta") { return groupAirflow }
+        if name.hasPrefix("Ts") { return groupSkin }
+        if name.hasPrefix("Th") { return groupSkin }
+        if name.hasPrefix("TW") { return groupWireless }
+        if name.hasPrefix("TV") { return groupVoltageRails }
+        return groupOther
     }
 
     static let sensorGroupOrder = [
-        "CPU die (P cores)", "CPU die (E cores)", "GPU clusters", "SSD", "Battery",
-        "Airflow", "Skin and board", "Wireless", "Voltage rails", "Other",
+        groupCPUPCores, groupCPUECores, groupGPU, groupSSD, groupBattery,
+        groupAirflow, groupSkin, groupWireless, groupVoltageRails, groupOther,
     ]
 
     // MARK: - Connection
@@ -233,26 +270,25 @@ final class SMCReader {
     }
 
     /// One-time discovery: a single enumeration classifying every plausible
-    /// temperature key into its domain (uncapped: the full die-sensor sweep
-    /// costs single-digit milliseconds at the read throttle), plus the fan
-    /// count from `FNum` with a probe of fan 0 as the fallback.
-    private func discoverKeys() {
-        didDiscover = true
-        fanCount = readFloat(Self.fourCC("FNum")).map { Int($0) } ?? 0
-        if fanCount == 0, (readFloat(Self.fourCC("F0Mx")) ?? 0) > 0 { fanCount = 1 }
-        guard let total = readUInt32(Self.fourCC("#KEY")), total > 0 else { return }
-        for index in 0..<total {
-            guard let key = keyAtIndex(index) else { continue }
-            guard let domain = Self.domain(forKeyName: Self.toString(key)) else { continue }
-            guard let value = readFloat(key), Self.isPlausibleDiscoveryTemperature(value) else {
-                continue
-            }
-            switch domain {
-            case .cpuDie: cpuKeys.append(key)
-            case .gpuDie: gpuKeys.append(key)
-            case .ssd: ssdKeys.append(key)
+    /// temperature key into its display group, plus the fan count from `FNum`
+    /// with a probe of fan 0 as the fallback. The strict gate here is what
+    /// keeps calibration offsets and dead zones out of every later sweep.
+    private func discover() {
+        guard groupedKeys == nil else { return }
+        var found: [(key: UInt32, name: String, group: String)] = []
+        if let total = readUInt32(Self.fourCC("#KEY")), total > 0 {
+            for index in 0..<total {
+                guard let key = keyAtIndex(index) else { continue }
+                let name = Self.toString(key)
+                guard name.hasPrefix("T") else { continue }
+                guard let value = readFloat(key), Self.isPlausibleDiscoveryTemperature(value)
+                else { continue }
+                found.append((key, name, Self.sensorGroup(forKeyName: name)))
             }
         }
+        groupedKeys = found
+        fanCount = readFloat(Self.fourCC("FNum")).map { Int($0) } ?? 0
+        if fanCount == 0, (readFloat(Self.fourCC("F0Mx")) ?? 0) > 0 { fanCount = 1 }
     }
 
     // MARK: - SMC protocol

--- a/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
@@ -836,7 +836,7 @@ public final class Sampler {
             purgeableBytes: vm?.purgeable ?? 0
         )
 
-        return SystemSample(
+        var sample = SystemSample(
             timestamp: now,
             totalRAM: totalRAM,
             free: vm?.free ?? 0,
@@ -882,14 +882,25 @@ public final class Sampler {
             gpuUtilization: gpu?.utilization,
             gpuPowerWatts: gpu?.gpuPowerWatts,
             anePowerWatts: gpu?.anePowerWatts,
-            cpuDieC: thermal?.cpuDieMaxC,
-            gpuDieC: thermal?.gpuDieMaxC,
-            ssdTemperatureC: thermal?.ssdMaxC,
-            fanRPM: thermal?.primaryFanRPM.map(Double.init),
             // Public API, no SMC involved: read every tick so the throttling
             // record survives even when no thermal surface is active.
             thermalPressure: ThermalPressureState(ProcessInfo.processInfo.thermalState)
         )
+        // Assigned rather than passed: the memberwise call is already at the
+        // type checker's practical limit, and every one of these is a plain
+        // optional copy.
+        sample.cpuDieC = thermal?.cpuDieMaxC
+        sample.gpuDieC = thermal?.gpuDieMaxC
+        sample.ssdTemperatureC = thermal?.ssdMaxC
+        sample.fanRPM = thermal?.primaryFanRPM.map(Double.init)
+        sample.cpuPCoreDieC = thermal?.cpuPCoreMaxC
+        sample.cpuECoreDieC = thermal?.cpuECoreMaxC
+        sample.airflowC = thermal?.airflowMaxC
+        sample.skinC = thermal?.skinMaxC
+        sample.wirelessC = thermal?.wirelessMaxC
+        sample.voltageRailC = thermal?.voltageRailMaxC
+        sample.otherSensorC = thermal?.otherMaxC
+        return sample
     }
 
 }

--- a/Tests/MacPerfMonitorCoreTests/ThermalHistoryTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/ThermalHistoryTests.swift
@@ -132,6 +132,74 @@ final class ThermalHistoryTests: XCTestCase {
         XCTAssertEqual(points.map { $0.cpuDieC ?? 0 }.max() ?? 0, 50, accuracy: 0.001)
     }
 
+    // MARK: - Per-domain sensor history (v15)
+
+    /// Every sensor group the Hardware charts draw must round-trip, so a
+    /// restart resumes the trend instead of starting blank.
+    func testSensorDomainsRoundTripAndSeedEveryChart() throws {
+        let now = Date()
+        var sample = thermalSample(at: now, cpu: 71, gpu: 54, ssd: 35, fan: 2400)
+        sample.cpuPCoreDieC = 71
+        sample.cpuECoreDieC = 63
+        sample.airflowC = 41
+        sample.skinC = 47
+        sample.wirelessC = 42
+        sample.voltageRailC = 66
+        sample.otherSensorC = 76
+        sample.batteryTemperatureCelsius = 29
+        try store.insert(systemSample: sample)
+
+        let history = try store.systemHistory(.fiveMinutes, now: now)
+        let point = try XCTUnwrap(history.last)
+        // Each group resolves to its recorded series through the same lookup
+        // the Hardware overview seeds from.
+        let expected: [(String, Double)] = [
+            (SMCReader.groupCPUPCores, 71), (SMCReader.groupCPUECores, 63),
+            (SMCReader.groupGPU, 54), (SMCReader.groupSSD, 35),
+            (SMCReader.groupBattery, 29), (SMCReader.groupAirflow, 41),
+            (SMCReader.groupSkin, 47), (SMCReader.groupWireless, 42),
+            (SMCReader.groupVoltageRails, 66), (SMCReader.groupOther, 76),
+        ]
+        for (group, value) in expected {
+            let recorded = HardwareFacts.SensorGroup.recordedValue(group, in: point)
+            XCTAssertEqual(try XCTUnwrap(recorded, group), value, accuracy: 0.001, group)
+        }
+        // No group is left without a series, or its chart could never seed.
+        for group in HardwareFacts.SensorGroup.displayOrder {
+            XCTAssertNotNil(HardwareFacts.SensorGroup.recordedValue(group, in: point), group)
+        }
+    }
+
+    /// Ticks that never read the SMC stay nil rather than seeding a chart
+    /// with zeros, and a battery-less desktop reports no battery series.
+    func testUnsampledDomainsStayNil() throws {
+        let now = Date()
+        try store.insert(systemSample: Make.system(timestamp: now, pressurePercent: 10))
+        let point = try XCTUnwrap(try store.systemHistory(.fiveMinutes, now: now).last)
+        for group in HardwareFacts.SensorGroup.displayOrder {
+            XCTAssertNil(HardwareFacts.SensorGroup.recordedValue(group, in: point), group)
+        }
+    }
+
+    func testSensorDomainsSurviveBothRollupTiers() throws {
+        for i in 0..<40 {
+            var sample = thermalSample(at: anchor.addingTimeInterval(Double(i) * 6), cpu: 50)
+            sample.cpuPCoreDieC = i == 20 ? 92 : 50
+            sample.airflowC = 40
+            sample.otherSensorC = 70
+            try store.insert(systemSample: sample)
+        }
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(600))
+        let minutePoints = try store.systemHistory(.oneDay, now: anchor.addingTimeInterval(600))
+        XCTAssertEqual(minutePoints.compactMap(\.cpuPCoreDieC).max() ?? 0, 92, accuracy: 0.001)
+        XCTAssertEqual(minutePoints.compactMap(\.airflowC).max() ?? 0, 40, accuracy: 0.001)
+
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(7200))
+        let hourPoints = try store.systemHistory(.sevenDays, now: anchor.addingTimeInterval(7200))
+        XCTAssertEqual(hourPoints.compactMap(\.cpuPCoreDieC).max() ?? 0, 92, accuracy: 0.001)
+        XCTAssertEqual(hourPoints.compactMap(\.otherSensorC).max() ?? 0, 70, accuracy: 0.001)
+    }
+
     // MARK: - Chart downsampler
 
     private func historyPoint(index: Int) -> SystemHistoryPoint {

--- a/Tests/MacPerfMonitorCoreTests/ThermalTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/ThermalTests.swift
@@ -6,33 +6,39 @@ final class ThermalTests: XCTestCase {
     // MARK: - Key classification
 
     func testDieKeysClassifyByPrefix() {
-        XCTAssertEqual(SMCReader.domain(forKeyName: "Tp05"), .cpuDie)
-        XCTAssertEqual(SMCReader.domain(forKeyName: "Tp1K"), .cpuDie)
-        XCTAssertEqual(SMCReader.domain(forKeyName: "Te0S"), .cpuDie)
-        XCTAssertEqual(SMCReader.domain(forKeyName: "Tg0D"), .gpuDie)
-        XCTAssertEqual(SMCReader.domain(forKeyName: "Tg1l"), .gpuDie)
-        XCTAssertEqual(SMCReader.domain(forKeyName: "TH0x"), .ssd)
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Tp05"), SMCReader.groupCPUPCores)
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Tp1K"), SMCReader.groupCPUPCores)
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Te0S"), SMCReader.groupCPUECores)
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Tg0D"), SMCReader.groupGPU)
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "Tg1l"), SMCReader.groupGPU)
+        XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TH0x"), SMCReader.groupSSD)
+        for name in ["Tp05", "Te0S", "Tg0D"] {
+            XCTAssertTrue(SMCReader.isDieGroup(SMCReader.sensorGroup(forKeyName: name)), name)
+        }
     }
 
     /// TV* keys are voltage rails, not die sensors. The SMC enumerates keys
     /// sorted with uppercase before lowercase, so a TV-accepting discovery
     /// with a 12-key cap filled every slot with voltage rails on M3 Pro and
-    /// the reported "die temperature" never included a die sensor.
-    func testVoltageRailKeysAreExcluded() {
+    /// the reported "die temperature" never included a die sensor. They are
+    /// still surfaced, in their own group, but can never feed a die figure.
+    func testVoltageRailKeysAreNeverDie() {
         for name in ["TVA0", "TVD0", "TVHE", "TVHF", "TVS0", "TVSx", "TVMD"] {
-            XCTAssertNil(SMCReader.domain(forKeyName: name), name)
+            XCTAssertEqual(
+                SMCReader.sensorGroup(forKeyName: name), SMCReader.groupVoltageRails, name)
+            XCTAssertFalse(SMCReader.isDieGroup(SMCReader.sensorGroup(forKeyName: name)), name)
         }
     }
 
     /// Case is load-bearing: TG0* (uppercase) keys are battery-adjacent ioft
     /// readings, TE*/TP* style names are not die sensors, and Th*/Ts* are
     /// board and skin sensors.
-    func testNonDieFamiliesAreExcluded() {
+    func testNonDieFamiliesAreNeverDie() {
         for name in [
             "TG0B", "TG0V", "TED0", "TFD0", "TB0T", "TW0P", "Ta04", "TaLP",
-            "Th00", "Ts0P", "Tz11", "TCMz", "Tf16", "TR0Z", "F0Ac", "#KEY",
+            "Th00", "Ts0P", "Tz11", "TCMz", "Tf16", "TR0Z",
         ] {
-            XCTAssertNil(SMCReader.domain(forKeyName: name), name)
+            XCTAssertFalse(SMCReader.isDieGroup(SMCReader.sensorGroup(forKeyName: name)), name)
         }
     }
 
@@ -119,6 +125,23 @@ final class ThermalTests: XCTestCase {
         XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TW0P"), "Wireless")
         XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TVHE"), "Voltage rails")
         XCTAssertEqual(SMCReader.sensorGroup(forKeyName: "TCMz"), "Other")
+        // The display order the surfaces iterate must cover every group the
+        // classifier can return, or a domain would silently never chart.
+        XCTAssertEqual(Set(HardwareFacts.SensorGroup.displayOrder).count, 10)
+        // The figures a user watches tick at the full read rate; the slow tail
+        // (an extra ~190 keys) rides its own longer cadence.
+        for group in [
+            SMCReader.groupCPUPCores, SMCReader.groupCPUECores, SMCReader.groupGPU,
+            SMCReader.groupSSD, SMCReader.groupBattery,
+        ] {
+            XCTAssertTrue(SMCReader.isFastGroup(group), group)
+        }
+        for group in [
+            SMCReader.groupAirflow, SMCReader.groupSkin, SMCReader.groupWireless,
+            SMCReader.groupVoltageRails, SMCReader.groupOther,
+        ] {
+            XCTAssertFalse(SMCReader.isFastGroup(group), group)
+        }
         // Every group name has a display position.
         let names = [
             "Tp00", "Te00", "Tg00", "TH0a", "TB1T", "TaRF", "Ts00", "TW0P", "TVS0", "Tf16",
@@ -160,6 +183,16 @@ final class ThermalTests: XCTestCase {
         }
         if let gpu = sample.gpuDieMaxC { XCTAssertTrue(SMCReader.isPlausibleReading(gpu)) }
         if let ssd = sample.ssdMaxC { XCTAssertTrue(SMCReader.isPlausibleReading(ssd)) }
+        // The headline die figure is exactly the hotter of the two clusters,
+        // never a rail or a board sensor.
+        let clusters = [sample.cpuPCoreMaxC, sample.cpuECoreMaxC].compactMap { $0 }
+        XCTAssertEqual(sample.cpuDieMaxC, clusters.max())
+        for value in [
+            sample.airflowMaxC, sample.skinMaxC, sample.wirelessMaxC, sample.voltageRailMaxC,
+            sample.otherMaxC, sample.batteryMaxC,
+        ].compactMap({ $0 }) {
+            XCTAssertTrue(SMCReader.isPlausibleReading(value))
+        }
         for fan in sample.fans {
             XCTAssertGreaterThanOrEqual(fan.rpm, 0)
             XCTAssertLessThan(fan.rpm, 20000)


### PR DESCRIPTION
From the report that the Hardware sensor charts reset and lose their trend lines when the app is closed.

They were accumulating in memory only. Now they read back from the log like every other chart.

- **v15 migration**: per-domain columns for the groups that had no recorded series (P core die, E core die, airflow, skin and board, wireless, voltage rails, other). GPU, SSD, battery and fans were already covered. Max rollups through the minute and hour tiers, matching the existing thermal columns.
- **Seeding**: the overview loads the raw five-minute window on appear and seeds every chart, keeping any live sweep samples that landed while the read was in flight. Groups with no recorded column, and databases predating v15, stay empty and fill from live sweeps rather than inventing data.
- **One classification**: SMCReader discovers once into a single grouped key list shared by the sampling read and the Hardware inventory, replacing the separate die-only discovery. `isDieGroup` keeps voltage rails and the unidentified tail out of any die figure.
- **Cost control**: sweeping all 262 T* keys per read measured 37 ms on an M3 Pro (140 us/key), which sustained would have moved time-averaged CPU from the documented 1.31% toward the 2% budget. The domains a user watches tick every read (~75 keys, ~10 ms); airflow, skin, wireless, rails and other move over minutes and ride a 30 s cadence, carried forward in between. Net ~0.1% of one core.

Verified: swift build (0 warnings), swift test (483 green), lint clean, and live on an M3 Pro: all ten domains present on every recorded row, and after a cold restart the charts render with their trend already drawn instead of blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ