### PR TITLE
Disk Map phase 1: scan engine, headless scan command, design notes

### DIFF
--- a/Sources/MacPerfMonitorCore/DiskMap/BulkAttributeLister.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/BulkAttributeLister.swift
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT
+
+import Darwin
+import Foundation
+
+/// The fast path: `getattrlistbulk(2)` returns many entries per call with
+/// exactly the attributes asked for, so a directory of ten thousand files is
+/// a handful of syscalls and no per-entry `lstat`. About an order of magnitude
+/// quicker than `FileManager` enumeration on APFS, which is the difference
+/// between a scan the user waits for and one they give up on.
+///
+/// Record layout (per the man page): a `u_int32_t` length, then
+/// `ATTR_CMN_RETURNED_ATTRS`, then `ATTR_CMN_ERROR` if set, then the remaining
+/// attributes in bit order within each group (common, dir, file, then the
+/// `ATTR_CMNEXT_*` group carried in `forkattr` under `FSOPT_ATTR_CMN_EXTENDED`).
+/// Every value starts on a 4-byte boundary, so 8-byte values are read with
+/// unaligned loads. The walker consumes only attributes the returned bitmap
+/// says are present, which is what makes it correct for files (no dir attrs),
+/// directories (no file attrs) and errored entries (name only) alike.
+public struct BulkAttributeLister: DirectoryLister {
+    /// Whether to ask for `ATTR_CMNEXT_PRIVATESIZE` (bytes that would be freed
+    /// on delete, the exact clone and snapshot accounting). Off by default: it
+    /// costs about half again the scan time, see `DiskMapScanOptions`.
+    public var fetchPrivateSize: Bool
+
+    public init(fetchPrivateSize: Bool = false) {
+        self.fetchPrivateSize = fetchPrivateSize
+    }
+
+    public func list(path: String) throws -> DirectoryListing {
+        let fd = try DirectoryOpener.open(path)
+        defer { close(fd) }
+        return try Self.list(fd: fd, fetchPrivateSize: fetchPrivateSize)
+    }
+
+    /// One buffer per call; 128 KiB holds a few hundred entries per syscall.
+    static let bufferSize = 128 * 1024
+
+    static func list(fd: Int32, fetchPrivateSize: Bool) throws -> DirectoryListing {
+        var request = attrlist()
+        request.bitmapcount = u_short(ATTR_BIT_MAP_COUNT)
+        request.commonattr =
+            attrgroup_t(ATTR_CMN_RETURNED_ATTRS) | attrgroup_t(ATTR_CMN_ERROR)
+            | attrgroup_t(ATTR_CMN_NAME) | attrgroup_t(ATTR_CMN_OBJTYPE)
+            | attrgroup_t(ATTR_CMN_MODTIME) | attrgroup_t(ATTR_CMN_FLAGS)
+            | attrgroup_t(ATTR_CMN_FILEID)
+        request.dirattr = attrgroup_t(ATTR_DIR_MOUNTSTATUS)
+        request.fileattr = attrgroup_t(ATTR_FILE_LINKCOUNT) | attrgroup_t(ATTR_FILE_ALLOCSIZE)
+        request.forkattr = attrgroup_t(ATTR_CMNEXT_EXT_FLAGS)
+        if fetchPrivateSize {
+            request.forkattr |= attrgroup_t(ATTR_CMNEXT_PRIVATESIZE)
+        }
+        let options = UInt64(FSOPT_ATTR_CMN_EXTENDED)
+
+        let buffer = UnsafeMutableRawPointer.allocate(byteCount: bufferSize, alignment: 8)
+        defer { buffer.deallocate() }
+
+        var listing = DirectoryListing()
+        listing.entries.reserveCapacity(256)
+        listing.nameBytes.reserveCapacity(256 * 24)
+
+        while true {
+            let returned = getattrlistbulk(fd, &request, buffer, bufferSize, options)
+            if returned < 0 {
+                throw DirectoryListingError(errno: errno)
+            }
+            if returned == 0 { break }
+            var cursor = UnsafeRawPointer(buffer)
+            let end = cursor + bufferSize
+            for _ in 0..<Int(returned) {
+                guard cursor + 4 <= end else { break }
+                let length = Int(cursor.loadUnaligned(as: UInt32.self))
+                guard length >= 24, cursor + length <= end else { break }
+                Self.decode(record: cursor, length: length, into: &listing)
+                cursor += length
+            }
+        }
+        return listing
+    }
+
+    // MARK: - Record decoding
+
+    private static func decode(
+        record: UnsafeRawPointer, length: Int, into listing: inout DirectoryListing
+    ) {
+        var field = record + 4
+        let commonReturned = field.loadUnaligned(as: UInt32.self)
+        let dirReturned = (field + 8).loadUnaligned(as: UInt32.self)
+        let fileReturned = (field + 12).loadUnaligned(as: UInt32.self)
+        let forkReturned = (field + 16).loadUnaligned(as: UInt32.self)
+        field += 20
+
+        var error: Int32 = 0
+        if commonReturned & UInt32(ATTR_CMN_ERROR) != 0 {
+            error = Int32(bitPattern: field.loadUnaligned(as: UInt32.self))
+            field += 4
+        }
+
+        var nameStart: UnsafeRawPointer?
+        var nameLength = 0
+        if commonReturned & UInt32(ATTR_CMN_NAME) != 0 {
+            let offset = Int(field.loadUnaligned(as: Int32.self))
+            var count = Int(field.loadUnaligned(fromByteOffset: 4, as: UInt32.self))
+            let start = field + offset
+            // attr_length includes the NUL terminator; strip it when present.
+            if count > 0, start.load(fromByteOffset: count - 1, as: UInt8.self) == 0 {
+                count -= 1
+            }
+            if offset >= 0, count >= 0, start + count <= record + length {
+                nameStart = start
+                nameLength = count
+            }
+            field += 8
+        }
+        guard let nameStart, nameLength > 0 else { return }
+
+        var type: DirectoryEntryType = .other
+        if commonReturned & UInt32(ATTR_CMN_OBJTYPE) != 0 {
+            type = DirectoryEntryType(vnodeType: field.loadUnaligned(as: UInt32.self))
+            field += 4
+        }
+        var modified: UInt32 = 0
+        if commonReturned & UInt32(ATTR_CMN_MODTIME) != 0 {
+            let seconds = field.loadUnaligned(as: Int64.self)
+            modified = seconds > 0 ? UInt32(clamping: seconds) : 0
+            field += 16
+        }
+        var bsdFlags: UInt32 = 0
+        if commonReturned & UInt32(ATTR_CMN_FLAGS) != 0 {
+            bsdFlags = field.loadUnaligned(as: UInt32.self)
+            field += 4
+        }
+        var fileID: UInt64 = 0
+        if commonReturned & UInt32(ATTR_CMN_FILEID) != 0 {
+            fileID = field.loadUnaligned(as: UInt64.self)
+            field += 8
+        }
+
+        var isMountPoint = false
+        if dirReturned & UInt32(ATTR_DIR_MOUNTSTATUS) != 0 {
+            let status = field.loadUnaligned(as: UInt32.self)
+            let boundary = UInt32(DIR_MNTSTATUS_MNTPOINT) | UInt32(DIR_MNTSTATUS_TRIGGER)
+            isMountPoint = status & boundary != 0
+            field += 4
+        }
+
+        var linkCount: UInt32 = 1
+        if fileReturned & UInt32(ATTR_FILE_LINKCOUNT) != 0 {
+            linkCount = field.loadUnaligned(as: UInt32.self)
+            field += 4
+        }
+        var allocated: UInt64 = 0
+        if fileReturned & UInt32(ATTR_FILE_ALLOCSIZE) != 0 {
+            let value = field.loadUnaligned(as: Int64.self)
+            allocated = value > 0 ? UInt64(value) : 0
+            field += 8
+        }
+
+        var privateSize: UInt64? = nil
+        if forkReturned & UInt32(ATTR_CMNEXT_PRIVATESIZE) != 0 {
+            let value = field.loadUnaligned(as: Int64.self)
+            privateSize = value > 0 ? UInt64(value) : 0
+            field += 8
+        }
+        var extendedFlags: UInt64 = 0
+        if forkReturned & UInt32(ATTR_CMNEXT_EXT_FLAGS) != 0 {
+            extendedFlags = field.loadUnaligned(as: UInt64.self)
+            field += 8
+        }
+
+        let name = UnsafeRawBufferPointer(start: nameStart, count: nameLength)
+        listing.append(name: name) { offset, count in
+            RawDirectoryEntry(
+                nameOffset: offset, nameLength: count, type: type, error: error,
+                allocated: allocated, privateSize: privateSize, fileID: fileID,
+                modified: modified, bsdFlags: bsdFlags, linkCount: linkCount,
+                extendedFlags: extendedFlags, isMountPoint: isMountPoint)
+        }
+    }
+}
+
+/// The portable path for filesystems that reject `getattrlistbulk` (exFAT,
+/// FAT, some network and third-party filesystems): `readdir` plus one
+/// `fstatat(AT_SYMLINK_NOFOLLOW)` per entry. Same contract, several times
+/// slower, no clone or private-size information.
+public struct ReaddirLister: DirectoryLister {
+    public init() {}
+
+    public func list(path: String) throws -> DirectoryListing {
+        let fd = try DirectoryOpener.open(path)
+        guard let dir = fdopendir(fd) else {
+            let code = errno
+            close(fd)
+            throw DirectoryListingError(errno: code)
+        }
+        defer { closedir(dir) }
+
+        var dirStat = stat()
+        let haveDirStat = fstat(fd, &dirStat) == 0
+
+        var listing = DirectoryListing()
+        while let entry = readdir(dir) {
+            let nameLength = Int(entry.pointee.d_namlen)
+            guard nameLength > 0 else { continue }
+            let (isDot, isDotDot) = withUnsafePointer(to: &entry.pointee.d_name) {
+                raw -> (Bool, Bool) in
+                let bytes = UnsafeRawPointer(raw).assumingMemoryBound(to: UInt8.self)
+                if nameLength == 1, bytes[0] == UInt8(ascii: ".") { return (true, false) }
+                if nameLength == 2, bytes[0] == UInt8(ascii: "."), bytes[1] == UInt8(ascii: ".") {
+                    return (false, true)
+                }
+                return (false, false)
+            }
+            if isDot || isDotDot { continue }
+
+            var st = stat()
+            let statResult = withUnsafePointer(to: &entry.pointee.d_name) { raw in
+                raw.withMemoryRebound(to: CChar.self, capacity: nameLength + 1) { cName in
+                    fstatat(fd, cName, &st, AT_SYMLINK_NOFOLLOW)
+                }
+            }
+            let statError: Int32 = statResult == 0 ? 0 : errno
+
+            withUnsafePointer(to: &entry.pointee.d_name) { raw in
+                let bytes = UnsafeRawBufferPointer(start: UnsafeRawPointer(raw), count: nameLength)
+                listing.append(name: bytes) { offset, count in
+                    guard statError == 0 else {
+                        return RawDirectoryEntry(
+                            nameOffset: offset, nameLength: count, type: .other, error: statError)
+                    }
+                    let type = DirectoryEntryType(mode: st.st_mode)
+                    let seconds = st.st_mtimespec.tv_sec
+                    let crossesDevice = haveDirStat && st.st_dev != dirStat.st_dev
+                    return RawDirectoryEntry(
+                        nameOffset: offset, nameLength: count, type: type,
+                        allocated: st.st_blocks > 0 ? UInt64(st.st_blocks) * 512 : 0,
+                        fileID: st.st_ino,
+                        modified: seconds > 0 ? UInt32(clamping: seconds) : 0,
+                        bsdFlags: st.st_flags, linkCount: UInt32(st.st_nlink),
+                        isMountPoint: type == .directory && crossesDevice)
+                }
+            }
+        }
+        return listing
+    }
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/DirectoryLister.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DirectoryLister.swift
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+
+import Darwin
+import Foundation
+
+/// What a directory entry is, as far as the scanner cares.
+public enum DirectoryEntryType: UInt8, Sendable {
+    case regular
+    case directory
+    case symlink
+    /// Sockets, fifos, devices: kept as zero-byte leaves.
+    case other
+}
+
+/// One directory entry, straight from the filesystem, with no strings: the
+/// name is a range into the listing's shared byte buffer. Fixed-size and
+/// trivially copyable so a listing of ten thousand entries is one allocation
+/// plus the names.
+public struct RawDirectoryEntry: Sendable, Equatable {
+    public var nameOffset: UInt32
+    public var nameLength: UInt16
+    public var type: DirectoryEntryType
+    /// Non-zero when the filesystem reported a per-entry error; only the name
+    /// is meaningful then.
+    public var error: Int32
+    /// Allocated bytes on disk (`ATTR_FILE_ALLOCSIZE`, `st_blocks * 512`).
+    public var allocated: UInt64
+    /// `ATTR_CMNEXT_PRIVATESIZE` when fetched, else equal to `allocated`.
+    public var privateSize: UInt64
+    public var fileID: UInt64
+    /// Whole seconds since 1970.
+    public var modified: UInt32
+    /// BSD `st_flags`.
+    public var bsdFlags: UInt32
+    public var linkCount: UInt32
+    /// `ATTR_CMNEXT_EXT_FLAGS` (zero from listers that cannot read it).
+    public var extendedFlags: UInt64
+    /// A directory that is a mount point or an automount trigger.
+    public var isMountPoint: Bool
+
+    public init(
+        nameOffset: UInt32, nameLength: UInt16, type: DirectoryEntryType, error: Int32 = 0,
+        allocated: UInt64 = 0, privateSize: UInt64? = nil, fileID: UInt64 = 0,
+        modified: UInt32 = 0, bsdFlags: UInt32 = 0, linkCount: UInt32 = 1,
+        extendedFlags: UInt64 = 0, isMountPoint: Bool = false
+    ) {
+        self.nameOffset = nameOffset
+        self.nameLength = nameLength
+        self.type = type
+        self.error = error
+        self.allocated = allocated
+        self.privateSize = privateSize ?? allocated
+        self.fileID = fileID
+        self.modified = modified
+        self.bsdFlags = bsdFlags
+        self.linkCount = linkCount
+        self.extendedFlags = extendedFlags
+        self.isMountPoint = isMountPoint
+    }
+}
+
+/// Everything read from one directory. Names exclude "." and ".." and are
+/// raw UTF-8 without terminators.
+public struct DirectoryListing: Sendable {
+    public var entries: [RawDirectoryEntry]
+    public var nameBytes: [UInt8]
+
+    public init(entries: [RawDirectoryEntry] = [], nameBytes: [UInt8] = []) {
+        self.entries = entries
+        self.nameBytes = nameBytes
+    }
+
+    public func name(of entry: RawDirectoryEntry) -> ArraySlice<UInt8> {
+        let start = Int(entry.nameOffset)
+        return nameBytes[start..<(start + Int(entry.nameLength))]
+    }
+
+    public func nameString(of entry: RawDirectoryEntry) -> String {
+        String(decoding: name(of: entry), as: UTF8.self)
+    }
+
+    /// Append one entry, copying its name into the shared buffer.
+    public mutating func append(
+        name: some Collection<UInt8>, _ make: (UInt32, UInt16) -> RawDirectoryEntry
+    ) {
+        let offset = UInt32(nameBytes.count)
+        nameBytes.append(contentsOf: name)
+        entries.append(make(offset, UInt16(min(name.count, Int(UInt16.max)))))
+    }
+}
+
+/// Why a directory could not be listed. The distinction between `notPermitted`
+/// and `accessDenied` is load-bearing: the first is TCC and Full Disk Access
+/// clears it, the second is ordinary Unix permissions and nothing the app can
+/// ask for will change it.
+public enum DirectoryListingError: Error, Sendable, Equatable {
+    /// EPERM: privacy protection (TCC) refused the open.
+    case notPermitted
+    /// EACCES: the directory is not readable by this user.
+    case accessDenied
+    /// ENOENT or ENOTDIR: it went away (or changed) since its parent was read.
+    case vanished
+    /// EDEADLK: an evicted (dataless) directory that would need to download.
+    case dataless
+    /// ENOTSUP from `getattrlistbulk`: this filesystem wants the readdir path.
+    case notSupported
+    case other(errno: Int32)
+
+    init(errno code: Int32) {
+        switch code {
+        case EPERM: self = .notPermitted
+        case EACCES: self = .accessDenied
+        case ENOENT, ENOTDIR: self = .vanished
+        case EDEADLK: self = .dataless
+        case ENOTSUP: self = .notSupported
+        default: self = .other(errno: code)
+        }
+    }
+
+    /// The tree flag a directory carries when its listing fails this way.
+    public var nodeFlag: FileNodeFlags {
+        switch self {
+        case .notPermitted: return .notPermitted
+        case .accessDenied: return .accessDenied
+        case .dataless: return .dataless
+        case .vanished, .notSupported, .other: return .unreadable
+        }
+    }
+}
+
+/// Reads one directory. Implementations must be safe to call from several
+/// threads at once (each call is independent) and must never follow symlinks,
+/// cross into another volume, or materialise dataless content.
+public protocol DirectoryLister: Sendable {
+    func list(path: String) throws -> DirectoryListing
+}
+
+/// Shared open logic. Paths deeper than `PATH_MAX` (deep `node_modules` trees
+/// reach it) cannot be opened in one call, so long paths are walked with
+/// `openat` one component at a time, holding a single descriptor.
+enum DirectoryOpener {
+    static let flags: Int32 = O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
+    /// Below this many bytes a plain `open` is used; `PATH_MAX` is 1024.
+    static let directOpenLimit = 960
+
+    /// Returns a descriptor the caller must close, or throws the mapped error.
+    static func open(_ path: String) throws -> Int32 {
+        let utf8Count = path.utf8.count
+        if utf8Count < directOpenLimit {
+            let fd = Darwin.open(path, flags)
+            guard fd >= 0 else { throw DirectoryListingError(errno: errno) }
+            return fd
+        }
+        return try openLong(path)
+    }
+
+    private static func openLong(_ path: String) throws -> Int32 {
+        var fd = Darwin.open("/", flags)
+        guard fd >= 0 else { throw DirectoryListingError(errno: errno) }
+        // Walk in chunks that each fit comfortably under PATH_MAX so the
+        // number of opens stays small even for very deep trees.
+        var chunk = ""
+        for component in path.split(separator: "/", omittingEmptySubsequences: true) {
+            if chunk.utf8.count + component.utf8.count + 1 >= directOpenLimit {
+                fd = try step(from: fd, relative: chunk)
+                chunk = ""
+            }
+            if !chunk.isEmpty { chunk += "/" }
+            chunk += component
+        }
+        if !chunk.isEmpty {
+            fd = try step(from: fd, relative: chunk)
+        }
+        return fd
+    }
+
+    private static func step(from fd: Int32, relative: String) throws -> Int32 {
+        let next = openat(fd, relative, flags)
+        let code = errno
+        close(fd)
+        guard next >= 0 else { throw DirectoryListingError(errno: code) }
+        return next
+    }
+}
+
+extension DirectoryEntryType {
+    /// From `fsobj_type_t` (the `vtype` enumeration).
+    init(vnodeType: UInt32) {
+        switch vnodeType {
+        case UInt32(VREG.rawValue): self = .regular
+        case UInt32(VDIR.rawValue): self = .directory
+        case UInt32(VLNK.rawValue): self = .symlink
+        default: self = .other
+        }
+    }
+
+    init(mode: mode_t) {
+        switch mode & S_IFMT {
+        case S_IFREG: self = .regular
+        case S_IFDIR: self = .directory
+        case S_IFLNK: self = .symlink
+        default: self = .other
+        }
+    }
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapReconciliation.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapReconciliation.swift
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import os
+
+/// Tallies the scanner keeps as it goes. Published in progress events and
+/// frozen into the reconciliation at the end.
+public struct DiskMapScanCounts: Sendable, Equatable {
+    /// Every entry read from a listing, whatever became of it.
+    public var entries: UInt64 = 0
+    /// Directories listed successfully.
+    public var directories: UInt64 = 0
+    /// Regular files kept as individual nodes.
+    public var files: UInt64 = 0
+    /// Regular files folded into per-kind small-file nodes.
+    public var foldedFiles: UInt64 = 0
+    public var symlinks: UInt64 = 0
+    /// Directories that returned EPERM (TCC; Full Disk Access clears it).
+    public var notPermitted: Int = 0
+    /// Data vaults (`UF_DATAVAULT`) that returned EPERM: entitlement-only,
+    /// nothing the user can grant.
+    public var dataVaults: Int = 0
+    /// Directories that returned EACCES (Unix permissions).
+    public var accessDenied: Int = 0
+    /// Directories that failed for any other reason.
+    public var unreadable: Int = 0
+    /// Directories that disappeared between their parent's listing and their own.
+    public var vanished: Int = 0
+    /// Evicted (dataless) directories, never opened.
+    public var datalessDirectories: Int = 0
+    /// Mount points and automount triggers, never descended.
+    public var separateVolumes: Int = 0
+    /// Later encounters of hard-linked files, counted once.
+    public var hardLinkDuplicates: Int = 0
+    /// Files with no local data (iCloud or file provider placeholders).
+    public var datalessFiles: Int = 0
+    /// Files flagged as possibly sharing blocks (clones or snapshot-held).
+    public var sharedBlockFiles: Int = 0
+    /// Entries the filesystem reported a per-entry error for.
+    public var entryErrors: Int = 0
+
+    public init() {}
+
+    /// Directories whose contents are missing from the tree, all causes.
+    public var unlistedDirectories: Int {
+        notPermitted + dataVaults + accessDenied + unreadable + vanished + datalessDirectories
+    }
+}
+
+/// A sibling volume of the scanned one that shares its container: the sealed
+/// System volume, Preboot, VM, Update. Not scannable, not removable, but part
+/// of what Finder calls "Macintosh HD used".
+public struct DiskMapSystemVolume: Sendable, Equatable, Identifiable {
+    public var id: String { mountPoint }
+    public var mountPoint: String
+    public var name: String
+    public var role: VolumeRole
+    public var usedBytes: UInt64
+}
+
+/// Why the scanned total and the volume's used figure differ, and by how
+/// much. The identity is `used = scanned + unaccounted`; purgeable space is an
+/// overlay (it overlaps files the scan counted as well as snapshot space it
+/// did not), shared blocks come straight from the tree, and the overshoot case
+/// (scanned exceeds used, which clones cause) is reported rather than hidden.
+public struct DiskMapReconciliation: Sendable, Equatable {
+    public var volumeMountPoint: String
+    public var volumeName: String?
+    public var totalBytes: UInt64?
+    /// `VolumeInfo.usedBytes` read after the scan finished.
+    public var usedBytes: UInt64?
+    public var availableBytes: UInt64?
+    /// Finder-style headline free figure (available plus purgeable).
+    public var importantUsageAvailableBytes: UInt64?
+    public var purgeableBytes: UInt64?
+    public var scannedBytes: UInt64
+    public var sharedBytes: UInt64
+    public var scannedItems: UInt64
+    /// `max(0, used - scanned)`: metadata, local snapshots, drift.
+    public var unaccountedBytes: UInt64
+    /// `max(0, scanned - used)`: clones counted at full size.
+    public var overshootBytes: UInt64
+    public var localSnapshotCount: Int?
+    public var counts: DiskMapScanCounts
+    public var systemVolumes: [DiskMapSystemVolume]
+    /// The volume's used bytes before the scan started, to expose drift.
+    public var usedBytesBeforeScan: UInt64?
+    /// True when used space moved more than 1% while the scan ran; the
+    /// unaccounted figure is then partly drift, not just metadata.
+    public var volumeChangedDuringScan: Bool
+
+    /// Bytes of scanned content the scan could see. When the scope is a
+    /// folder this is still the volume's figure; the UI labels it as such.
+    public var accountedFraction: Double? {
+        guard let usedBytes, usedBytes > 0 else { return nil }
+        return min(1, Double(scannedBytes) / Double(usedBytes))
+    }
+
+    static func compute(
+        scope: DiskMapScope,
+        mountPoint: String,
+        volume: VolumeInfo?,
+        allVolumes: [VolumeInfo],
+        usedBefore: UInt64?,
+        scannedBytes: UInt64,
+        sharedBytes: UInt64,
+        scannedItems: UInt64,
+        counts: DiskMapScanCounts,
+        localSnapshotCount: Int?
+    ) -> DiskMapReconciliation {
+        let used = volume?.usedBytes
+        let unaccounted = used.map { $0 > scannedBytes ? $0 - scannedBytes : 0 } ?? 0
+        let overshoot = used.map { scannedBytes > $0 ? scannedBytes - $0 : 0 } ?? 0
+        var changed = false
+        if let used, let usedBefore, used > 0 {
+            let delta = used > usedBefore ? used - usedBefore : usedBefore - used
+            changed = Double(delta) / Double(used) > 0.01
+        }
+
+        var system: [DiskMapSystemVolume] = []
+        if scope == .startupDisk, let container = volume?.containerBSDName {
+            for sibling in allVolumes
+            where sibling.containerBSDName == container && sibling.mountPoint != mountPoint {
+                switch sibling.role {
+                case .system, .preboot, .recovery, .vm, .support:
+                    system.append(
+                        DiskMapSystemVolume(
+                            mountPoint: sibling.mountPoint, name: sibling.name,
+                            role: sibling.role, usedBytes: sibling.usedBytes))
+                case .data, .user:
+                    continue
+                }
+            }
+            system.sort { $0.usedBytes > $1.usedBytes }
+        }
+
+        return DiskMapReconciliation(
+            volumeMountPoint: mountPoint,
+            volumeName: volume?.name,
+            totalBytes: volume?.totalBytes,
+            usedBytes: used,
+            availableBytes: volume?.availableBytes,
+            importantUsageAvailableBytes: volume?.importantUsageAvailableBytes,
+            purgeableBytes: volume?.purgeableBytes,
+            scannedBytes: scannedBytes,
+            sharedBytes: sharedBytes,
+            scannedItems: scannedItems,
+            unaccountedBytes: unaccounted,
+            overshootBytes: overshoot,
+            localSnapshotCount: localSnapshotCount,
+            counts: counts,
+            systemVolumes: system,
+            usedBytesBeforeScan: usedBefore,
+            volumeChangedDuringScan: changed)
+    }
+}
+
+/// Counts local Time Machine snapshots on a volume by asking `tmutil`; there
+/// is no public API for it and `fs_snapshot_list` needs an entitlement. Bounded
+/// by a short timeout so a wedged tool can never hold a scan's completion.
+public enum LocalSnapshotCounter {
+    private static let log = Logger(subsystem: "uk.co.bzwrd.macperfmonitor", category: "diskmap")
+
+    public static func count(mountPoint: String, timeout: TimeInterval = 3) -> Int? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tmutil")
+        process.arguments = ["listlocalsnapshots", mountPoint]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        process.standardInput = FileHandle.nullDevice
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
+        do {
+            try process.run()
+        } catch {
+            log.notice("tmutil unavailable: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        if exited.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            return nil
+        }
+        guard process.terminationStatus == 0,
+            let text = String(data: data, encoding: .utf8)
+        else { return nil }
+        return text.split(whereSeparator: \.isNewline)
+            .filter { $0.hasPrefix("com.apple.TimeMachine.") }
+            .count
+    }
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapScanner.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapScanner.swift
@@ -1,0 +1,787 @@
+// SPDX-License-Identifier: MIT
+
+import Darwin
+import Foundation
+import os
+
+/// Knobs for one scan. Defaults are what the app uses; the CLI exposes them
+/// so the defaults can be measured rather than guessed.
+public struct DiskMapScanOptions: Sendable {
+    /// Files smaller than this are folded into per-kind small-file nodes
+    /// (see `FileTreeBuilder`). Nil picks a threshold from the volume's used
+    /// inode count; 0 disables folding.
+    public var smallFileThreshold: UInt64?
+    /// A directory folds only when it has more small files than this, so a
+    /// tidy folder of a dozen documents keeps every file visible.
+    public var minimumSmallFilesToFold: Int
+    public var workerCount: Int
+    /// Ask for `ATTR_CMNEXT_PRIVATESIZE` on every entry (exact clone and
+    /// snapshot accounting in the tree). Off by default: measured over 2 M
+    /// entries it turned a 15 s scan into a 23 s one, so the app fetches the
+    /// private size lazily for the item the user is looking at instead.
+    public var fetchPrivateSize: Bool
+    /// How often a progress event with a pruned preview is emitted.
+    public var previewInterval: TimeInterval
+    public var qualityOfService: QualityOfService
+    /// Mark the scan's disk reads as utility-class so foreground work is not
+    /// starved. Off only for benchmarking.
+    public var throttleIO: Bool
+    /// Ask `tmutil` for the local snapshot count when the scan finishes.
+    public var countLocalSnapshots: Bool
+    /// Replace the filesystem reader (tests use a synthetic one).
+    public var lister: (any DirectoryLister)?
+
+    public init(
+        smallFileThreshold: UInt64? = nil,
+        minimumSmallFilesToFold: Int = 24,
+        workerCount: Int = DiskMapScanOptions.defaultWorkerCount,
+        fetchPrivateSize: Bool = false,
+        previewInterval: TimeInterval = 0.5,
+        qualityOfService: QualityOfService = .utility,
+        throttleIO: Bool = true,
+        countLocalSnapshots: Bool = true,
+        lister: (any DirectoryLister)? = nil
+    ) {
+        self.smallFileThreshold = smallFileThreshold
+        self.minimumSmallFilesToFold = minimumSmallFilesToFold
+        self.workerCount = workerCount
+        self.fetchPrivateSize = fetchPrivateSize
+        self.previewInterval = previewInterval
+        self.qualityOfService = qualityOfService
+        self.throttleIO = throttleIO
+        self.countLocalSnapshots = countLocalSnapshots
+        self.lister = lister
+    }
+
+    /// Measured on an M3 Pro over 145 k warm entries: 1 worker 11.3 s, 2 4.4 s,
+    /// 4 2.4 s, 6 1.9 s, 8 1.7 s. Six takes most of the win without occupying
+    /// every core of a smaller chip while the sampler keeps ticking.
+    public static let defaultWorkerCount = min(
+        6, max(1, ProcessInfo.processInfo.activeProcessorCount))
+
+    /// Fold nothing on a small volume, 16 KiB on a typical one, 64 KiB on a
+    /// very large one. The point is bounding node count (about 80 bytes each)
+    /// without hiding anything the map could ever draw.
+    public static func adaptiveThreshold(usedInodes: UInt64?) -> UInt64 {
+        guard let usedInodes else { return 16_384 }
+        if usedInodes < 250_000 { return 0 }
+        if usedInodes < 3_500_000 { return 16_384 }
+        return 65_536
+    }
+}
+
+public struct DiskMapScanProgress: Sendable, Equatable {
+    public var scope: DiskMapScope
+    public var entries: UInt64
+    public var directories: UInt64
+    public var bytes: UInt64
+    /// Canonical path of the directory most recently merged.
+    public var currentPath: String
+    public var elapsed: TimeInterval
+    public var counts: DiskMapScanCounts
+    /// Used inodes on the volume when the scope is a whole volume; the
+    /// denominator for a determinate progress bar.
+    public var expectedEntries: UInt64?
+
+    public var fraction: Double? {
+        guard let expectedEntries, expectedEntries > 0 else { return nil }
+        return min(1, Double(entries) / Double(expectedEntries))
+    }
+}
+
+public enum DiskMapScanError: Error, LocalizedError, Sendable, Equatable {
+    case rootNotADirectory(String)
+    case rootNotReadable(String, DirectoryListingError)
+
+    public var errorDescription: String? {
+        switch self {
+        case .rootNotADirectory(let path):
+            return "\(path) is not a folder."
+        case .rootNotReadable(let path, let reason):
+            switch reason {
+            case .notPermitted:
+                return
+                    "macOS did not allow access to \(path). Grant Full Disk Access and try again."
+            case .accessDenied:
+                return "\(path) is not readable by your user account."
+            case .vanished:
+                return "\(path) no longer exists."
+            case .dataless:
+                return "\(path) is stored in iCloud and has not been downloaded."
+            case .notSupported, .other:
+                return "\(path) could not be read."
+            }
+        }
+    }
+}
+
+/// A finished scan: the frozen tree plus everything needed to explain it.
+public struct DiskMapSnapshot: Sendable {
+    public var scope: DiskMapScope
+    /// The directory that was opened (the Data volume root for the startup
+    /// disk); node paths hang off this.
+    public var rootPath: String
+    public var tree: FileTree
+    public var reconciliation: DiskMapReconciliation
+    public var scannedAt: Date
+    public var duration: TimeInterval
+    /// True when the scan was cancelled: the tree is what had been read.
+    public var partial: Bool
+    public var smallFileThreshold: UInt64
+    /// Bumped by in-place edits (a trash) so views can compare cheaply.
+    public var revision: Int
+
+    public init(
+        scope: DiskMapScope, rootPath: String, tree: FileTree,
+        reconciliation: DiskMapReconciliation, scannedAt: Date, duration: TimeInterval,
+        partial: Bool, smallFileThreshold: UInt64, revision: Int
+    ) {
+        self.scope = scope
+        self.rootPath = rootPath
+        self.tree = tree
+        self.reconciliation = reconciliation
+        self.scannedAt = scannedAt
+        self.duration = duration
+        self.partial = partial
+        self.smallFileThreshold = smallFileThreshold
+        self.revision = revision
+    }
+
+    /// The path the user should see (and Finder should open) for a node.
+    public func displayPath(of node: Int32) -> String {
+        FirmlinkMap.system.canonicalPath(tree.path(of: node, rootPath: rootPath))
+    }
+
+    /// The path to open on disk for a node.
+    public func filesystemPath(of node: Int32) -> String {
+        tree.path(of: node, rootPath: rootPath)
+    }
+}
+
+public enum DiskMapScanEvent: Sendable {
+    case progress(DiskMapScanProgress, DiskMapPreviewNode)
+    case completed(DiskMapSnapshot)
+    case failed(DiskMapScanError)
+}
+
+/// Lets a blocking caller (the CLI on SIGINT) stop a scan.
+public final class DiskMapCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+    private var handler: (() -> Void)?
+
+    public init() {}
+
+    public var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    public func cancel() {
+        lock.lock()
+        cancelled = true
+        let handler = self.handler
+        lock.unlock()
+        handler?()
+    }
+
+    func attach(_ handler: @escaping () -> Void) {
+        lock.lock()
+        self.handler = handler
+        let already = cancelled
+        lock.unlock()
+        if already { handler() }
+    }
+}
+
+/// Walks a scope and builds a `FileTree`. One coordinator thread owns the
+/// tree; a handful of worker threads read directories. Threads rather than
+/// tasks because the IO policies that keep the scan polite (no dataless
+/// materialisation, utility-class disk reads) are per thread, and a
+/// cooperative-pool thread is shared with everything else in the process.
+///
+/// Work is a LIFO stack of directories (depth-first keeps the frontier small)
+/// and results flow back through a bounded inbox, so a fast reader cannot
+/// outrun the coordinator's memory. Cancelling finalises what has been read
+/// into a partial snapshot instead of throwing the work away.
+public final class DiskMapScanner: @unchecked Sendable {
+    private let volumeSource: @Sendable () -> [VolumeInfo]
+    private let snapshotCounter: @Sendable (String) -> Int?
+
+    public init(
+        volumeSource: @escaping @Sendable () -> [VolumeInfo] = { VolumeReader().read().volumes },
+        snapshotCounter: @escaping @Sendable (String) -> Int? = {
+            LocalSnapshotCounter.count(mountPoint: $0)
+        }
+    ) {
+        self.volumeSource = volumeSource
+        self.snapshotCounter = snapshotCounter
+    }
+
+    /// Progress events at `options.previewInterval`, then exactly one
+    /// `completed` or `failed`, then the stream ends. Dropping the stream
+    /// cancels the scan.
+    public func scan(
+        _ scope: DiskMapScope, options: DiskMapScanOptions = DiskMapScanOptions()
+    )
+        -> AsyncStream<DiskMapScanEvent>
+    {
+        AsyncStream(bufferingPolicy: .bufferingNewest(4)) { continuation in
+            let job = DiskMapScanJob(
+                scope: scope, options: options, volumeSource: volumeSource,
+                snapshotCounter: snapshotCounter
+            ) { event in
+                continuation.yield(event)
+                switch event {
+                case .completed, .failed: continuation.finish()
+                case .progress: break
+                }
+            }
+            continuation.onTermination = { _ in job.cancel() }
+            job.start()
+        }
+    }
+
+    /// Synchronous variant for the CLI and for tests.
+    public func scanBlocking(
+        _ scope: DiskMapScope,
+        options: DiskMapScanOptions = DiskMapScanOptions(),
+        cancellation: DiskMapCancellationToken? = nil,
+        onProgress: ((DiskMapScanProgress, DiskMapPreviewNode) -> Void)? = nil
+    ) throws -> DiskMapSnapshot {
+        let done = DispatchSemaphore(value: 0)
+        let box = ResultBox()
+        let job = DiskMapScanJob(
+            scope: scope, options: options, volumeSource: volumeSource,
+            snapshotCounter: snapshotCounter
+        ) { event in
+            switch event {
+            case .progress(let progress, let preview):
+                onProgress?(progress, preview)
+            case .completed(let snapshot):
+                box.result = .success(snapshot)
+                done.signal()
+            case .failed(let error):
+                box.result = .failure(error)
+                done.signal()
+            }
+        }
+        cancellation?.attach { job.cancel() }
+        job.start()
+        done.wait()
+        return try box.result!.get()
+    }
+
+    private final class ResultBox: @unchecked Sendable {
+        var result: Result<DiskMapSnapshot, DiskMapScanError>?
+    }
+}
+
+// MARK: - The job
+
+final class DiskMapScanJob: @unchecked Sendable {
+    private static let log = Logger(subsystem: "uk.co.bzwrd.macperfmonitor", category: "diskmap")
+
+    private struct DirectoryJob {
+        var node: Int32
+        var path: String
+    }
+
+    private enum Message {
+        case listing(node: Int32, path: String, DirectoryListing)
+        case failure(node: Int32, path: String, DirectoryListingError)
+    }
+
+    private let scope: DiskMapScope
+    private let options: DiskMapScanOptions
+    private let volumeSource: @Sendable () -> [VolumeInfo]
+    private let snapshotCounter: @Sendable (String) -> Int?
+    private let emit: (DiskMapScanEvent) -> Void
+
+    private let cancelFlag = OSAllocatedUnfairLock(initialState: false)
+    private let startFlag = OSAllocatedUnfairLock(initialState: false)
+    private let stack = WorkStack()
+    private let inbox = Inbox(capacity: 64)
+    private let workersDone = DispatchGroup()
+
+    // Coordinator-thread state.
+    private let builder = FileTreeBuilder()
+    private var counts = DiskMapScanCounts()
+    private var hardLinks = Set<UInt64>()
+    private var threshold: UInt64 = 0
+    private var lister: any DirectoryLister = BulkAttributeLister()
+    private var outstanding = 0
+    private var lastPath = ""
+
+    init(
+        scope: DiskMapScope,
+        options: DiskMapScanOptions,
+        volumeSource: @escaping @Sendable () -> [VolumeInfo],
+        snapshotCounter: @escaping @Sendable (String) -> Int?,
+        emit: @escaping (DiskMapScanEvent) -> Void
+    ) {
+        self.scope = scope
+        self.options = options
+        self.volumeSource = volumeSource
+        self.snapshotCounter = snapshotCounter
+        self.emit = emit
+    }
+
+    var isCancelled: Bool { cancelFlag.withLock { $0 } }
+
+    func cancel() {
+        let first = cancelFlag.withLock { flag -> Bool in
+            let was = flag
+            flag = true
+            return !was
+        }
+        guard first else { return }
+        stack.finish()
+        inbox.close()
+    }
+
+    func start() {
+        let first = startFlag.withLock { flag -> Bool in
+            let was = flag
+            flag = true
+            return !was
+        }
+        guard first else { return }
+        let thread = Thread { [self] in run() }
+        thread.name = "uk.co.bzwrd.macperfmonitor.diskmap.coordinator"
+        thread.qualityOfService = options.qualityOfService
+        thread.start()
+    }
+
+    // MARK: Coordinator
+
+    private func run() {
+        Self.applyThreadPolicies(throttle: options.throttleIO)
+        let startedAt = Date()
+        let startClock = DispatchTime.now()
+        let rootPath = scope.scanRoot
+
+        var rootStat = stat()
+        guard lstat(rootPath, &rootStat) == 0 else {
+            emit(.failed(.rootNotReadable(rootPath, DirectoryListingError(errno: errno))))
+            return
+        }
+        guard rootStat.st_mode & S_IFMT == S_IFDIR else {
+            emit(.failed(.rootNotADirectory(rootPath)))
+            return
+        }
+
+        let mountPoint = DiskMapScope.mountPoint(ofPath: rootPath) ?? rootPath
+        let usedInodes = DiskMapScope.usedInodes(ofPath: rootPath)
+        threshold =
+            options.smallFileThreshold
+            ?? DiskMapScanOptions.adaptiveThreshold(usedInodes: usedInodes)
+        let usedBefore = volumeSource().first { $0.mountPoint == mountPoint }?.usedBytes
+
+        lister = options.lister ?? BulkAttributeLister(fetchPrivateSize: options.fetchPrivateSize)
+        let rootListing: DirectoryListing
+        do {
+            rootListing = try listRoot(rootPath)
+        } catch let error as DirectoryListingError {
+            emit(.failed(.rootNotReadable(rootPath, error)))
+            return
+        } catch {
+            emit(.failed(.rootNotReadable(rootPath, .other(errno: 0))))
+            return
+        }
+
+        Self.log.notice(
+            "Disk Map scan start: \(rootPath, privacy: .public) threshold \(self.threshold) workers \(self.options.workerCount)"
+        )
+
+        // Folding leaves roughly six nodes in ten for a whole volume; reserving
+        // that up front avoids the last array doubling (which peaked RSS at
+        // twice the arena on a 3 M-inode disk). Folder scopes grow from zero.
+        if scope.isWholeVolume, let usedInodes {
+            builder.reserve(Int(min(usedInodes * 3 / 5, 4_000_000)))
+        }
+        let rootSeconds = rootStat.st_mtimespec.tv_sec
+        builder.appendRoot(
+            name: scope.rootName, fileID: rootStat.st_ino,
+            modified: rootSeconds > 0 ? UInt32(clamping: rootSeconds) : 0,
+            flags: Self.flags(forBSDFlags: rootStat.st_flags, name: []))
+        merge(rootListing, into: FileTree.root, path: rootPath)
+
+        let workerCount = max(1, options.workerCount)
+        for index in 0..<workerCount {
+            workersDone.enter()
+            let thread = Thread { [self] in
+                workerLoop()
+                workersDone.leave()
+            }
+            thread.name = "uk.co.bzwrd.macperfmonitor.diskmap.worker-\(index)"
+            thread.qualityOfService = options.qualityOfService
+            thread.start()
+        }
+
+        var lastPreview = startClock
+        let previewNanos = UInt64(max(0.001, options.previewInterval) * 1_000_000_000)
+        while outstanding > 0, !isCancelled {
+            guard let message = inbox.take() else { break }
+            outstanding -= 1
+            handle(message)
+            let now = DispatchTime.now()
+            if now.uptimeNanoseconds - lastPreview.uptimeNanoseconds >= previewNanos {
+                emitProgress(startedAt: startedAt, usedInodes: usedInodes)
+                lastPreview = now
+            }
+        }
+
+        stack.finish()
+        _ = workersDone.wait(timeout: .now() + 5)
+        // Listings that landed after the loop stopped (cancellation) are
+        // still good data; fold them in rather than drop them.
+        while let message = inbox.takeIfAvailable() {
+            outstanding -= 1
+            handle(message)
+        }
+
+        let partial = isCancelled
+        let tree = builder.build()
+        let volumesAfter = volumeSource()
+        let volume = volumesAfter.first { $0.mountPoint == mountPoint }
+        let snapshots = options.countLocalSnapshots ? snapshotCounter(mountPoint) : nil
+        let reconciliation = DiskMapReconciliation.compute(
+            scope: scope, mountPoint: mountPoint, volume: volume, allVolumes: volumesAfter,
+            usedBefore: usedBefore, scannedBytes: tree.bytes[0], sharedBytes: tree.shared[0],
+            scannedItems: UInt64(tree.count[0]), counts: counts, localSnapshotCount: snapshots)
+        let duration = Date().timeIntervalSince(startedAt)
+        Self.log.notice(
+            "Disk Map scan \(partial ? "cancelled" : "done", privacy: .public): \(tree.nodeCount) nodes, \(self.counts.entries) entries, \(tree.bytes[0]) bytes in \(duration, format: .fixed(precision: 1))s"
+        )
+        emit(
+            .completed(
+                DiskMapSnapshot(
+                    scope: scope, rootPath: rootPath, tree: tree, reconciliation: reconciliation,
+                    scannedAt: Date(), duration: duration, partial: partial,
+                    smallFileThreshold: threshold, revision: 1)))
+    }
+
+    /// The root listing doubles as the filesystem probe: `ENOTSUP` from the
+    /// bulk reader means this volume wants the readdir path for the whole scan.
+    private func listRoot(_ path: String) throws -> DirectoryListing {
+        do {
+            return try lister.list(path: path)
+        } catch DirectoryListingError.notSupported where options.lister == nil {
+            lister = ReaddirLister()
+            return try lister.list(path: path)
+        }
+    }
+
+    private func handle(_ message: Message) {
+        switch message {
+        case .listing(let node, let path, let listing):
+            merge(listing, into: node, path: path)
+        case .failure(let node, let path, let error):
+            if error == .notPermitted, builder.flags(of: node).contains(.dataVault) {
+                // A vault refuses everyone without the entitlement; keep it
+                // out of the Full Disk Access count so the banner stays true.
+                counts.dataVaults += 1
+                lastPath = path
+                return
+            }
+            builder.markUnlisted(node, error.nodeFlag)
+            switch error {
+            case .notPermitted: counts.notPermitted += 1
+            case .accessDenied: counts.accessDenied += 1
+            case .vanished: counts.vanished += 1
+            case .dataless: counts.datalessDirectories += 1
+            case .notSupported, .other: counts.unreadable += 1
+            }
+            lastPath = path
+        }
+    }
+
+    /// Turn one listing into the directory's child block, dedupe hard links,
+    /// fold small files, and queue the subdirectories worth descending into.
+    private func merge(_ listing: DirectoryListing, into node: Int32, path: String) {
+        counts.directories += 1
+        counts.entries += UInt64(listing.entries.count)
+        lastPath = path
+
+        var block: [FileTreeBuilder.Entry] = []
+        block.reserveCapacity(listing.entries.count)
+        var small: [FileTreeBuilder.Entry] = []
+        var childDirectories: [(offset: Int, path: String)] = []
+        let basePath = path == "/" ? "" : path
+
+        for raw in listing.entries {
+            let name = listing.name(of: raw)
+            if raw.error != 0 {
+                counts.entryErrors += 1
+                block.append(
+                    FileTreeBuilder.Entry(
+                        name: name, bytes: 0, fileID: raw.fileID, modified: raw.modified,
+                        flags: [.unreadable], kind: .other))
+                continue
+            }
+            var flags = Self.flags(forBSDFlags: raw.bsdFlags, name: name)
+
+            switch raw.type {
+            case .directory:
+                flags.insert(.directory)
+                let kind = name.withUnsafeBufferPointer {
+                    FileKindClassifier.kind(forNameBytes: $0, isDirectory: true)
+                }
+                if kind != .folder { flags.insert(.package) }
+                var descend = true
+                if raw.isMountPoint {
+                    flags.insert(.separateVolume)
+                    counts.separateVolumes += 1
+                    descend = false
+                } else if raw.bsdFlags & UInt32(SF_DATALESS) != 0 {
+                    counts.datalessDirectories += 1
+                    descend = false
+                }
+                if descend {
+                    let childPath = basePath + "/" + String(decoding: name, as: UTF8.self)
+                    childDirectories.append((block.count, childPath))
+                }
+                block.append(
+                    FileTreeBuilder.Entry(
+                        name: name, bytes: 0, fileID: raw.fileID, modified: raw.modified,
+                        count: 1, flags: flags, kind: kind))
+
+            case .regular:
+                var bytes = raw.allocated
+                var shared = raw.privateSize < raw.allocated ? raw.allocated - raw.privateSize : 0
+                if raw.bsdFlags & UInt32(SF_DATALESS) != 0 { counts.datalessFiles += 1 }
+                if raw.extendedFlags & UInt64(EF_MAY_SHARE_BLOCKS) != 0 {
+                    flags.insert(.mayShareBlocks)
+                    counts.sharedBlockFiles += 1
+                }
+                if raw.linkCount > 1, !hardLinks.insert(raw.fileID).inserted {
+                    flags.insert(.hardLinkDuplicate)
+                    bytes = 0
+                    shared = 0
+                    counts.hardLinkDuplicates += 1
+                }
+                let kind = name.withUnsafeBufferPointer {
+                    FileKindClassifier.kind(forNameBytes: $0, isDirectory: false)
+                }
+                let entry = FileTreeBuilder.Entry(
+                    name: name, bytes: bytes, shared: shared, fileID: raw.fileID,
+                    modified: raw.modified, count: 1, flags: flags, kind: kind)
+                if threshold > 0, bytes < threshold {
+                    small.append(entry)
+                } else {
+                    counts.files += 1
+                    block.append(entry)
+                }
+
+            case .symlink:
+                flags.insert(.symlink)
+                counts.symlinks += 1
+                let entry = FileTreeBuilder.Entry(
+                    name: name, bytes: raw.allocated, fileID: raw.fileID,
+                    modified: raw.modified, count: 1, flags: flags, kind: .other)
+                if threshold > 0 { small.append(entry) } else { block.append(entry) }
+
+            case .other:
+                let entry = FileTreeBuilder.Entry(
+                    name: name, bytes: 0, fileID: raw.fileID, modified: raw.modified, count: 1,
+                    flags: flags, kind: .other)
+                if threshold > 0 { small.append(entry) } else { block.append(entry) }
+            }
+        }
+
+        if small.count > options.minimumSmallFilesToFold {
+            counts.foldedFiles += UInt64(small.count)
+            block.append(contentsOf: Self.folds(of: small))
+        } else {
+            counts.files += UInt64(small.filter { !$0.flags.contains(.symlink) }.count)
+            block.append(contentsOf: small)
+        }
+
+        let range = builder.appendChildren(of: node, block)
+        for child in childDirectories {
+            stack.push(DirectoryJob(node: range.lowerBound + Int32(child.offset), path: child.path))
+            outstanding += 1
+        }
+    }
+
+    /// One synthetic child per kind present, in display order, carrying the
+    /// exact bytes and count of the files it stands in for.
+    private static func folds(of small: [FileTreeBuilder.Entry]) -> [FileTreeBuilder.Entry] {
+        struct Accumulator {
+            var bytes: UInt64 = 0
+            var shared: UInt64 = 0
+            var count: UInt32 = 0
+            var modified: UInt32 = 0
+        }
+        var byKind: [FileKind: Accumulator] = [:]
+        for entry in small {
+            var acc = byKind[entry.kind] ?? Accumulator()
+            acc.bytes &+= entry.bytes
+            acc.shared &+= entry.shared
+            acc.count &+= 1
+            acc.modified = max(acc.modified, entry.modified)
+            byKind[entry.kind] = acc
+        }
+        var folds: [FileTreeBuilder.Entry] = []
+        for kind in FileKind.displayOrder {
+            guard let acc = byKind[kind] else { continue }
+            folds.append(
+                FileTreeBuilder.Entry(
+                    name: [], bytes: acc.bytes, shared: acc.shared, fileID: 0,
+                    modified: acc.modified, count: acc.count, flags: [.smallFilesFold],
+                    kind: kind))
+        }
+        return folds
+    }
+
+    private func emitProgress(startedAt: Date, usedInodes: UInt64?) {
+        let total = builder.totalBytes
+        let progress = DiskMapScanProgress(
+            scope: scope, entries: counts.entries, directories: counts.directories,
+            bytes: total, currentPath: FirmlinkMap.system.canonicalPath(lastPath),
+            elapsed: Date().timeIntervalSince(startedAt), counts: counts,
+            expectedEntries: scope.isWholeVolume ? usedInodes : nil)
+        let preview = builder.preview(
+            depthLimit: 3, minimumBytes: max(1 << 20, total / 1000), maxChildren: 48)
+        emit(.progress(progress, preview))
+    }
+
+    private static func flags(forBSDFlags bsd: UInt32, name: ArraySlice<UInt8>) -> FileNodeFlags {
+        var flags: FileNodeFlags = []
+        if bsd & UInt32(UF_HIDDEN) != 0 || name.first == UInt8(ascii: ".") { flags.insert(.hidden) }
+        if bsd & UInt32(SF_RESTRICTED) != 0 { flags.insert(.restricted) }
+        if bsd & UInt32(SF_IMMUTABLE) != 0 { flags.insert(.immutable) }
+        if bsd & UInt32(SF_DATALESS) != 0 { flags.insert(.dataless) }
+        if bsd & UInt32(UF_DATAVAULT) != 0 { flags.insert(.dataVault) }
+        return flags
+    }
+
+    // MARK: Workers
+
+    private func workerLoop() {
+        Self.applyThreadPolicies(throttle: options.throttleIO)
+        while let job = stack.pop() {
+            if isCancelled { break }
+            do {
+                let listing = try lister.list(path: job.path)
+                inbox.post(.listing(node: job.node, path: job.path, listing))
+            } catch let error as DirectoryListingError {
+                inbox.post(.failure(node: job.node, path: job.path, error))
+            } catch {
+                inbox.post(.failure(node: job.node, path: job.path, .other(errno: 0)))
+            }
+        }
+    }
+
+    /// Per-thread IO policies: never materialise dataless (iCloud) content,
+    /// never bump access times, and read at utility priority so the person's
+    /// foreground work keeps the disk.
+    static func applyThreadPolicies(throttle: Bool) {
+        _ = setiopolicy_np(
+            IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES, IOPOL_SCOPE_THREAD,
+            IOPOL_MATERIALIZE_DATALESS_FILES_OFF)
+        _ = setiopolicy_np(
+            IOPOL_TYPE_VFS_ATIME_UPDATES, IOPOL_SCOPE_THREAD, IOPOL_ATIME_UPDATES_OFF)
+        if throttle {
+            _ = setiopolicy_np(IOPOL_TYPE_DISK, IOPOL_SCOPE_THREAD, IOPOL_UTILITY)
+        }
+    }
+
+    // MARK: Queues
+
+    /// Directories waiting to be read. LIFO: the newest (deepest) first, so
+    /// the frontier stays about depth times fan-out instead of the whole
+    /// breadth of a level.
+    private final class WorkStack {
+        private let condition = NSCondition()
+        private var jobs: [DirectoryJob] = []
+        private var finished = false
+
+        func push(_ job: DirectoryJob) {
+            condition.lock()
+            jobs.append(job)
+            condition.signal()
+            condition.unlock()
+        }
+
+        /// Blocks until a job is available; nil once finished and drained.
+        func pop() -> DirectoryJob? {
+            condition.lock()
+            defer { condition.unlock() }
+            while jobs.isEmpty, !finished {
+                condition.wait()
+            }
+            return jobs.popLast()
+        }
+
+        func finish() {
+            condition.lock()
+            finished = true
+            condition.broadcast()
+            condition.unlock()
+        }
+    }
+
+    /// Results flowing back to the coordinator, bounded so readers wait for
+    /// the merger rather than piling listings up in memory.
+    private final class Inbox {
+        private let condition = NSCondition()
+        private var items: [Message] = []
+        private var head = 0
+        private var closed = false
+        private let capacity: Int
+
+        init(capacity: Int) {
+            self.capacity = capacity
+        }
+
+        func post(_ message: Message) {
+            condition.lock()
+            while items.count - head >= capacity, !closed {
+                condition.wait()
+            }
+            if !closed {
+                items.append(message)
+                condition.broadcast()
+            }
+            condition.unlock()
+        }
+
+        /// Blocks until a message arrives; nil once closed and empty.
+        func take() -> Message? {
+            condition.lock()
+            defer { condition.unlock() }
+            while items.count == head, !closed {
+                condition.wait()
+            }
+            return dequeue()
+        }
+
+        func takeIfAvailable() -> Message? {
+            condition.lock()
+            defer { condition.unlock() }
+            return dequeue()
+        }
+
+        func close() {
+            condition.lock()
+            closed = true
+            condition.broadcast()
+            condition.unlock()
+        }
+
+        private func dequeue() -> Message? {
+            guard items.count > head else { return nil }
+            let message = items[head]
+            head += 1
+            if head >= 256 || head == items.count {
+                items.removeFirst(head)
+                head = 0
+            }
+            condition.broadcast()
+            return message
+        }
+    }
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapScope.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapScope.swift
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+
+import Darwin
+import Foundation
+
+/// What a Disk Map scan covers. The startup disk means the Data volume (see
+/// `FirmlinkMap`), presented as "Macintosh HD"; a folder is any directory the
+/// user picks; a volume is an external or secondary mount.
+public enum DiskMapScope: Hashable, Codable, Sendable {
+    case startupDisk
+    case home
+    case folder(String)
+    case volume(String)
+
+    /// The directory the scanner opens.
+    public var scanRoot: String {
+        switch self {
+        case .startupDisk: return Self.startupDiskScanRoot
+        case .home: return NSHomeDirectory()
+        case .folder(let path): return path
+        case .volume(let mountPoint): return mountPoint
+        }
+    }
+
+    /// The path shown to the user for the root.
+    public var displayRoot: String {
+        switch self {
+        case .startupDisk: return "/"
+        case .home: return NSHomeDirectory()
+        case .folder(let path): return FirmlinkMap.system.canonicalPath(path)
+        case .volume(let mountPoint): return mountPoint
+        }
+    }
+
+    /// The root node's name.
+    public var rootName: String {
+        switch self {
+        case .startupDisk: return "Macintosh HD"
+        case .home: return (NSHomeDirectory() as NSString).lastPathComponent
+        case .folder(let path):
+            let name = (path as NSString).lastPathComponent
+            return name.isEmpty ? path : name
+        case .volume(let mountPoint):
+            return mountPoint == "/" ? "Macintosh HD" : (mountPoint as NSString).lastPathComponent
+        }
+    }
+
+    /// Whether the scan covers a whole volume, in which case the volume's
+    /// used inode count is a fair progress denominator and the reconciliation
+    /// bar can compare against the volume's used bytes directly.
+    public var isWholeVolume: Bool {
+        switch self {
+        case .startupDisk, .volume: return true
+        case .home, .folder: return false
+        }
+    }
+
+    /// A stable file-name-safe key for the persisted snapshot.
+    public var id: String {
+        switch self {
+        case .startupDisk: return "startup"
+        case .home: return "home"
+        case .folder(let path): return "folder-" + Self.fileSafe(path)
+        case .volume(let mountPoint): return "volume-" + Self.fileSafe(mountPoint)
+        }
+    }
+
+    /// Normalise a user-chosen directory into a scope. `/`, `/System` and the
+    /// Data volume root all mean the startup disk (scanning `/` would walk the
+    /// sealed System volume and the Data volume together, which no volume
+    /// figure reconciles against); the home directory is `.home`; a folder
+    /// under a firmlink is opened by its Data-volume path so its bytes are
+    /// counted where they live.
+    public static func resolved(folder path: String) -> DiskMapScope {
+        let standardized = (path as NSString).standardizingPath
+        let trimmed =
+            standardized.count > 1 && standardized.hasSuffix("/")
+            ? String(standardized.dropLast()) : standardized
+        if trimmed == "/" || trimmed == "/System" || trimmed == FirmlinkMap.dataVolumeRoot {
+            return .startupDisk
+        }
+        if trimmed == NSHomeDirectory() { return .home }
+        return .folder(trimmed)
+    }
+
+    /// The Data volume when the startup disk is a volume group, else `/`.
+    static var startupDiskScanRoot: String {
+        var st = stat()
+        if stat(FirmlinkMap.dataVolumeRoot, &st) == 0, st.st_mode & S_IFMT == S_IFDIR {
+            return FirmlinkMap.dataVolumeRoot
+        }
+        return "/"
+    }
+
+    /// The mount point of the volume containing `path`, from `statfs`.
+    public static func mountPoint(ofPath path: String) -> String? {
+        var fs = statfs()
+        guard statfs(path, &fs) == 0 else { return nil }
+        return withUnsafePointer(to: &fs.f_mntonname) { raw in
+            raw.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) { String(cString: $0) }
+        }
+    }
+
+    /// Inodes in use on the volume containing `path` (`f_files - f_ffree`),
+    /// the denominator for a determinate progress bar and the input to the
+    /// adaptive small-file threshold.
+    public static func usedInodes(ofPath path: String) -> UInt64? {
+        var fs = statfs()
+        guard statfs(path, &fs) == 0, fs.f_files >= fs.f_ffree else { return nil }
+        return fs.f_files - fs.f_ffree
+    }
+
+    private static func fileSafe(_ path: String) -> String {
+        let allowed = Set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+        let mapped = path.map { allowed.contains($0) ? String($0) : "_" }.joined()
+        // Bound the length and keep it unique with a short hash of the path.
+        var hash: UInt64 = 1_469_598_103_934_665_603
+        for byte in path.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 1_099_511_628_211
+        }
+        return String(mapped.suffix(40)) + "-" + String(hash, radix: 16)
+    }
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/FileKind.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/FileKind.swift
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// The coarse category the Disk Map colours and groups by. Files are
+/// classified by extension at scan time from a static table (no `UTType`
+/// lookups on the hot path: three million entries cannot afford one each), so
+/// the categories are deliberately broad and the table small. Raw values are
+/// persisted in snapshots; append new cases, never renumber.
+public enum FileKind: UInt8, Sendable, CaseIterable, Codable {
+    /// A plain directory. Packages take the kind of their extension instead.
+    case folder = 0
+    case application = 1
+    case video = 2
+    case image = 3
+    case audio = 4
+    /// Archives and disk images: zip, dmg, iso, sparsebundle, ...
+    case archive = 5
+    case document = 6
+    /// Source, build products, dependency stores, developer tooling.
+    case code = 7
+    /// Databases, virtual machine disks, container images, datasets.
+    case data = 8
+    /// Logs, caches, crash reports: content that regenerates.
+    case cache = 9
+    case system = 10
+    case other = 11
+
+    public var label: String {
+        switch self {
+        case .folder: return "Folder"
+        case .application: return "Applications"
+        case .video: return "Video"
+        case .image: return "Images"
+        case .audio: return "Audio"
+        case .archive: return "Archives and disk images"
+        case .document: return "Documents"
+        case .code: return "Code and developer"
+        case .data: return "Data and databases"
+        case .cache: return "Logs and caches"
+        case .system: return "System"
+        case .other: return "Other"
+        }
+    }
+
+    /// The order the Kinds view and legends list categories in.
+    public static let displayOrder: [FileKind] = [
+        .application, .video, .image, .audio, .archive, .document, .code, .data, .cache,
+        .system, .other,
+    ]
+}
+
+/// Extension tables for kind classification and package detection. Lookups
+/// are allocation-free: an extension of up to sixteen ASCII bytes is packed
+/// into a two-word key, lower-cased on the way in. Longer extensions fall to
+/// `.other`, except the handful of long package extensions, which go through
+/// a small string table because directories are rare enough to afford it.
+public enum FileKindClassifier {
+    /// Classify a file by its name. `isDirectory` selects the package table;
+    /// a directory whose extension is not a package extension is `.folder`.
+    public static func kind(forName name: String, isDirectory: Bool) -> FileKind {
+        var bytes = Array(name.utf8)
+        return bytes.withUnsafeMutableBufferPointer {
+            kind(forNameBytes: $0, isDirectory: isDirectory)
+        }
+    }
+
+    /// Byte-level entry point used by the scanner on raw listing names.
+    static func kind(
+        forNameBytes name: UnsafeMutableBufferPointer<UInt8>, isDirectory: Bool
+    )
+        -> FileKind
+    {
+        kind(forNameBytes: UnsafeBufferPointer(name), isDirectory: isDirectory)
+    }
+
+    static func kind(forNameBytes name: UnsafeBufferPointer<UInt8>, isDirectory: Bool) -> FileKind {
+        guard let dot = lastDot(in: name), dot + 1 < name.count else {
+            return isDirectory ? .folder : .other
+        }
+        let extensionLength = name.count - dot - 1
+        if isDirectory {
+            guard extensionLength <= maximumPackageExtensionLength else { return .folder }
+            var chars = [UInt8](repeating: 0, count: extensionLength)
+            for i in 0..<extensionLength { chars[i] = lowercased(name[dot + 1 + i]) }
+            let key = String(decoding: chars, as: UTF8.self)
+            return packages[key] ?? .folder
+        }
+        guard let key = packedKey(name, from: dot + 1) else { return .other }
+        return files[key] ?? .other
+    }
+
+    /// True when a directory with this name is a package the map should treat
+    /// as a leaf (an app, a library bundle, a project).
+    public static func isPackage(name: String) -> Bool {
+        kind(forName: name, isDirectory: true) != .folder
+    }
+
+    static func isPackage(nameBytes name: UnsafeBufferPointer<UInt8>) -> Bool {
+        kind(forNameBytes: name, isDirectory: true) != .folder
+    }
+
+    // MARK: - Tables
+
+    private static let maximumPackageExtensionLength = 16
+
+    /// Directory extensions that mean "package". Value is the kind the package
+    /// counts as in the Kinds view.
+    private static let packages: [String: FileKind] = [
+        "app": .application, "appex": .application, "xpc": .application,
+        "plugin": .application, "bundle": .application, "kext": .application,
+        "framework": .application, "prefpane": .application, "saver": .application,
+        "qlgenerator": .application, "mdimporter": .application, "wdgt": .application,
+        "action": .application, "workflow": .application, "docset": .code,
+        "playground": .code, "xcodeproj": .code, "xcworkspace": .code, "xcarchive": .code,
+        "xcappdata": .code, "xctest": .code, "swiftpm": .code,
+        "photoslibrary": .image, "aplibrary": .image, "musiclibrary": .audio,
+        "tvlibrary": .video, "imovielibrary": .video, "fcpbundle": .video, "logicx": .audio,
+        "band": .audio, "mpkg": .archive, "sparsebundle": .archive, "rtfd": .document,
+        "scptd": .code, "vmwarevm": .data, "pvm": .data, "utm": .data, "key": .document,
+        "pages": .document, "numbers": .document, "download": .other,
+        "textclipping": .document, "lproj": .system, "nib": .system, "storyboardc": .system,
+        "abbu": .data, "iconset": .image, "xcassets": .code, "xcdatamodeld": .code,
+        "lsp": .code, "mlmodelc": .data, "mlpackage": .data,
+    ]
+
+    /// Up to sixteen lower-cased ASCII bytes, big-endian across two words.
+    private struct ExtensionKey: Hashable {
+        var high: UInt64
+        var low: UInt64
+    }
+
+    /// File extensions, packed. Built once from a readable list.
+    private static let files: [ExtensionKey: FileKind] = {
+        var table: [ExtensionKey: FileKind] = [:]
+        func add(_ kind: FileKind, _ extensions: [String]) {
+            for ext in extensions {
+                var bytes = Array(ext.utf8)
+                let key = bytes.withUnsafeMutableBufferPointer { buffer in
+                    packedKey(UnsafeBufferPointer(buffer), from: 0)
+                }
+                if let key { table[key] = kind }
+            }
+        }
+        add(
+            .video,
+            [
+                "mp4", "m4v", "mov", "mkv", "avi", "wmv", "flv", "webm", "mpg", "mpeg", "m2ts",
+                "mts", "ts", "3gp", "vob", "ogv", "mxf", "braw", "r3d", "prproj", "fcpxml",
+            ])
+        add(
+            .image,
+            [
+                "jpg", "jpeg", "png", "gif", "heic", "heif", "tif", "tiff", "bmp", "webp", "raw",
+                "cr2", "cr3", "nef", "arw", "dng", "orf", "raf", "rw2", "psd", "psb", "ai", "svg",
+                "icns", "ico", "avif", "jxl", "eps", "sketch", "fig", "afphoto", "afdesign",
+                "pxd", "pxm", "xcf",
+            ])
+        add(
+            .audio,
+            [
+                "mp3", "m4a", "aac", "flac", "wav", "aif", "aiff", "ogg", "oga", "opus", "wma",
+                "alac", "caf", "m4b", "m4p", "mid", "midi", "aup3", "als", "logicx",
+            ])
+        add(
+            .archive,
+            [
+                "zip", "gz", "tgz", "bz2", "xz", "zst", "7z", "rar", "tar", "lz", "lzma", "dmg",
+                "iso", "img", "pkg", "xip", "cpio", "sit", "sitx", "war", "jar", "aar", "whl",
+                "ipsw", "ipa", "apk", "deb", "rpm", "cab", "sparseim", "toast", "cdr",
+            ])
+        add(
+            .document,
+            [
+                "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "odt", "ods", "odp", "rtf",
+                "txt", "md", "markdown", "epub", "mobi", "azw3", "csv", "tsv", "numbers", "pages",
+                "key", "keynote", "note", "tex", "bib", "indd", "pub", "vsd", "vsdx",
+            ])
+        add(
+            .code,
+            [
+                "swift", "c", "h", "m", "mm", "cpp", "cc", "cxx", "hpp", "hh", "java", "kt", "kts",
+                "scala", "go", "rs", "py", "pyc", "pyo", "rb", "php", "js", "mjs", "cjs", "ts",
+                "tsx", "jsx", "vue", "svelte", "html", "htm", "css", "scss", "sass", "less",
+                "json", "yaml", "yml", "toml", "xml", "plist", "sh", "zsh", "bash", "fish", "pl",
+                "lua", "r", "jl", "dart", "cs", "fs", "vb", "sql", "graphql", "proto", "cmake",
+                "make", "mk", "gradle", "pbxproj", "xcconfig", "entitlements", "storyboard",
+                "xib", "strings", "o", "a", "so", "dylib", "dsym", "wasm", "class", "node",
+                "swiftmodule", "swiftdoc", "pcm", "bc", "ll", "d", "map", "lock", "gemspec",
+                "podspec", "nupkg", "crate", "rlib", "rmeta", "elc", "hi", "beam", "ex", "exs",
+                "erl", "clj", "hs", "ml", "nim", "zig", "v", "sv", "vhd", "ipynb",
+            ])
+        add(
+            .data,
+            [
+                "sqlite", "sqlite3", "db", "db3", "sqlitedb", "realm", "mdb", "accdb", "parquet",
+                "avro", "orc", "arrow", "feather", "h5", "hdf5", "npy", "npz", "pkl", "pickle",
+                "pt", "pth", "ckpt", "safetensors", "gguf", "ggml", "onnx", "mlmodel", "bin",
+                "dat", "vmdk", "vdi", "vhd", "vhdx", "qcow2", "qcow", "hdd", "vmem",
+                "vmss", "nvram", "ova", "ovf", "tfrecord", "mat", "sav", "dta", "rdata", "rds",
+                "bak", "dump", "wal", "shm", "ldb", "sst", "idx", "pack",
+            ])
+        add(
+            .cache,
+            [
+                "log", "crash", "ips", "diag", "spin", "hang", "trace", "tracev3", "cache",
+                "tmp", "temp", "part", "crdownload", "download", "swp", "swo", "orig", "rej",
+                "old", "cachedata", "etag", "journal", "asl",
+            ])
+        add(
+            .system,
+            [
+                "kext", "efi", "kernelcache", "im4p", "im4m", "img4", "aea", "asar", "car",
+                "metallib", "mom", "momd", "nib", "loctable", "dylib_cache", "cryptex",
+            ])
+        return table
+    }()
+
+    // MARK: - Byte helpers
+
+    private static func lastDot(in name: UnsafeBufferPointer<UInt8>) -> Int? {
+        var i = name.count - 1
+        while i > 0 {
+            if name[i] == UInt8(ascii: ".") { return i }
+            i -= 1
+        }
+        // A leading dot is a hidden-file marker, not an extension separator.
+        return nil
+    }
+
+    @inline(__always)
+    private static func lowercased(_ byte: UInt8) -> UInt8 {
+        (byte >= UInt8(ascii: "A") && byte <= UInt8(ascii: "Z")) ? byte + 32 : byte
+    }
+
+    /// Pack up to sixteen bytes, lower-cased, big-endian, into one key. Nil
+    /// for anything longer or non-ASCII (those are never in the table anyway).
+    /// Shorter extensions leave leading zero bytes; a file name can never
+    /// contain NUL, so "a" and a hypothetical "\0a" cannot collide.
+    private static func packedKey(
+        _ name: UnsafeBufferPointer<UInt8>, from start: Int
+    )
+        -> ExtensionKey?
+    {
+        let length = name.count - start
+        guard length >= 1, length <= 16 else { return nil }
+        var high: UInt64 = 0
+        var low: UInt64 = 0
+        for i in 0..<length {
+            let byte = name[start + i]
+            guard byte < 0x80 else { return nil }
+            if i < 8 {
+                high = (high << 8) | UInt64(lowercased(byte))
+            } else {
+                low = (low << 8) | UInt64(lowercased(byte))
+            }
+        }
+        return ExtensionKey(high: high, low: low)
+    }
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/FileTree.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/FileTree.swift
@@ -1,0 +1,509 @@
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Per-node facts that do not fit a size or a date. Raw values are persisted
+/// in snapshots; append new bits, never reassign them.
+public struct FileNodeFlags: OptionSet, Sendable, Hashable, Codable {
+    public let rawValue: UInt16
+    public init(rawValue: UInt16) { self.rawValue = rawValue }
+
+    public static let directory = FileNodeFlags(rawValue: 1 << 0)
+    /// A directory whose extension marks it as a package (app, bundle,
+    /// library). Scanned fully, drawn as a leaf until drilled into.
+    public static let package = FileNodeFlags(rawValue: 1 << 1)
+    public static let symlink = FileNodeFlags(rawValue: 1 << 2)
+    /// A later encounter of a hard-linked file already counted elsewhere.
+    /// Carries zero bytes so the total matches `du`.
+    public static let hardLinkDuplicate = FileNodeFlags(rawValue: 1 << 3)
+    /// `EF_MAY_SHARE_BLOCKS`: an APFS clone or a file held by a snapshot.
+    public static let mayShareBlocks = FileNodeFlags(rawValue: 1 << 4)
+    /// `SF_DATALESS`: an evicted iCloud or file-provider item. Zero local
+    /// bytes; the scanner never materialises it.
+    public static let dataless = FileNodeFlags(rawValue: 1 << 5)
+    /// `SF_RESTRICTED`: SIP-protected, cannot be trashed.
+    public static let restricted = FileNodeFlags(rawValue: 1 << 6)
+    /// A directory that returned EPERM: TCC denied it, Full Disk Access fixes it.
+    public static let notPermitted = FileNodeFlags(rawValue: 1 << 7)
+    /// A directory that returned EACCES: Unix permissions, owned by another user.
+    public static let accessDenied = FileNodeFlags(rawValue: 1 << 8)
+    /// A directory that failed for any other reason (the errno is not kept).
+    public static let unreadable = FileNodeFlags(rawValue: 1 << 9)
+    /// A mount point or automount trigger: another volume lives here, never
+    /// descended, zero bytes.
+    public static let separateVolume = FileNodeFlags(rawValue: 1 << 10)
+    /// A synthetic child holding a directory's many small files of one kind.
+    /// `count` is how many, `bytes` their exact total.
+    public static let smallFilesFold = FileNodeFlags(rawValue: 1 << 11)
+    /// `UF_HIDDEN` or a leading dot.
+    public static let hidden = FileNodeFlags(rawValue: 1 << 12)
+    /// Moved to the Trash from inside the app after the scan; bytes were
+    /// re-homed into the In Trash bucket.
+    public static let trashed = FileNodeFlags(rawValue: 1 << 13)
+    /// `SF_IMMUTABLE`: locked by the system.
+    public static let immutable = FileNodeFlags(rawValue: 1 << 14)
+    /// `UF_DATAVAULT`: a macOS data vault, readable only with an entitlement.
+    /// Full Disk Access does not open these, so an EPERM here is not the
+    /// user's to fix and must not feed the "grant access" banner.
+    public static let dataVault = FileNodeFlags(rawValue: 1 << 15)
+
+    /// Flags that mean a directory's contents are not in the tree.
+    public static let unlisted: FileNodeFlags = [
+        .notPermitted, .accessDenied, .unreadable, .separateVolume, .dataless, .dataVault,
+    ]
+}
+
+/// The scanned filesystem as a compact arena: one entry per node in parallel
+/// arrays indexed by `Int32`, names in a single UTF-8 buffer. A directory's
+/// children occupy one contiguous index range (`firstChild ..< firstChild +
+/// childCount`) because a listing is appended in one go, which is what makes
+/// the arena cheap to walk, to persist, and to bounds-check on load. Index 0
+/// is the scan root. Children always have higher indices than their parent.
+///
+/// Sizes are allocated bytes (what the file occupies on disk), never logical
+/// length: sparse and compressed files count what they actually use, which is
+/// the only number that reconciles against the volume's used space.
+///
+/// Values are immutable once built; the scanner produces one through
+/// `FileTreeBuilder` and the app treats the result as a frozen snapshot.
+public struct FileTree: Sendable {
+    public private(set) var parent: [Int32]
+    public private(set) var firstChild: [Int32]
+    public private(set) var childCount: [Int32]
+    /// Allocated bytes: the file's own for a leaf, the subtree total for a
+    /// directory (folds and unlisted directories included).
+    public private(set) var bytes: [UInt64]
+    /// Bytes shared with a clone or trapped in a snapshot (allocated minus
+    /// `ATTR_CMNEXT_PRIVATESIZE`), aggregated like `bytes`. All zero when the
+    /// scan did not fetch private sizes.
+    public private(set) var shared: [UInt64]
+    /// `ATTR_CMN_FILEID`, so an action taken later can confirm the entry is
+    /// still the one the user looked at.
+    public private(set) var fileID: [UInt64]
+    /// Modification time as whole seconds since 1970.
+    public private(set) var modified: [UInt32]
+    /// Items under a directory (files, folds and directories, recursively);
+    /// 1 for a file; the folded file count for a fold.
+    public private(set) var count: [UInt32]
+    public private(set) var flags: [FileNodeFlags]
+    public private(set) var kind: [FileKind]
+    /// `nameBytes[nameOffsets[i] ..< nameOffsets[i + 1]]` is node i's name.
+    public private(set) var nameOffsets: [UInt32]
+    public private(set) var nameBytes: [UInt8]
+
+    public var nodeCount: Int { parent.count }
+    public var isEmpty: Bool { parent.isEmpty }
+
+    public static let root: Int32 = 0
+
+    init(
+        parent: [Int32], firstChild: [Int32], childCount: [Int32], bytes: [UInt64],
+        shared: [UInt64], fileID: [UInt64], modified: [UInt32], count: [UInt32],
+        flags: [FileNodeFlags], kind: [FileKind], nameOffsets: [UInt32], nameBytes: [UInt8]
+    ) {
+        self.parent = parent
+        self.firstChild = firstChild
+        self.childCount = childCount
+        self.bytes = bytes
+        self.shared = shared
+        self.fileID = fileID
+        self.modified = modified
+        self.count = count
+        self.flags = flags
+        self.kind = kind
+        self.nameOffsets = nameOffsets
+        self.nameBytes = nameBytes
+    }
+
+    public static let empty = FileTree(
+        parent: [], firstChild: [], childCount: [], bytes: [], shared: [], fileID: [],
+        modified: [], count: [], flags: [], kind: [], nameOffsets: [0], nameBytes: [])
+
+    // MARK: - Accessors
+
+    public func name(of node: Int32) -> String {
+        let i = Int(node)
+        let start = Int(nameOffsets[i])
+        let end = Int(nameOffsets[i + 1])
+        return String(decoding: nameBytes[start..<end], as: UTF8.self)
+    }
+
+    public func nameBytes(of node: Int32) -> ArraySlice<UInt8> {
+        let i = Int(node)
+        return nameBytes[Int(nameOffsets[i])..<Int(nameOffsets[i + 1])]
+    }
+
+    public func children(of node: Int32) -> Range<Int32> {
+        let i = Int(node)
+        let first = firstChild[i]
+        return first..<(first + childCount[i])
+    }
+
+    public func isDirectory(_ node: Int32) -> Bool {
+        flags[Int(node)].contains(.directory)
+    }
+
+    public func modifiedDate(of node: Int32) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(modified[Int(node)]))
+    }
+
+    /// Root first, node last.
+    public func ancestry(of node: Int32) -> [Int32] {
+        var chain: [Int32] = [node]
+        var current = node
+        while current != Self.root {
+            current = parent[Int(current)]
+            chain.append(current)
+        }
+        chain.reverse()
+        return chain
+    }
+
+    public func depth(of node: Int32) -> Int {
+        var depth = 0
+        var current = node
+        while current != Self.root {
+            current = parent[Int(current)]
+            depth += 1
+        }
+        return depth
+    }
+
+    /// The node's path under `rootPath` (the scan root, not the display
+    /// root; see `FirmlinkMap` for the canonical form). Folds have no path of
+    /// their own and return their parent's.
+    public func path(of node: Int32, rootPath: String) -> String {
+        var components: [ArraySlice<UInt8>] = []
+        var current = node
+        while current != Self.root {
+            if !flags[Int(current)].contains(.smallFilesFold) {
+                components.append(nameBytes(of: current))
+            }
+            current = parent[Int(current)]
+        }
+        guard !components.isEmpty else { return rootPath }
+        var bytes = Array(rootPath.utf8)
+        if bytes.last == UInt8(ascii: "/") { bytes.removeLast() }
+        for component in components.reversed() {
+            bytes.append(UInt8(ascii: "/"))
+            bytes.append(contentsOf: component)
+        }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    /// Children of `node` sorted by bytes, largest first. Sorting is done at
+    /// query time on the few thousand nodes a view can show rather than once
+    /// over the whole arena, because the arena keeps children contiguous.
+    public func childrenBySize(of node: Int32) -> [Int32] {
+        Array(children(of: node)).sorted { bytes[Int($0)] > bytes[Int($1)] }
+    }
+
+    /// Whether `ancestor` is on `node`'s parent chain (or is the node).
+    public func node(_ node: Int32, isWithin ancestor: Int32) -> Bool {
+        var current = node
+        while true {
+            if current == ancestor { return true }
+            if current == Self.root { return false }
+            current = parent[Int(current)]
+        }
+    }
+
+    /// Re-home a trashed node's bytes: the node keeps its own figures and
+    /// gains `.trashed`; every ancestor loses the bytes, shared and count.
+    /// Returns the bytes removed from the ancestors.
+    @discardableResult
+    public mutating func markTrashed(_ node: Int32) -> UInt64 {
+        let i = Int(node)
+        guard !flags[i].contains(.trashed) else { return 0 }
+        flags[i].insert(.trashed)
+        let removedBytes = bytes[i]
+        let removedShared = shared[i]
+        let removedCount = count[i]
+        var current = node
+        while current != Self.root {
+            current = parent[Int(current)]
+            let c = Int(current)
+            bytes[c] = bytes[c] >= removedBytes ? bytes[c] - removedBytes : 0
+            shared[c] = shared[c] >= removedShared ? shared[c] - removedShared : 0
+            count[c] = count[c] >= removedCount ? count[c] - removedCount : 0
+        }
+        return removedBytes
+    }
+
+    /// Structural validation for data read from disk: every index must point
+    /// inside the arena, parents must precede children, child ranges must be
+    /// in bounds, and the name offsets must be monotonic and end at the name
+    /// buffer's end. Cheap (one linear pass) and the reason a corrupt
+    /// snapshot file can never crash a walk.
+    public var isStructurallyValid: Bool {
+        let n = parent.count
+        guard firstChild.count == n, childCount.count == n, bytes.count == n,
+            shared.count == n, fileID.count == n, modified.count == n, count.count == n,
+            flags.count == n, kind.count == n, nameOffsets.count == n + 1
+        else { return false }
+        guard nameOffsets.first == 0, Int(nameOffsets[n]) == nameBytes.count else { return false }
+        if n == 0 { return true }
+        guard parent[0] == 0 else { return false }
+        for i in 0..<n {
+            if i > 0 {
+                let p = parent[i]
+                guard p >= 0, Int(p) < i else { return false }
+            }
+            let c = childCount[i]
+            guard c >= 0 else { return false }
+            if c > 0 {
+                let first = firstChild[i]
+                guard first > Int32(i), Int(first) + Int(c) <= n else { return false }
+            }
+            guard nameOffsets[i] <= nameOffsets[i + 1] else { return false }
+        }
+        return true
+    }
+}
+
+/// Single-writer builder for `FileTree`. The scanner's coordinator owns one,
+/// appends each directory listing as one contiguous block of children, and
+/// keeps subtree totals current on the way (a walk up the parent chain per
+/// listing) so previews can be cut from a half-built tree without a second
+/// pass.
+public final class FileTreeBuilder {
+    private var parent: [Int32] = []
+    private var firstChild: [Int32] = []
+    private var childCount: [Int32] = []
+    private var bytes: [UInt64] = []
+    private var shared: [UInt64] = []
+    private var fileID: [UInt64] = []
+    private var modified: [UInt32] = []
+    private var count: [UInt32] = []
+    private var flags: [FileNodeFlags] = []
+    private var kind: [FileKind] = []
+    private var nameOffsets: [UInt32] = [0]
+    private var nameBytes: [UInt8] = []
+
+    public init(expectedNodes: Int = 0) {
+        reserve(expectedNodes)
+    }
+
+    public var nodeCount: Int { parent.count }
+    public var totalBytes: UInt64 { bytes.first ?? 0 }
+    public var totalCount: UInt32 { count.first ?? 0 }
+
+    public func reserve(_ nodes: Int) {
+        guard nodes > 0 else { return }
+        parent.reserveCapacity(nodes)
+        firstChild.reserveCapacity(nodes)
+        childCount.reserveCapacity(nodes)
+        bytes.reserveCapacity(nodes)
+        shared.reserveCapacity(nodes)
+        fileID.reserveCapacity(nodes)
+        modified.reserveCapacity(nodes)
+        count.reserveCapacity(nodes)
+        flags.reserveCapacity(nodes)
+        kind.reserveCapacity(nodes)
+        nameOffsets.reserveCapacity(nodes + 1)
+        nameBytes.reserveCapacity(nodes * 20)
+    }
+
+    /// One node's facts as handed in by a listing.
+    public struct Entry: Sendable {
+        public var name: ArraySlice<UInt8>
+        public var bytes: UInt64
+        public var shared: UInt64
+        public var fileID: UInt64
+        public var modified: UInt32
+        public var count: UInt32
+        public var flags: FileNodeFlags
+        public var kind: FileKind
+
+        public init(
+            name: ArraySlice<UInt8>, bytes: UInt64, shared: UInt64 = 0, fileID: UInt64 = 0,
+            modified: UInt32 = 0, count: UInt32 = 1, flags: FileNodeFlags = [],
+            kind: FileKind = .other
+        ) {
+            self.name = name
+            self.bytes = bytes
+            self.shared = shared
+            self.fileID = fileID
+            self.modified = modified
+            self.count = count
+            self.flags = flags
+            self.kind = kind
+        }
+    }
+
+    /// Must be the first call. The root's own bytes and count start at zero
+    /// and accumulate as listings land.
+    @discardableResult
+    public func appendRoot(
+        name: String, fileID: UInt64, modified: UInt32, flags: FileNodeFlags
+    )
+        -> Int32
+    {
+        precondition(parent.isEmpty, "root already appended")
+        append(
+            Entry(
+                name: ArraySlice(name.utf8), bytes: 0, fileID: fileID, modified: modified,
+                count: 0, flags: flags.union(.directory), kind: .folder),
+            parent: 0)
+        return 0
+    }
+
+    /// Append a directory's children as one contiguous block, then push the
+    /// block's own bytes and count up through every ancestor. Directories in
+    /// the block start with their own entry only (bytes 0, count 1); their
+    /// listings arrive later and accumulate the same way.
+    /// Returns the index range the children were given.
+    @discardableResult
+    public func appendChildren(of directory: Int32, _ entries: [Entry]) -> Range<Int32> {
+        let d = Int(directory)
+        precondition(d < parent.count, "unknown directory")
+        precondition(childCount[d] == 0, "directory listed twice")
+        let first = Int32(parent.count)
+        var blockBytes: UInt64 = 0
+        var blockShared: UInt64 = 0
+        var blockCount: UInt32 = 0
+        for entry in entries {
+            append(entry, parent: directory)
+            blockBytes &+= entry.bytes
+            blockShared &+= entry.shared
+            blockCount &+= entry.count
+        }
+        firstChild[d] = first
+        childCount[d] = Int32(entries.count)
+        accumulate(from: directory, bytes: blockBytes, shared: blockShared, count: blockCount)
+        return first..<(first + Int32(entries.count))
+    }
+
+    /// Mark a directory whose listing failed. Its entry stays, so the map
+    /// shows where the hole is.
+    public func markUnlisted(_ directory: Int32, _ reason: FileNodeFlags) {
+        flags[Int(directory)].insert(reason)
+    }
+
+    public func flags(of node: Int32) -> FileNodeFlags { flags[Int(node)] }
+    public func bytes(of node: Int32) -> UInt64 { bytes[Int(node)] }
+    public func count(of node: Int32) -> UInt32 { count[Int(node)] }
+    public func kind(of node: Int32) -> FileKind { kind[Int(node)] }
+    public func parent(of node: Int32) -> Int32 { parent[Int(node)] }
+    public func childRange(of node: Int32) -> Range<Int32> {
+        let i = Int(node)
+        return firstChild[i]..<(firstChild[i] + childCount[i])
+    }
+
+    public func name(of node: Int32) -> String {
+        let i = Int(node)
+        return String(
+            decoding: nameBytes[Int(nameOffsets[i])..<Int(nameOffsets[i + 1])], as: UTF8.self)
+    }
+
+    /// Freeze into a value. The builder is left empty; it is not reusable.
+    public func build() -> FileTree {
+        let tree = FileTree(
+            parent: parent, firstChild: firstChild, childCount: childCount, bytes: bytes,
+            shared: shared, fileID: fileID, modified: modified, count: count, flags: flags,
+            kind: kind, nameOffsets: nameOffsets, nameBytes: nameBytes)
+        parent = []
+        firstChild = []
+        childCount = []
+        bytes = []
+        shared = []
+        fileID = []
+        modified = []
+        count = []
+        flags = []
+        kind = []
+        nameOffsets = [0]
+        nameBytes = []
+        return tree
+    }
+
+    /// A pruned copy of the top of the tree for progressive rendering while
+    /// the scan is still running: directories and files down to `depthLimit`
+    /// whose bytes clear `minimumBytes`, largest first, at most `maxChildren`
+    /// per level, with the remainder folded into one aggregate child.
+    public func preview(
+        depthLimit: Int, minimumBytes: UInt64, maxChildren: Int
+    ) -> DiskMapPreviewNode {
+        guard !parent.isEmpty else {
+            return DiskMapPreviewNode(
+                name: "", bytes: 0, count: 0, isDirectory: true, children: [], omittedBytes: 0,
+                omittedCount: 0)
+        }
+        return previewNode(
+            0, depth: 0, depthLimit: depthLimit, minimumBytes: minimumBytes,
+            maxChildren: maxChildren)
+    }
+
+    // MARK: - Private
+
+    private func append(_ entry: Entry, parent p: Int32) {
+        parent.append(p)
+        firstChild.append(0)
+        childCount.append(0)
+        bytes.append(entry.bytes)
+        shared.append(entry.shared)
+        fileID.append(entry.fileID)
+        modified.append(entry.modified)
+        count.append(entry.count)
+        flags.append(entry.flags)
+        kind.append(entry.kind)
+        nameBytes.append(contentsOf: entry.name)
+        nameOffsets.append(UInt32(nameBytes.count))
+    }
+
+    private func accumulate(
+        from directory: Int32, bytes b: UInt64, shared s: UInt64, count c: UInt32
+    ) {
+        var current = directory
+        while true {
+            let i = Int(current)
+            bytes[i] &+= b
+            shared[i] &+= s
+            count[i] &+= c
+            if current == 0 { break }
+            current = parent[i]
+        }
+    }
+
+    private func previewNode(
+        _ node: Int32, depth: Int, depthLimit: Int, minimumBytes: UInt64, maxChildren: Int
+    ) -> DiskMapPreviewNode {
+        let i = Int(node)
+        let isDirectory = flags[i].contains(.directory)
+        var children: [DiskMapPreviewNode] = []
+        var omittedBytes: UInt64 = 0
+        var omittedCount: UInt32 = 0
+        if isDirectory, depth < depthLimit, childCount[i] > 0 {
+            let range = childRange(of: node)
+            let sorted = range.sorted { bytes[Int($0)] > bytes[Int($1)] }
+            for child in sorted {
+                let c = Int(child)
+                if children.count < maxChildren, bytes[c] >= minimumBytes {
+                    children.append(
+                        previewNode(
+                            child, depth: depth + 1, depthLimit: depthLimit,
+                            minimumBytes: minimumBytes, maxChildren: maxChildren))
+                } else {
+                    omittedBytes &+= bytes[c]
+                    omittedCount &+= count[c]
+                }
+            }
+        }
+        return DiskMapPreviewNode(
+            name: name(of: node), bytes: bytes[i], count: count[i], isDirectory: isDirectory,
+            children: children, omittedBytes: omittedBytes, omittedCount: omittedCount)
+    }
+}
+
+/// A pruned, value-typed slice of the tree, small enough to publish to the UI
+/// twice a second while the arena is still growing.
+public struct DiskMapPreviewNode: Sendable, Equatable {
+    public var name: String
+    public var bytes: UInt64
+    public var count: UInt32
+    public var isDirectory: Bool
+    public var children: [DiskMapPreviewNode]
+    /// Bytes and items of children that did not make the cut.
+    public var omittedBytes: UInt64
+    public var omittedCount: UInt32
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/FirmlinkMap.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/FirmlinkMap.swift
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Maps Data-volume paths back to the paths people know. Since Catalina the
+/// startup disk is a volume group: the sealed System volume is mounted at `/`
+/// and the writable Data volume at `/System/Volumes/Data`, with firmlinks
+/// (`/usr/share/firmlinks`) grafting `/Users`, `/Applications`, `/Library`
+/// and a few more onto it. The scanner walks the Data volume so its total
+/// equals that one volume's used space, and this map turns
+/// `/System/Volumes/Data/Users/neil` into `/Users/neil` for display and for
+/// Finder.
+///
+/// Note that a device-id check cannot find the boundary: the System and Data
+/// volumes of a group report the same `st_dev`. Mount status is the signal,
+/// and this map is only about naming.
+public struct FirmlinkMap: Sendable, Equatable {
+    public static let dataVolumeRoot = "/System/Volumes/Data"
+
+    /// `(dataPath, canonicalPath)` sorted longest data path first so the most
+    /// specific prefix wins.
+    private let entries: [(data: String, canonical: String)]
+
+    /// The system table, parsed once. Empty when the file is missing (a
+    /// pre-Catalina layout or a stripped-down environment), in which case
+    /// paths pass through unchanged.
+    public static let system: FirmlinkMap = {
+        guard let text = try? String(contentsOfFile: "/usr/share/firmlinks", encoding: .utf8) else {
+            return FirmlinkMap(lines: [])
+        }
+        return FirmlinkMap(lines: text.split(whereSeparator: \.isNewline).map(String.init))
+    }()
+
+    /// Each line is `<canonical path>\t<relative target on the Data volume>`.
+    public init(lines: [String], dataVolumeRoot: String = FirmlinkMap.dataVolumeRoot) {
+        var parsed: [(data: String, canonical: String)] = []
+        for line in lines {
+            let parts = line.split(separator: "\t", maxSplits: 1).map {
+                $0.trimmingCharacters(in: .whitespaces)
+            }
+            guard parts.count == 2, parts[0].hasPrefix("/"), !parts[1].isEmpty else { continue }
+            let target = parts[1].hasPrefix("/") ? String(parts[1].dropFirst()) : parts[1]
+            parsed.append((data: dataVolumeRoot + "/" + target, canonical: parts[0]))
+        }
+        parsed.sort { $0.data.count > $1.data.count }
+        self.entries = parsed
+        self.dataVolumeRoot = dataVolumeRoot
+    }
+
+    private let dataVolumeRoot: String
+
+    public static func == (lhs: FirmlinkMap, rhs: FirmlinkMap) -> Bool {
+        lhs.dataVolumeRoot == rhs.dataVolumeRoot
+            && lhs.entries.map(\.data) == rhs.entries.map(\.data)
+            && lhs.entries.map(\.canonical) == rhs.entries.map(\.canonical)
+    }
+
+    /// The path as the user knows it. Paths outside the Data volume root pass
+    /// through; the root itself becomes `/`; Data paths under a firmlink are
+    /// rewritten; other Data paths (for example `.Spotlight-V100`) stay as
+    /// they are because nothing else names them.
+    public func canonicalPath(_ path: String) -> String {
+        guard path.hasPrefix(dataVolumeRoot) else { return path }
+        if path.count == dataVolumeRoot.count { return "/" }
+        guard
+            path.utf8[path.utf8.index(path.utf8.startIndex, offsetBy: dataVolumeRoot.utf8.count)]
+                == UInt8(ascii: "/")
+        else { return path }
+        for entry in entries where path.hasPrefix(entry.data) {
+            if path.count == entry.data.count { return entry.canonical }
+            let boundary = path.utf8.index(path.utf8.startIndex, offsetBy: entry.data.utf8.count)
+            if path.utf8[boundary] == UInt8(ascii: "/") {
+                return entry.canonical + path[boundary...]
+            }
+        }
+        return path
+    }
+
+    /// The Data-volume path for a canonical one, when a firmlink covers it.
+    /// Used to turn a user-chosen folder like `/Users/neil` into the path the
+    /// scanner should open so its totals match the volume.
+    public func dataVolumePath(_ canonical: String) -> String {
+        for entry in entries where canonical.hasPrefix(entry.canonical) {
+            if canonical.count == entry.canonical.count { return entry.data }
+            let boundary = canonical.utf8.index(
+                canonical.utf8.startIndex, offsetBy: entry.canonical.utf8.count)
+            if canonical.utf8[boundary] == UInt8(ascii: "/") {
+                return entry.data + canonical[boundary...]
+            }
+        }
+        return canonical
+    }
+}

--- a/Sources/macperfmonitor-cli/main.swift
+++ b/Sources/macperfmonitor-cli/main.swift
@@ -23,6 +23,8 @@ case "probe":
     runProbe()
 case "sample":
     runSample(arguments: Array(arguments.dropFirst(2)))
+case "scan":
+    runScan(arguments: Array(arguments.dropFirst(2)))
 case "emit-checks":
     // Emit the built-in diagnostic check catalog as JSON, so the publish script can
     // seed the server manifest from the in-app pack without drift.
@@ -74,7 +76,18 @@ func printUsage() {
         Usage:
           macperfmonitor-cli probe                      Probe per-process read coverage and system memory (default)
           macperfmonitor-cli sample [options]           Continuously sample into the database
+          macperfmonitor-cli scan [path] [options]      Scan a folder or volume with the Disk Map engine
           macperfmonitor-cli help                       Show this help
+
+        scan options (path defaults to the home folder; / means the startup disk):
+          --workers <n>          Reader threads (default \(DiskMapScanOptions.defaultWorkerCount))
+          --threshold <bytes>    Small-file fold threshold (default: adaptive from inode count)
+          --no-fold              Keep every file as its own node
+          --private-size         Fetch ATTR_CMNEXT_PRIVATESIZE per entry (about 1.5x slower)
+          --no-throttle          Do not mark reads as utility-class IO
+          --top <n>              Largest directories and files to list (default 15)
+          --json                 Print the summary as JSON instead of text
+          --quiet                No progress line
 
         sample options:
           --interval <seconds>   Sampling cadence (default 2.0)
@@ -357,6 +370,209 @@ func runSample(arguments: [String]) {
     let onDisk = databaseSizeOnDisk(dbURL)
     print("  on-disk size    : \(ByteFormat.string(onDisk)) (incl. WAL/SHM)")
     print("  ticks recorded  : \(tickCount)")
+    print("")
+}
+
+// MARK: - Disk Map scan
+
+/// Headless run of the Disk Map engine: the harness for measuring throughput,
+/// memory and the fold threshold, and for checking totals against `du -sk`.
+func runScan(arguments: [String]) {
+    var path = NSHomeDirectory()
+    var options = DiskMapScanOptions()
+    var top = 15
+    var json = false
+    var quiet = false
+
+    var i = 0
+    while i < arguments.count {
+        let arg = arguments[i]
+        func nextValue() -> String? {
+            guard i + 1 < arguments.count else { return nil }
+            i += 1
+            return arguments[i]
+        }
+        switch arg {
+        case "--workers":
+            if let v = nextValue(), let n = Int(v), n > 0 { options.workerCount = n }
+        case "--threshold":
+            if let v = nextValue(), let n = UInt64(v) { options.smallFileThreshold = n }
+        case "--no-fold":
+            options.smallFileThreshold = 0
+        case "--private-size":
+            options.fetchPrivateSize = true
+        case "--no-throttle":
+            options.throttleIO = false
+        case "--top":
+            if let v = nextValue(), let n = Int(v), n >= 0 { top = n }
+        case "--json":
+            json = true
+        case "--quiet":
+            quiet = true
+        default:
+            if arg.hasPrefix("--") {
+                FileHandle.standardError.write(Data("Ignoring unknown option: \(arg)\n".utf8))
+            } else {
+                path = (arg as NSString).expandingTildeInPath
+            }
+        }
+        i += 1
+    }
+
+    let scope = DiskMapScope.resolved(folder: path)
+    let token = DiskMapCancellationToken()
+    signal(SIGINT, onInterrupt)
+    keepRunning = true
+
+    if !quiet {
+        FileHandle.standardError.write(
+            Data(
+                "Scanning \(scope.scanRoot) (\(scope.rootName)), workers \(options.workerCount)\n"
+                    .utf8))
+    }
+    let started = Date()
+    var lastLine = Date.distantPast
+    let snapshot: DiskMapSnapshot
+    do {
+        snapshot = try DiskMapScanner().scanBlocking(scope, options: options, cancellation: token) {
+            progress, _ in
+            if !keepRunning { token.cancel() }
+            guard !quiet, Date().timeIntervalSince(lastLine) >= 1 else { return }
+            lastLine = Date()
+            let rate = progress.elapsed > 0 ? Double(progress.entries) / progress.elapsed : 0
+            let location =
+                progress.currentPath.count > 60
+                ? "…" + progress.currentPath.suffix(59) : progress.currentPath
+            let line = String(
+                format: "  %6.1fs  %9llu entries  %7.0f/s  %10@  %@\n", progress.elapsed,
+                progress.entries, rate, ByteFormat.string(progress.bytes), location)
+            FileHandle.standardError.write(Data(line.utf8))
+        }
+    } catch {
+        FileHandle.standardError.write(Data("Scan failed: \(error.localizedDescription)\n".utf8))
+        exit(1)
+    }
+
+    let elapsed = Date().timeIntervalSince(started)
+    let tree = snapshot.tree
+    let rec = snapshot.reconciliation
+    let counts = rec.counts
+    var usage = rusage()
+    getrusage(RUSAGE_SELF, &usage)
+    let peakRSS = UInt64(max(0, usage.ru_maxrss))
+    let openFDs = (try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd"))?.count ?? -1
+    let rate = elapsed > 0 ? Double(counts.entries) / elapsed : 0
+    let arenaBytes =
+        tree.nodeCount * (4 + 4 + 4 + 8 + 8 + 8 + 4 + 4 + 2 + 1 + 4) + tree.nameBytes.count
+
+    func topNodes(directories: Bool) -> [(Int32, UInt64)] {
+        var picked: [(Int32, UInt64)] = []
+        for node in 1..<Int32(tree.nodeCount) {
+            let flags = tree.flags[Int(node)]
+            let isDirectory = flags.contains(.directory)
+            guard isDirectory == directories, !flags.contains(.smallFilesFold) else { continue }
+            picked.append((node, tree.bytes[Int(node)]))
+        }
+        picked.sort { $0.1 > $1.1 }
+        return Array(picked.prefix(top))
+    }
+
+    if json {
+        var summary: [String: Any] = [
+            "scope": scope.id, "root": snapshot.rootPath, "partial": snapshot.partial,
+            "elapsedSeconds": elapsed, "entries": counts.entries, "entriesPerSecond": rate,
+            "directories": counts.directories, "files": counts.files,
+            "foldedFiles": counts.foldedFiles, "nodes": tree.nodeCount,
+            "arenaBytes": arenaBytes, "peakRSS": peakRSS, "openFileDescriptors": openFDs,
+            "scannedBytes": rec.scannedBytes, "sharedBytes": rec.sharedBytes,
+            "unaccountedBytes": rec.unaccountedBytes, "overshootBytes": rec.overshootBytes,
+            "notPermitted": counts.notPermitted, "dataVaults": counts.dataVaults,
+            "accessDenied": counts.accessDenied,
+            "unreadable": counts.unreadable, "vanished": counts.vanished,
+            "datalessDirectories": counts.datalessDirectories,
+            "datalessFiles": counts.datalessFiles, "separateVolumes": counts.separateVolumes,
+            "hardLinkDuplicates": counts.hardLinkDuplicates,
+            "sharedBlockFiles": counts.sharedBlockFiles, "entryErrors": counts.entryErrors,
+            "smallFileThreshold": snapshot.smallFileThreshold, "workers": options.workerCount,
+            "volumeChangedDuringScan": rec.volumeChangedDuringScan,
+        ]
+        if let used = rec.usedBytes { summary["usedBytes"] = used }
+        if let purgeable = rec.purgeableBytes { summary["purgeableBytes"] = purgeable }
+        if let snapshots = rec.localSnapshotCount { summary["localSnapshots"] = snapshots }
+        summary["topDirectories"] = topNodes(directories: true).map {
+            ["path": snapshot.displayPath(of: $0.0), "bytes": $0.1]
+        }
+        summary["topFiles"] = topNodes(directories: false).map {
+            ["path": snapshot.displayPath(of: $0.0), "bytes": $0.1]
+        }
+        if let data = try? JSONSerialization.data(
+            withJSONObject: summary, options: [.prettyPrinted, .sortedKeys]),
+            let text = String(data: data, encoding: .utf8)
+        {
+            print(text)
+        }
+        return
+    }
+
+    printSection("Scan" + (snapshot.partial ? " (cancelled, partial)" : ""))
+    print("  root            : \(snapshot.rootPath)")
+    print(String(format: "  elapsed         : %.1fs", elapsed))
+    print("  entries         : \(counts.entries)  (\(Int(rate))/s)")
+    print("  directories     : \(counts.directories)")
+    print("  files           : \(counts.files) kept, \(counts.foldedFiles) folded")
+    print(
+        "  nodes           : \(tree.nodeCount)  (~\(ByteFormat.string(UInt64(arenaBytes))) arena)")
+    print(
+        "  fold threshold  : \(snapshot.smallFileThreshold) bytes, \(options.workerCount) workers")
+    print("  peak RSS        : \(ByteFormat.string(peakRSS))")
+    print("  open fds now    : \(openFDs)")
+
+    printSection("Bytes")
+    print("  scanned         : \(ByteFormat.string(rec.scannedBytes))  (\(rec.scannedBytes))")
+    if let used = rec.usedBytes {
+        print("  volume used     : \(ByteFormat.string(used))  (\(rec.volumeMountPoint))")
+        print("  unaccounted     : \(ByteFormat.string(rec.unaccountedBytes))")
+        if rec.overshootBytes > 0 {
+            print(
+                "  overshoot       : \(ByteFormat.string(rec.overshootBytes)) (clones counted in full)"
+            )
+        }
+        if rec.volumeChangedDuringScan {
+            print("  note            : volume changed during the scan")
+        }
+    }
+    print("  shared blocks   : \(ByteFormat.string(rec.sharedBytes))")
+    if let purgeable = rec.purgeableBytes {
+        print("  purgeable       : \(ByteFormat.string(purgeable))")
+    }
+    if let snapshots = rec.localSnapshotCount { print("  local snapshots : \(snapshots)") }
+    for volume in rec.systemVolumes {
+        print(
+            "  \(pad(volume.role.label.lowercased(), 16)): \(ByteFormat.string(volume.usedBytes))")
+    }
+
+    printSection("Exceptions")
+    print("  not permitted   : \(counts.notPermitted) (EPERM, Full Disk Access)")
+    print("  data vaults     : \(counts.dataVaults) (EPERM, entitlement only)")
+    print("  access denied   : \(counts.accessDenied) (EACCES)")
+    print("  unreadable      : \(counts.unreadable)   vanished: \(counts.vanished)")
+    print("  dataless        : \(counts.datalessDirectories) dirs, \(counts.datalessFiles) files")
+    print("  separate volumes: \(counts.separateVolumes)")
+    print(
+        "  hard-link dupes : \(counts.hardLinkDuplicates)   clone-flagged: \(counts.sharedBlockFiles)"
+    )
+    print("  entry errors    : \(counts.entryErrors)")
+
+    if top > 0 {
+        printSection("Largest directories")
+        for (node, bytes) in topNodes(directories: true) {
+            print("  " + pad(ByteFormat.string(bytes), 11) + snapshot.displayPath(of: node))
+        }
+        printSection("Largest files")
+        for (node, bytes) in topNodes(directories: false) {
+            print("  " + pad(ByteFormat.string(bytes), 11) + snapshot.displayPath(of: node))
+        }
+    }
     print("")
 }
 

--- a/Tests/MacPerfMonitorCoreTests/DiskMapClassifierTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskMapClassifierTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class DiskMapClassifierTests: XCTestCase {
+    private func kind(_ name: String, directory: Bool = false) -> FileKind {
+        FileKindClassifier.kind(forName: name, isDirectory: directory)
+    }
+
+    func testFileKindsByExtension() {
+        XCTAssertEqual(kind("movie.MOV"), .video)
+        XCTAssertEqual(kind("IMG_0001.heic"), .image)
+        XCTAssertEqual(kind("track.flac"), .audio)
+        XCTAssertEqual(kind("Xcode.dmg"), .archive)
+        XCTAssertEqual(kind("thesis.pdf"), .document)
+        XCTAssertEqual(kind("main.swift"), .code)
+        XCTAssertEqual(kind("DSC_0100.raw"), .image)
+        XCTAssertEqual(kind("model.gguf"), .data)
+        XCTAssertEqual(kind("system.log"), .cache)
+        XCTAssertEqual(kind("kernel.kernelcache"), .system)
+        XCTAssertEqual(kind("README"), .other)
+        XCTAssertEqual(kind(".zshrc"), .other)
+        XCTAssertEqual(kind("archive.tar.gz"), .archive)
+        XCTAssertEqual(
+            kind("weird.verylongextension"), .other)
+        XCTAssertEqual(kind("trailingdot."), .other)
+        XCTAssertEqual(kind("ünïcödé.jpg"), .image)
+    }
+
+    func testPackagesAndFolders() {
+        XCTAssertEqual(kind("Safari.app", directory: true), .application)
+        XCTAssertEqual(kind("Foo.framework", directory: true), .application)
+        XCTAssertEqual(kind("Proj.xcodeproj", directory: true), .code)
+        XCTAssertEqual(
+            kind("Photos Library.photoslibrary", directory: true), .image)
+        XCTAssertEqual(kind("Documents", directory: true), .folder)
+        XCTAssertEqual(kind("node_modules", directory: true), .folder)
+        XCTAssertEqual(kind("photo.jpg", directory: true), .folder)
+        XCTAssertTrue(FileKindClassifier.isPackage(name: "Thing.APP"))
+        XCTAssertFalse(FileKindClassifier.isPackage(name: "Thing"))
+    }
+
+    func testDisplayOrderCoversEveryNonFolderKind() {
+        let ordered = Set(FileKind.displayOrder)
+        for kind in FileKind.allCases where kind != .folder {
+            XCTAssertTrue(ordered.contains(kind), kind.label)
+        }
+        XCTAssertFalse(ordered.contains(.folder))
+    }
+
+    // MARK: - Firmlinks
+
+    private let map = FirmlinkMap(lines: [
+        "/Users\tUsers",
+        "/Applications\tApplications",
+        "/Library\tLibrary",
+        "/System/Library/Caches\tSystem/Library/Caches",
+        "/usr/local\tusr/local",
+        "/private\tprivate",
+        "garbage line without tab",
+    ])
+
+    func testCanonicalPaths() {
+        XCTAssertEqual(map.canonicalPath("/System/Volumes/Data/Users/neil/x"), "/Users/neil/x")
+        XCTAssertEqual(map.canonicalPath("/System/Volumes/Data/Users"), "/Users")
+        XCTAssertEqual(map.canonicalPath("/System/Volumes/Data"), "/")
+        XCTAssertEqual(
+            map.canonicalPath("/System/Volumes/Data/System/Library/Caches/a"),
+            "/System/Library/Caches/a")
+        XCTAssertEqual(map.canonicalPath("/System/Volumes/Data/usr/local/bin"), "/usr/local/bin")
+        XCTAssertEqual(
+            map.canonicalPath("/System/Volumes/Data/.Spotlight-V100"),
+            "/System/Volumes/Data/.Spotlight-V100")
+        XCTAssertEqual(map.canonicalPath("/Users/neil"), "/Users/neil")
+        XCTAssertEqual(
+            map.canonicalPath("/System/Volumes/DataX/Users"), "/System/Volumes/DataX/Users")
+        XCTAssertEqual(
+            map.canonicalPath("/System/Volumes/Data/Userspace"), "/System/Volumes/Data/Userspace",
+            "prefix matches must stop at a component boundary")
+    }
+
+    func testDataVolumePaths() {
+        XCTAssertEqual(map.dataVolumePath("/Users/neil"), "/System/Volumes/Data/Users/neil")
+        XCTAssertEqual(map.dataVolumePath("/Users"), "/System/Volumes/Data/Users")
+        XCTAssertEqual(map.dataVolumePath("/Volumes/Ext"), "/Volumes/Ext")
+        XCTAssertEqual(map.dataVolumePath("/Userspace/x"), "/Userspace/x")
+    }
+
+    func testSystemMapLoadsWhenPresent() {
+        guard FileManager.default.fileExists(atPath: "/usr/share/firmlinks") else { return }
+        XCTAssertEqual(FirmlinkMap.system.canonicalPath("/System/Volumes/Data/Users/x"), "/Users/x")
+    }
+
+    // MARK: - Scope
+
+    func testScopeResolution() {
+        XCTAssertEqual(DiskMapScope.resolved(folder: "/"), .startupDisk)
+        XCTAssertEqual(DiskMapScope.resolved(folder: "/System"), .startupDisk)
+        XCTAssertEqual(DiskMapScope.resolved(folder: "/System/"), .startupDisk)
+        XCTAssertEqual(DiskMapScope.resolved(folder: "/System/Volumes/Data"), .startupDisk)
+        XCTAssertEqual(DiskMapScope.resolved(folder: NSHomeDirectory()), .home)
+        XCTAssertEqual(DiskMapScope.resolved(folder: "/Volumes/Ext/"), .folder("/Volumes/Ext"))
+        XCTAssertEqual(DiskMapScope.resolved(folder: "/tmp/../tmp/a"), .folder("/tmp/a"))
+    }
+
+    func testScopeNamesAndIDs() {
+        XCTAssertEqual(DiskMapScope.startupDisk.rootName, "Macintosh HD")
+        XCTAssertEqual(DiskMapScope.startupDisk.displayRoot, "/")
+        XCTAssertEqual(DiskMapScope.startupDisk.id, "startup")
+        XCTAssertEqual(DiskMapScope.folder("/Users/neil/Movies").rootName, "Movies")
+        XCTAssertEqual(DiskMapScope.volume("/Volumes/Backup").rootName, "Backup")
+        XCTAssertEqual(DiskMapScope.volume("/").rootName, "Macintosh HD")
+        XCTAssertTrue(DiskMapScope.startupDisk.isWholeVolume)
+        XCTAssertFalse(DiskMapScope.home.isWholeVolume)
+        let a = DiskMapScope.folder("/Users/neil/Movies").id
+        let b = DiskMapScope.folder("/Users/neil/Music").id
+        XCTAssertNotEqual(a, b)
+        XCTAssertTrue(a.hasPrefix("folder-"))
+        XCTAssertFalse(a.contains("/"))
+        let long = DiskMapScope.folder(String(repeating: "/abcdefghij", count: 30)).id
+        XCTAssertLessThan(long.count, 80)
+    }
+
+    func testScopeRoundTripsThroughCodable() throws {
+        let scopes: [DiskMapScope] = [.startupDisk, .home, .folder("/a/b"), .volume("/Volumes/X")]
+        for scope in scopes {
+            let data = try JSONEncoder().encode(scope)
+            XCTAssertEqual(try JSONDecoder().decode(DiskMapScope.self, from: data), scope)
+        }
+    }
+
+    func testStatfsHelpersOnTheRoot() {
+        XCTAssertEqual(DiskMapScope.mountPoint(ofPath: "/"), "/")
+        XCTAssertNotNil(DiskMapScope.usedInodes(ofPath: "/"))
+        XCTAssertNil(DiskMapScope.mountPoint(ofPath: "/definitely/not/here"))
+    }
+
+    func testAdaptiveThreshold() {
+        XCTAssertEqual(DiskMapScanOptions.adaptiveThreshold(usedInodes: nil), 16_384)
+        XCTAssertEqual(DiskMapScanOptions.adaptiveThreshold(usedInodes: 10_000), 0)
+        XCTAssertEqual(DiskMapScanOptions.adaptiveThreshold(usedInodes: 3_000_000), 16_384)
+        XCTAssertEqual(DiskMapScanOptions.adaptiveThreshold(usedInodes: 12_000_000), 65_536)
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/DiskMapListerTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskMapListerTests.swift
@@ -1,0 +1,281 @@
+import Darwin
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+/// The listers against a real temp tree: every field cross-checked with
+/// `lstat`, the two implementations checked against each other, and the awkward
+/// shapes (hard links, sparse files, clones, huge directories, long and
+/// non-ASCII names, paths past PATH_MAX, unreadable directories) exercised.
+final class DiskMapListerTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiskMapListerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        // Restore permissions on anything the tests locked so removal works,
+        // then remove through descriptors: the deep-path fixture is past
+        // PATH_MAX and Foundation cannot address it.
+        if let enumerator = FileManager.default.enumerator(atPath: root.path) {
+            for case let relative as String in enumerator {
+                chmod(root.appendingPathComponent(relative).path, 0o755)
+            }
+        }
+        let parentFD = open(root.deletingLastPathComponent().path, O_RDONLY | O_DIRECTORY)
+        if parentFD >= 0 {
+            Self.removeTree(named: root.lastPathComponent, in: parentFD)
+            close(parentFD)
+        }
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    /// `rm -rf` by descriptor so it works at any depth.
+    private static func removeTree(named name: String, in parentFD: Int32) {
+        let fd = openat(parentFD, name, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+        if fd >= 0, let dir = fdopendir(fd) {
+            var names: [String] = []
+            while let entry = readdir(dir) {
+                let child = withUnsafePointer(to: &entry.pointee.d_name) {
+                    $0.withMemoryRebound(to: CChar.self, capacity: 1024) { String(cString: $0) }
+                }
+                if child != ".", child != ".." { names.append(child) }
+            }
+            for child in names {
+                if unlinkat(fd, child, 0) != 0 { removeTree(named: child, in: fd) }
+            }
+            closedir(dir)
+        } else if fd >= 0 {
+            close(fd)
+        }
+        unlinkat(parentFD, name, AT_REMOVEDIR)
+    }
+
+    /// Build `levels` nested directories of `component` under the root using
+    /// `mkdirat`, plus a `leaf` file of `leafBytes`, and return the deepest
+    /// directory's URL (which is longer than PATH_MAX).
+    private func makeDeepDirectory(levels: Int, component: String, leafBytes: Int) throws -> URL {
+        var fd = open(root.path, O_RDONLY | O_DIRECTORY)
+        guard fd >= 0 else { throw POSIXError(.EIO) }
+        var url = root!
+        for _ in 0..<levels {
+            guard mkdirat(fd, component, 0o755) == 0 else {
+                close(fd)
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            let next = openat(fd, component, O_RDONLY | O_DIRECTORY)
+            close(fd)
+            guard next >= 0 else { throw POSIXError(.EIO) }
+            fd = next
+            url.appendPathComponent(component)
+        }
+        let leaf = openat(fd, "leaf", O_CREAT | O_WRONLY, 0o644)
+        close(fd)
+        guard leaf >= 0 else { throw POSIXError(.EIO) }
+        let payload = [UInt8](repeating: 7, count: leafBytes)
+        _ = payload.withUnsafeBytes { Darwin.write(leaf, $0.baseAddress, $0.count) }
+        close(leaf)
+        return url
+    }
+
+    private func write(_ name: String, bytes: Int, in directory: URL? = nil) throws -> URL {
+        let url = (directory ?? root).appendingPathComponent(name)
+        try Data(repeating: 0x41, count: bytes).write(to: url)
+        return url
+    }
+
+    private func lstatInfo(_ url: URL) -> stat {
+        var st = stat()
+        XCTAssertEqual(lstat(url.path, &st), 0, url.path)
+        return st
+    }
+
+    private func listing(
+        _ lister: any DirectoryLister, _ url: URL
+    ) throws -> [String: RawDirectoryEntry] {
+        let result = try lister.list(path: url.path)
+        var byName: [String: RawDirectoryEntry] = [:]
+        for entry in result.entries {
+            byName[result.nameString(of: entry)] = entry
+        }
+        return byName
+    }
+
+    func testBulkFieldsMatchLstat() throws {
+        _ = try write("small.txt", bytes: 10)
+        _ = try write("big.bin", bytes: 300_000)
+        let sub = root.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("link"), withDestinationURL: sub)
+
+        let entries = try listing(BulkAttributeLister(), root)
+        XCTAssertEqual(Set(entries.keys), ["small.txt", "big.bin", "sub", "link"])
+
+        for (name, entry) in entries {
+            let st = lstatInfo(root.appendingPathComponent(name))
+            XCTAssertEqual(entry.error, 0, name)
+            XCTAssertEqual(entry.fileID, st.st_ino, name)
+            XCTAssertEqual(entry.modified, UInt32(st.st_mtimespec.tv_sec), name)
+            XCTAssertEqual(entry.bsdFlags, st.st_flags, name)
+            XCTAssertEqual(entry.type, DirectoryEntryType(mode: st.st_mode), name)
+            XCTAssertFalse(entry.isMountPoint, name)
+            if entry.type == .regular {
+                XCTAssertEqual(entry.allocated, UInt64(st.st_blocks) * 512, name)
+                XCTAssertEqual(entry.linkCount, UInt32(st.st_nlink), name)
+                XCTAssertLessThanOrEqual(entry.privateSize, entry.allocated, name)
+            }
+        }
+        XCTAssertGreaterThanOrEqual(entries["big.bin"]!.allocated, 300_000)
+        XCTAssertEqual(entries["sub"]!.type, .directory)
+        XCTAssertEqual(entries["link"]!.type, .symlink)
+    }
+
+    func testReaddirParityWithBulk() throws {
+        _ = try write("a.txt", bytes: 5000)
+        _ = try write("b.txt", bytes: 70_000)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("d"), withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("s"),
+            withDestinationURL: root.appendingPathComponent("a.txt"))
+
+        let bulk = try listing(BulkAttributeLister(), root)
+        let readdir = try listing(ReaddirLister(), root)
+        XCTAssertEqual(Set(bulk.keys), Set(readdir.keys))
+        for (name, b) in bulk {
+            let r = try XCTUnwrap(readdir[name])
+            XCTAssertEqual(b.type, r.type, name)
+            XCTAssertEqual(b.fileID, r.fileID, name)
+            XCTAssertEqual(b.modified, r.modified, name)
+            XCTAssertEqual(b.bsdFlags, r.bsdFlags, name)
+            XCTAssertEqual(b.isMountPoint, r.isMountPoint, name)
+            if b.type == .regular {
+                XCTAssertEqual(b.allocated, r.allocated, name)
+                XCTAssertEqual(b.linkCount, r.linkCount, name)
+            }
+        }
+    }
+
+    func testHardLinksShareFileIDAndReportLinkCount() throws {
+        let original = try write("orig", bytes: 20_000)
+        try FileManager.default.linkItem(at: original, to: root.appendingPathComponent("copy"))
+        for lister in [any DirectoryLister](arrayLiteral: BulkAttributeLister(), ReaddirLister()) {
+            let entries = try listing(lister, root)
+            XCTAssertEqual(entries["orig"]?.linkCount, 2)
+            XCTAssertEqual(entries["copy"]?.linkCount, 2)
+            XCTAssertEqual(entries["orig"]?.fileID, entries["copy"]?.fileID)
+        }
+    }
+
+    func testSparseFileAllocatesLessThanItsLength() throws {
+        let url = root.appendingPathComponent("sparse")
+        let fd = open(url.path, O_CREAT | O_WRONLY, 0o644)
+        XCTAssertGreaterThanOrEqual(fd, 0)
+        XCTAssertEqual(ftruncate(fd, 50 * 1024 * 1024), 0)
+        close(fd)
+        let entries = try listing(BulkAttributeLister(), root)
+        let sparse = try XCTUnwrap(entries["sparse"])
+        XCTAssertLessThan(sparse.allocated, 50 * 1024 * 1024)
+    }
+
+    func testClonesCarryTheSharedBlocksFlagAndPrivateSize() throws {
+        let original = try write("orig", bytes: 1_000_000)
+        let clone = root.appendingPathComponent("clone")
+        guard clonefile(original.path, clone.path, 0) == 0 else {
+            throw XCTSkip("clonefile unsupported here (errno \(errno))")
+        }
+        let entries = try listing(BulkAttributeLister(fetchPrivateSize: true), root)
+        for name in ["orig", "clone"] {
+            let entry = try XCTUnwrap(entries[name])
+            XCTAssertNotEqual(entry.extendedFlags & UInt64(EF_MAY_SHARE_BLOCKS), 0, name)
+            XCTAssertLessThan(entry.privateSize, entry.allocated, "\(name) shares every block")
+        }
+        let without = try listing(BulkAttributeLister(fetchPrivateSize: false), root)
+        XCTAssertEqual(without["orig"]?.privateSize, without["orig"]?.allocated)
+    }
+
+    func testLargeDirectoryNeedsSeveralBulkCalls() throws {
+        let big = root.appendingPathComponent("big", isDirectory: true)
+        try FileManager.default.createDirectory(at: big, withIntermediateDirectories: true)
+        for i in 0..<5000 {
+            try Data().write(to: big.appendingPathComponent("file-\(i)"))
+        }
+        let bulk = try BulkAttributeLister().list(path: big.path)
+        XCTAssertEqual(bulk.entries.count, 5000)
+        XCTAssertEqual(Set(bulk.entries.map(bulk.nameString)).count, 5000)
+        let readdir = try ReaddirLister().list(path: big.path)
+        XCTAssertEqual(readdir.entries.count, 5000)
+    }
+
+    func testLongAndNonASCIINamesRoundTrip() throws {
+        let longName = String(repeating: "n", count: 250) + ".mov"
+        let unicode = "日本語のファイル名 with spaces.jpg"
+        _ = try write(longName, bytes: 1)
+        _ = try write(unicode, bytes: 1)
+        for lister in [any DirectoryLister](arrayLiteral: BulkAttributeLister(), ReaddirLister()) {
+            let entries = try listing(lister, root)
+            XCTAssertNotNil(entries[longName])
+            // The filesystem may normalise Unicode; compare by decomposition-insensitive equality.
+            XCTAssertTrue(entries.keys.contains { $0.compare(unicode) == .orderedSame })
+        }
+    }
+
+    func testPathsDeeperThanPathMaxOpenThroughOpenat() throws {
+        let deep = try makeDeepDirectory(
+            levels: 7, component: String(repeating: "d", count: 200), leafBytes: 12_345)
+        XCTAssertGreaterThan(deep.path.utf8.count, 1024)
+        for lister in [any DirectoryLister](arrayLiteral: BulkAttributeLister(), ReaddirLister()) {
+            let entries = try listing(lister, deep)
+            XCTAssertEqual(entries["leaf"]?.type, .regular)
+            XCTAssertGreaterThanOrEqual(entries["leaf"]?.allocated ?? 0, 12_345)
+        }
+    }
+
+    func testErrorsAreClassified() throws {
+        let missing = root.path + "/missing"
+        XCTAssertThrowsError(try BulkAttributeLister().list(path: missing)) { error in
+            XCTAssertEqual(error as? DirectoryListingError, .vanished)
+        }
+        let file = try write("plain", bytes: 1)
+        XCTAssertThrowsError(try BulkAttributeLister().list(path: file.path)) { error in
+            XCTAssertEqual(error as? DirectoryListingError, .vanished, "ENOTDIR maps to vanished")
+        }
+        guard geteuid() != 0 else { return }
+        let locked = root.appendingPathComponent("locked", isDirectory: true)
+        try FileManager.default.createDirectory(at: locked, withIntermediateDirectories: true)
+        chmod(locked.path, 0)
+        XCTAssertThrowsError(try BulkAttributeLister().list(path: locked.path)) { error in
+            XCTAssertEqual(error as? DirectoryListingError, .accessDenied)
+        }
+        XCTAssertThrowsError(try ReaddirLister().list(path: locked.path)) { error in
+            XCTAssertEqual(error as? DirectoryListingError, .accessDenied)
+        }
+    }
+
+    func testMountPointsAreFlaggedNotDescended() throws {
+        guard FileManager.default.fileExists(atPath: "/System/Volumes/Data") else {
+            throw XCTSkip("no volume group on this machine")
+        }
+        let entries = try listing(BulkAttributeLister(), URL(fileURLWithPath: "/System/Volumes"))
+        XCTAssertEqual(entries["Data"]?.type, .directory)
+        XCTAssertEqual(entries["Data"]?.isMountPoint, true)
+    }
+
+    func testErrnoMapping() {
+        XCTAssertEqual(DirectoryListingError(errno: EPERM), .notPermitted)
+        XCTAssertEqual(DirectoryListingError(errno: EACCES), .accessDenied)
+        XCTAssertEqual(DirectoryListingError(errno: ENOENT), .vanished)
+        XCTAssertEqual(DirectoryListingError(errno: ENOTDIR), .vanished)
+        XCTAssertEqual(DirectoryListingError(errno: EDEADLK), .dataless)
+        XCTAssertEqual(DirectoryListingError(errno: ENOTSUP), .notSupported)
+        XCTAssertEqual(DirectoryListingError(errno: EIO), .other(errno: EIO))
+        XCTAssertEqual(DirectoryListingError.notPermitted.nodeFlag, .notPermitted)
+        XCTAssertEqual(DirectoryListingError.accessDenied.nodeFlag, .accessDenied)
+        XCTAssertEqual(DirectoryListingError.dataless.nodeFlag, .dataless)
+        XCTAssertEqual(DirectoryListingError.vanished.nodeFlag, .unreadable)
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/DiskMapScannerTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskMapScannerTests.swift
@@ -1,0 +1,590 @@
+import Darwin
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+/// A scripted filesystem: the scanner's coordinator logic (accumulation,
+/// folding, hard links, boundaries, error taxonomy, cancellation) tested
+/// without touching the disk. Paths are keyed exactly as the scanner builds
+/// them (`root + "/" + name`).
+private final class SyntheticLister: DirectoryLister, @unchecked Sendable {
+    struct Item {
+        var name: String
+        var type: DirectoryEntryType = .regular
+        var bytes: UInt64 = 0
+        var privateSize: UInt64? = nil
+        var fileID: UInt64 = 0
+        var linkCount: UInt32 = 1
+        var bsdFlags: UInt32 = 0
+        var extendedFlags: UInt64 = 0
+        var isMountPoint = false
+        var modified: UInt32 = 1_700_000_000
+        var error: Int32 = 0
+    }
+
+    var directories: [String: Result<[Item], DirectoryListingError>] = [:]
+    var delay: TimeInterval = 0
+    private let lock = NSLock()
+    private var listedPaths: [String] = []
+    private var nextID: UInt64 = 1000
+
+    var listed: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return listedPaths
+    }
+
+    func list(path: String) throws -> DirectoryListing {
+        lock.lock()
+        listedPaths.append(path)
+        let scripted = directories[path]
+        lock.unlock()
+        if delay > 0 { Thread.sleep(forTimeInterval: delay) }
+        guard let scripted else { throw DirectoryListingError.other(errno: EIO) }
+        let items = try scripted.get()
+        var listing = DirectoryListing()
+        for item in items {
+            let id: UInt64
+            if item.fileID != 0 {
+                id = item.fileID
+            } else {
+                lock.lock()
+                nextID += 1
+                id = nextID
+                lock.unlock()
+            }
+            listing.append(name: Array(item.name.utf8)) { offset, count in
+                RawDirectoryEntry(
+                    nameOffset: offset, nameLength: count, type: item.type, error: item.error,
+                    allocated: item.bytes, privateSize: item.privateSize, fileID: id,
+                    modified: item.modified, bsdFlags: item.bsdFlags, linkCount: item.linkCount,
+                    extendedFlags: item.extendedFlags, isMountPoint: item.isMountPoint)
+            }
+        }
+        return listing
+    }
+}
+
+private func file(
+    _ name: String, _ bytes: UInt64, id: UInt64 = 0, links: UInt32 = 1, flags: UInt32 = 0,
+    ext: UInt64 = 0, privateSize: UInt64? = nil
+) -> SyntheticLister.Item {
+    SyntheticLister.Item(
+        name: name, type: .regular, bytes: bytes, privateSize: privateSize, fileID: id,
+        linkCount: links, bsdFlags: flags, extendedFlags: ext)
+}
+
+private func dir(
+    _ name: String, mount: Bool = false, dataless: Bool = false
+) -> SyntheticLister.Item {
+    SyntheticLister.Item(
+        name: name, type: .directory, bsdFlags: dataless ? UInt32(SF_DATALESS) : 0,
+        isMountPoint: mount)
+}
+
+final class DiskMapScannerTests: XCTestCase {
+    private var root: URL!
+    private var rootPath: String { root.path }
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiskMapScannerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func fakeVolume(
+        mountPoint: String, used: UInt64, purgeable: UInt64? = nil
+    ) -> VolumeInfo {
+        VolumeInfo(
+            mountPoint: mountPoint, name: "Test", bsdName: "disk9s1", fsTypeName: "apfs",
+            volumeUUID: nil, role: .data, isRoot: false, isLocal: true, isReadOnly: false,
+            isInternal: true, isEjectable: false, isEncrypted: false, totalBytes: 10_000,
+            freeBytes: 10_000 - used, availableBytes: 10_000 - used,
+            importantUsageAvailableBytes: purgeable.map { 10_000 - used + $0 },
+            purgeableBytes: purgeable, containerBSDName: "disk9", blockSize: 4096,
+            spaceUsedBytes: used)
+    }
+
+    private func scanner(
+        _ lister: SyntheticLister, volumes: @escaping @Sendable () -> [VolumeInfo] = { [] },
+        snapshots: @escaping @Sendable (String) -> Int? = { _ in nil }
+    ) -> DiskMapScanner {
+        DiskMapScanner(volumeSource: volumes, snapshotCounter: snapshots)
+    }
+
+    private func options(
+        _ lister: SyntheticLister, threshold: UInt64? = 0, workers: Int = 2,
+        minimumSmallFilesToFold: Int = 24
+    ) -> DiskMapScanOptions {
+        DiskMapScanOptions(
+            smallFileThreshold: threshold, minimumSmallFilesToFold: minimumSmallFilesToFold,
+            workerCount: workers, previewInterval: 10, countLocalSnapshots: false, lister: lister)
+    }
+
+    // MARK: - Coordinator logic
+
+    func testNestedTotalsCountsAndPaths() throws {
+        let lister = SyntheticLister()
+        lister.directories[rootPath] = .success([dir("a"), dir("b"), file("c", 50)])
+        lister.directories[rootPath + "/a"] = .success([file("a1", 100), file("a2", 200)])
+        lister.directories[rootPath + "/b"] = .success([file("b1", 1000, privateSize: 600)])
+
+        let snapshot = try scanner(lister).scanBlocking(.folder(rootPath), options: options(lister))
+        let tree = snapshot.tree
+        XCTAssertFalse(snapshot.partial)
+        XCTAssertEqual(tree.nodeCount, 7)
+        XCTAssertEqual(tree.bytes[0], 1350)
+        XCTAssertEqual(tree.shared[0], 400)
+        XCTAssertEqual(tree.count[0], 6)
+        XCTAssertEqual(snapshot.reconciliation.scannedBytes, 1350)
+        XCTAssertEqual(snapshot.reconciliation.sharedBytes, 400)
+        XCTAssertEqual(snapshot.reconciliation.scannedItems, 6)
+        XCTAssertEqual(snapshot.reconciliation.counts.directories, 3)
+        XCTAssertEqual(snapshot.reconciliation.counts.files, 4)
+        XCTAssertEqual(snapshot.reconciliation.counts.entries, 6)
+        XCTAssertTrue(tree.isStructurallyValid)
+
+        let byName = Dictionary(
+            uniqueKeysWithValues: (0..<Int32(tree.nodeCount)).map { (tree.name(of: $0), $0) })
+        XCTAssertEqual(tree.bytes[Int(byName["a"]!)], 300)
+        XCTAssertEqual(tree.bytes[Int(byName["b"]!)], 1000)
+        XCTAssertEqual(snapshot.filesystemPath(of: byName["b1"]!), rootPath + "/b/b1")
+        XCTAssertEqual(tree.name(of: 0), (rootPath as NSString).lastPathComponent)
+        XCTAssertEqual(Set(lister.listed), [rootPath, rootPath + "/a", rootPath + "/b"])
+    }
+
+    func testBoundariesAreNotDescended() throws {
+        let lister = SyntheticLister()
+        lister.directories[rootPath] = .success([
+            dir("vol", mount: true), dir("cloud", dataless: true), dir("ok"),
+        ])
+        lister.directories[rootPath + "/ok"] = .success([file("f", 10)])
+
+        let snapshot = try scanner(lister).scanBlocking(.folder(rootPath), options: options(lister))
+        let counts = snapshot.reconciliation.counts
+        XCTAssertEqual(counts.separateVolumes, 1)
+        XCTAssertEqual(counts.datalessDirectories, 1)
+        XCTAssertEqual(counts.unreadable, 0, "boundaries must never be opened")
+        XCTAssertEqual(Set(lister.listed), [rootPath, rootPath + "/ok"])
+        let tree = snapshot.tree
+        for node in tree.children(of: 0) {
+            switch tree.name(of: node) {
+            case "vol":
+                XCTAssertTrue(tree.flags[Int(node)].contains(.separateVolume))
+                XCTAssertTrue(tree.flags[Int(node)].contains(.directory))
+            case "cloud":
+                XCTAssertTrue(tree.flags[Int(node)].contains(.dataless))
+            default: break
+            }
+        }
+        XCTAssertEqual(tree.bytes[0], 10)
+    }
+
+    func testListingErrorsAreClassifiedPerDirectory() throws {
+        let lister = SyntheticLister()
+        lister.directories[rootPath] = .success([dir("tcc"), dir("perm"), dir("gone"), dir("io")])
+        lister.directories[rootPath + "/tcc"] = .failure(.notPermitted)
+        lister.directories[rootPath + "/perm"] = .failure(.accessDenied)
+        lister.directories[rootPath + "/gone"] = .failure(.vanished)
+        lister.directories[rootPath + "/io"] = .failure(.other(errno: EIO))
+
+        let snapshot = try scanner(lister).scanBlocking(.folder(rootPath), options: options(lister))
+        let counts = snapshot.reconciliation.counts
+        XCTAssertEqual(counts.notPermitted, 1)
+        XCTAssertEqual(counts.accessDenied, 1)
+        XCTAssertEqual(counts.vanished, 1)
+        XCTAssertEqual(counts.unreadable, 1)
+        XCTAssertEqual(counts.unlistedDirectories, 4)
+        let tree = snapshot.tree
+        let flagsByName = Dictionary(
+            uniqueKeysWithValues: tree.children(of: 0).map {
+                (tree.name(of: $0), tree.flags[Int($0)])
+            })
+        XCTAssertTrue(flagsByName["tcc"]!.contains(.notPermitted))
+        XCTAssertTrue(flagsByName["perm"]!.contains(.accessDenied))
+        XCTAssertTrue(flagsByName["gone"]!.contains(.unreadable))
+        XCTAssertTrue(flagsByName["io"]!.contains(.unreadable))
+        XCTAssertFalse(flagsByName["perm"]!.contains(.notPermitted))
+    }
+
+    func testDataVaultsDoNotCountAgainstFullDiskAccess() throws {
+        let lister = SyntheticLister()
+        var vault = dir("Biome")
+        vault.bsdFlags = UInt32(UF_DATAVAULT)
+        lister.directories[rootPath] = .success([vault, dir("Mail")])
+        lister.directories[rootPath + "/Biome"] = .failure(.notPermitted)
+        lister.directories[rootPath + "/Mail"] = .failure(.notPermitted)
+        let snapshot = try scanner(lister).scanBlocking(.folder(rootPath), options: options(lister))
+        let counts = snapshot.reconciliation.counts
+        XCTAssertEqual(counts.dataVaults, 1)
+        XCTAssertEqual(counts.notPermitted, 1)
+        XCTAssertEqual(counts.unlistedDirectories, 2)
+        let tree = snapshot.tree
+        let vaultNode = tree.children(of: 0).first { tree.name(of: $0) == "Biome" }!
+        XCTAssertTrue(tree.flags[Int(vaultNode)].contains(.dataVault))
+        XCTAssertFalse(tree.flags[Int(vaultNode)].contains(.notPermitted))
+    }
+
+    func testPerEntryErrorsBecomeUnreadableLeaves() throws {
+        let lister = SyntheticLister()
+        var broken = file("broken", 0)
+        broken.error = EIO
+        lister.directories[rootPath] = .success([broken, file("fine", 8)])
+        let snapshot = try scanner(lister).scanBlocking(.folder(rootPath), options: options(lister))
+        XCTAssertEqual(snapshot.reconciliation.counts.entryErrors, 1)
+        XCTAssertEqual(snapshot.tree.bytes[0], 8)
+        let broke = snapshot.tree.children(of: 0).first { snapshot.tree.name(of: $0) == "broken" }!
+        XCTAssertTrue(snapshot.tree.flags[Int(broke)].contains(.unreadable))
+    }
+
+    func testHardLinksAreCountedOnce() throws {
+        let lister = SyntheticLister()
+        lister.directories[rootPath] = .success([
+            dir("x"), dir("y"), file("solo", 4096, id: 9, links: 1),
+        ])
+        lister.directories[rootPath + "/x"] = .success([file("f1", 4096, id: 7, links: 2)])
+        lister.directories[rootPath + "/y"] = .success([file("f2", 4096, id: 7, links: 2)])
+
+        let snapshot = try scanner(lister).scanBlocking(
+            .folder(rootPath), options: options(lister, workers: 1))
+        XCTAssertEqual(snapshot.tree.bytes[0], 8192)
+        XCTAssertEqual(snapshot.reconciliation.counts.hardLinkDuplicates, 1)
+        let dupes = (0..<Int32(snapshot.tree.nodeCount)).filter {
+            snapshot.tree.flags[Int($0)].contains(.hardLinkDuplicate)
+        }
+        XCTAssertEqual(dupes.count, 1)
+        XCTAssertEqual(snapshot.tree.bytes[Int(dupes[0])], 0)
+    }
+
+    func testSmallFilesFoldPerKindAboveTheMinimum() throws {
+        let lister = SyntheticLister()
+        var items: [SyntheticLister.Item] = [file("big.mov", 5000)]
+        for i in 0..<20 { items.append(file("p\(i).jpg", 10)) }
+        for i in 0..<10 { items.append(file("d\(i).txt", 20)) }
+        lister.directories[rootPath] = .success(items)
+
+        let folded = try scanner(lister).scanBlocking(
+            .folder(rootPath), options: options(lister, threshold: 100))
+        let tree = folded.tree
+        XCTAssertEqual(tree.childCount[0], 3, "one big file plus one fold per kind")
+        XCTAssertEqual(tree.bytes[0], 5400)
+        XCTAssertEqual(tree.count[0], 31)
+        XCTAssertEqual(folded.reconciliation.counts.foldedFiles, 30)
+        XCTAssertEqual(folded.reconciliation.counts.files, 1)
+        XCTAssertEqual(folded.smallFileThreshold, 100)
+        let folds = tree.children(of: 0).filter { tree.flags[Int($0)].contains(.smallFilesFold) }
+        XCTAssertEqual(folds.count, 2)
+        let image = folds.first { tree.kind[Int($0)] == .image }!
+        XCTAssertEqual(tree.bytes[Int(image)], 200)
+        XCTAssertEqual(tree.count[Int(image)], 20)
+        XCTAssertEqual(tree.name(of: image), "")
+        let document = folds.first { tree.kind[Int($0)] == .document }!
+        XCTAssertEqual(tree.bytes[Int(document)], 200)
+        XCTAssertEqual(tree.count[Int(document)], 10)
+        // Kinds order: image before document.
+        XCTAssertLessThan(image, document)
+
+        let unfolded = try scanner(lister).scanBlocking(
+            .folder(rootPath), options: options(lister, threshold: 0))
+        XCTAssertEqual(unfolded.tree.childCount[0], 31)
+        XCTAssertEqual(unfolded.tree.bytes[0], 5400)
+
+        let fewSmall = try scanner(lister).scanBlocking(
+            .folder(rootPath), options: options(lister, threshold: 100, minimumSmallFilesToFold: 40)
+        )
+        XCTAssertEqual(fewSmall.tree.childCount[0], 31, "below the minimum nothing folds")
+        XCTAssertEqual(fewSmall.reconciliation.counts.foldedFiles, 0)
+    }
+
+    func testPackagesSymlinksAndFlags() throws {
+        let lister = SyntheticLister()
+        var link = SyntheticLister.Item(name: "alias", type: .symlink, bytes: 0)
+        link.linkCount = 1
+        let socket = SyntheticLister.Item(name: "sock", type: .other)
+        lister.directories[rootPath] = .success([
+            dir("Foo.app"), link, socket, file(".hidden", 1),
+            file("locked", 2, flags: UInt32(SF_RESTRICTED) | UInt32(SF_IMMUTABLE)),
+            file("clone", 3, ext: UInt64(EF_MAY_SHARE_BLOCKS), privateSize: 0),
+            file("evicted", 0, flags: UInt32(SF_DATALESS)),
+        ])
+        lister.directories[rootPath + "/Foo.app"] = .success([file("bin", 9)])
+        let snapshot = try scanner(lister).scanBlocking(.folder(rootPath), options: options(lister))
+        let tree = snapshot.tree
+        let byName = Dictionary(
+            uniqueKeysWithValues: tree.children(of: 0).map { (tree.name(of: $0), $0) })
+        XCTAssertTrue(tree.flags[Int(byName["Foo.app"]!)].contains(.package))
+        XCTAssertEqual(tree.kind[Int(byName["Foo.app"]!)], .application)
+        XCTAssertEqual(tree.bytes[Int(byName["Foo.app"]!)], 9, "packages are still scanned")
+        XCTAssertTrue(tree.flags[Int(byName["alias"]!)].contains(.symlink))
+        XCTAssertEqual(tree.bytes[Int(byName["alias"]!)], 0)
+        XCTAssertEqual(tree.bytes[Int(byName["sock"]!)], 0)
+        XCTAssertTrue(tree.flags[Int(byName[".hidden"]!)].contains(.hidden))
+        XCTAssertTrue(tree.flags[Int(byName["locked"]!)].contains(.restricted))
+        XCTAssertTrue(tree.flags[Int(byName["locked"]!)].contains(.immutable))
+        XCTAssertTrue(tree.flags[Int(byName["clone"]!)].contains(.mayShareBlocks))
+        XCTAssertEqual(tree.shared[Int(byName["clone"]!)], 3)
+        XCTAssertTrue(tree.flags[Int(byName["evicted"]!)].contains(.dataless))
+        let counts = snapshot.reconciliation.counts
+        XCTAssertEqual(counts.symlinks, 1)
+        XCTAssertEqual(counts.sharedBlockFiles, 1)
+        XCTAssertEqual(counts.datalessFiles, 1)
+        XCTAssertEqual(tree.bytes[0], 15)
+    }
+
+    // MARK: - Reconciliation
+
+    func testReconciliationReadsTheVolumeAfterTheScan() throws {
+        let lister = SyntheticLister()
+        lister.directories[rootPath] = .success([file("f", 1350)])
+        let mount = try XCTUnwrap(DiskMapScope.mountPoint(ofPath: rootPath))
+        final class Calls: @unchecked Sendable {
+            let lock = NSLock()
+            var count = 0
+            func next() -> Int {
+                lock.lock()
+                defer { lock.unlock() }
+                count += 1
+                return count
+            }
+        }
+        let calls = Calls()
+        let volumes: @Sendable () -> [VolumeInfo] = { [self] in
+            let used: UInt64 = calls.next() == 1 ? 1000 : 1500
+            return [fakeVolume(mountPoint: mount, used: used, purgeable: 70)]
+        }
+        let snapshot = try scanner(lister, volumes: volumes, snapshots: { _ in 3 }).scanBlocking(
+            .folder(rootPath), options: options(lister))
+        let rec = snapshot.reconciliation
+        XCTAssertEqual(rec.volumeMountPoint, mount)
+        XCTAssertEqual(rec.usedBytesBeforeScan, 1000)
+        XCTAssertEqual(rec.usedBytes, 1500)
+        XCTAssertEqual(rec.scannedBytes, 1350)
+        XCTAssertEqual(rec.unaccountedBytes, 150)
+        XCTAssertEqual(rec.overshootBytes, 0)
+        XCTAssertEqual(rec.purgeableBytes, 70)
+        XCTAssertTrue(rec.volumeChangedDuringScan)
+        XCTAssertNil(rec.localSnapshotCount, "counting was switched off in the options")
+        XCTAssertEqual(rec.accountedFraction!, 0.9, accuracy: 0.0001)
+    }
+
+    func testReconciliationOvershootAndSystemVolumes() {
+        let data = fakeVolume(mountPoint: "/System/Volumes/Data", used: 1000)
+        var system = fakeVolume(mountPoint: "/", used: 120)
+        system.role = .system
+        var vm = fakeVolume(mountPoint: "/System/Volumes/VM", used: 30)
+        vm.role = .vm
+        var other = fakeVolume(mountPoint: "/Volumes/Ext", used: 5000)
+        other.containerBSDName = "disk7"
+        other.role = .user
+        let rec = DiskMapReconciliation.compute(
+            scope: .startupDisk, mountPoint: "/System/Volumes/Data", volume: data,
+            allVolumes: [data, system, vm, other], usedBefore: 1000, scannedBytes: 1200,
+            sharedBytes: 250, scannedItems: 10, counts: DiskMapScanCounts(), localSnapshotCount: 2)
+        XCTAssertEqual(rec.overshootBytes, 200)
+        XCTAssertEqual(rec.unaccountedBytes, 0)
+        XCTAssertFalse(rec.volumeChangedDuringScan)
+        XCTAssertEqual(rec.systemVolumes.map(\.mountPoint), ["/", "/System/Volumes/VM"])
+        XCTAssertEqual(rec.systemVolumes.map(\.usedBytes), [120, 30])
+        XCTAssertEqual(rec.localSnapshotCount, 2)
+
+        let folderRec = DiskMapReconciliation.compute(
+            scope: .folder("/x"), mountPoint: "/System/Volumes/Data", volume: data,
+            allVolumes: [data, system], usedBefore: nil, scannedBytes: 10, sharedBytes: 0,
+            scannedItems: 1, counts: DiskMapScanCounts(), localSnapshotCount: nil)
+        XCTAssertTrue(folderRec.systemVolumes.isEmpty, "system buckets belong to the startup disk")
+        XCTAssertNil(folderRec.usedBytesBeforeScan)
+    }
+
+    // MARK: - Lifecycle
+
+    func testCancellationYieldsAPartialSnapshot() throws {
+        let lister = SyntheticLister()
+        lister.delay = 0.002
+        var top: [SyntheticLister.Item] = []
+        for i in 0..<300 {
+            top.append(dir("d\(i)"))
+            lister.directories[rootPath + "/d\(i)"] = .success([file("f", 1)])
+        }
+        lister.directories[rootPath] = .success(top)
+        let token = DiskMapCancellationToken()
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) { token.cancel() }
+        let snapshot = try scanner(lister).scanBlocking(
+            .folder(rootPath), options: options(lister, workers: 1), cancellation: token)
+        XCTAssertTrue(snapshot.partial)
+        XCTAssertTrue(token.isCancelled)
+        XCTAssertLessThan(snapshot.reconciliation.counts.directories, 301)
+        XCTAssertGreaterThan(snapshot.tree.nodeCount, 1)
+        XCTAssertTrue(snapshot.tree.isStructurallyValid)
+        XCTAssertEqual(
+            snapshot.tree.bytes[0], UInt64(snapshot.reconciliation.counts.directories - 1))
+    }
+
+    func testAsyncStreamDeliversProgressThenCompletes() async throws {
+        let lister = SyntheticLister()
+        lister.delay = 0.002
+        var top: [SyntheticLister.Item] = []
+        for i in 0..<60 {
+            top.append(dir("d\(i)"))
+            lister.directories[rootPath + "/d\(i)"] = .success([file("f", 2_000_000)])
+        }
+        lister.directories[rootPath] = .success(top)
+        var options = options(lister, workers: 1)
+        options.previewInterval = 0.005
+
+        var progressCount = 0
+        var lastPreview: DiskMapPreviewNode?
+        var completed: DiskMapSnapshot?
+        for await event in scanner(lister).scan(.folder(rootPath), options: options) {
+            switch event {
+            case .progress(let progress, let preview):
+                progressCount += 1
+                lastPreview = preview
+                XCTAssertNil(progress.expectedEntries, "folder scopes have no inode denominator")
+                XCTAssertNil(progress.fraction)
+                XCTAssertEqual(progress.scope, .folder(rootPath))
+            case .completed(let snapshot):
+                completed = snapshot
+            case .failed(let error):
+                XCTFail("unexpected failure \(error)")
+            }
+        }
+        XCTAssertGreaterThan(progressCount, 0)
+        XCTAssertNotNil(lastPreview)
+        let snapshot = try XCTUnwrap(completed)
+        XCTAssertFalse(snapshot.partial)
+        XCTAssertEqual(snapshot.tree.bytes[0], 120_000_000)
+        XCTAssertEqual(snapshot.tree.nodeCount, 121)
+    }
+
+    func testDroppingTheStreamCancelsTheScan() async throws {
+        let lister = SyntheticLister()
+        lister.delay = 0.005
+        var top: [SyntheticLister.Item] = []
+        for i in 0..<400 {
+            top.append(dir("d\(i)"))
+            lister.directories[rootPath + "/d\(i)"] = .success([file("f", 1)])
+        }
+        lister.directories[rootPath] = .success(top)
+        var options = options(lister, workers: 1)
+        options.previewInterval = 0.001
+        // The app's model iterates the stream inside a Task and cancels that
+        // Task; cancellation reaches the scan through the stream's termination.
+        let scanner = scanner(lister)
+        let consumer = Task {
+            var events = 0
+            for await _ in scanner.scan(.folder(rootPath), options: options) { events += 1 }
+            return events
+        }
+        try await Task.sleep(nanoseconds: 60_000_000)
+        consumer.cancel()
+        _ = await consumer.value
+        // The worker notices between directories; the count must plateau far
+        // below the full 401.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let listedAfterCancel = lister.listed.count
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertLessThanOrEqual(lister.listed.count, listedAfterCancel + 1)
+        XCTAssertLessThan(lister.listed.count, 401)
+    }
+
+    func testRootFailures() {
+        let missing = root.appendingPathComponent("missing").path
+        XCTAssertThrowsError(try DiskMapScanner().scanBlocking(.folder(missing))) { error in
+            XCTAssertEqual(error as? DiskMapScanError, .rootNotReadable(missing, .vanished))
+        }
+        let filePath = root.appendingPathComponent("plain").path
+        FileManager.default.createFile(atPath: filePath, contents: Data())
+        XCTAssertThrowsError(try DiskMapScanner().scanBlocking(.folder(filePath))) { error in
+            XCTAssertEqual(error as? DiskMapScanError, .rootNotADirectory(filePath))
+        }
+        XCTAssertNotNil(DiskMapScanError.rootNotReadable("/x", .notPermitted).errorDescription)
+    }
+
+    // MARK: - Real filesystem
+
+    /// Every byte the scanner reports must match an independent `lstat` walk
+    /// with the same rules (allocated size, hard links once, symlinks as they
+    /// report), with and without folding.
+    func testRealTreeMatchesAnLstatWalk() throws {
+        let fm = FileManager.default
+        let docs = root.appendingPathComponent("docs", isDirectory: true)
+        let pics = root.appendingPathComponent("pics", isDirectory: true)
+        let nested = pics.appendingPathComponent("2024/trip", isDirectory: true)
+        try fm.createDirectory(at: docs, withIntermediateDirectories: true)
+        try fm.createDirectory(at: nested, withIntermediateDirectories: true)
+        for i in 0..<40 {
+            try Data(repeating: 1, count: 100 + i).write(
+                to: docs.appendingPathComponent("n\(i).txt"))
+        }
+        try Data(repeating: 2, count: 200_000).write(to: docs.appendingPathComponent("big.pdf"))
+        try Data(repeating: 3, count: 50_000).write(to: nested.appendingPathComponent("a.jpg"))
+        try Data(repeating: 4, count: 30_000).write(to: nested.appendingPathComponent("b.jpg"))
+        try fm.linkItem(
+            at: nested.appendingPathComponent("a.jpg"),
+            to: pics.appendingPathComponent("a-link.jpg"))
+        try fm.createSymbolicLink(
+            at: root.appendingPathComponent("shortcut"), withDestinationURL: docs)
+
+        var expectedBytes: UInt64 = 0
+        var expectedItems: UInt32 = 0
+        var seenInodes = Set<UInt64>()
+        let enumerator = fm.enumerator(atPath: rootPath)!
+        for case let relative as String in enumerator {
+            var st = stat()
+            guard lstat(root.appendingPathComponent(relative).path, &st) == 0 else { continue }
+            expectedItems += 1
+            if st.st_mode & S_IFMT == S_IFREG {
+                if st.st_nlink > 1, !seenInodes.insert(st.st_ino).inserted { continue }
+                expectedBytes += UInt64(st.st_blocks) * 512
+            } else if st.st_mode & S_IFMT == S_IFLNK {
+                expectedBytes += UInt64(st.st_blocks) * 512
+            }
+        }
+
+        let plain = DiskMapScanOptions(
+            smallFileThreshold: 0, workerCount: 3, previewInterval: 10, countLocalSnapshots: false)
+        let full = try DiskMapScanner().scanBlocking(.folder(rootPath), options: plain)
+        XCTAssertEqual(full.tree.bytes[0], expectedBytes)
+        XCTAssertEqual(full.tree.count[0], expectedItems)
+        XCTAssertEqual(full.tree.nodeCount, Int(expectedItems) + 1)
+        XCTAssertEqual(full.reconciliation.counts.hardLinkDuplicates, 1)
+        XCTAssertTrue(full.tree.isStructurallyValid)
+        XCTAssertNotNil(full.reconciliation.usedBytes, "the temp volume is a real one")
+
+        var folding = plain
+        folding.smallFileThreshold = 16_384
+        let folded = try DiskMapScanner().scanBlocking(.folder(rootPath), options: folding)
+        XCTAssertEqual(folded.tree.bytes[0], expectedBytes, "folding never changes a total")
+        XCTAssertEqual(folded.tree.count[0], expectedItems)
+        XCTAssertLessThan(folded.tree.nodeCount, full.tree.nodeCount)
+        XCTAssertEqual(folded.reconciliation.counts.foldedFiles, 40)
+    }
+
+    func testDisplayPathAppliesFirmlinks() throws {
+        guard FileManager.default.fileExists(atPath: "/usr/share/firmlinks") else {
+            throw XCTSkip("no firmlinks table")
+        }
+        let builder = FileTreeBuilder()
+        builder.appendRoot(name: "Macintosh HD", fileID: 2, modified: 0, flags: [])
+        builder.appendChildren(
+            of: 0,
+            [
+                FileTreeBuilder.Entry(
+                    name: ArraySlice("Users".utf8), bytes: 0, flags: [.directory], kind: .folder)
+            ])
+        let snapshot = DiskMapSnapshot(
+            scope: .startupDisk, rootPath: "/System/Volumes/Data", tree: builder.build(),
+            reconciliation: DiskMapReconciliation.compute(
+                scope: .startupDisk, mountPoint: "/System/Volumes/Data", volume: nil,
+                allVolumes: [], usedBefore: nil, scannedBytes: 0, sharedBytes: 0, scannedItems: 0,
+                counts: DiskMapScanCounts(), localSnapshotCount: nil),
+            scannedAt: Date(), duration: 0, partial: false, smallFileThreshold: 0, revision: 1)
+        XCTAssertEqual(snapshot.displayPath(of: 1), "/Users")
+        XCTAssertEqual(snapshot.filesystemPath(of: 1), "/System/Volumes/Data/Users")
+        XCTAssertEqual(snapshot.displayPath(of: 0), "/")
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/DiskMapTreeTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskMapTreeTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class DiskMapTreeTests: XCTestCase {
+    private func entry(
+        _ name: String, bytes: UInt64, directory: Bool = false, kind: FileKind = .other,
+        shared: UInt64 = 0, count: UInt32 = 1
+    ) -> FileTreeBuilder.Entry {
+        FileTreeBuilder.Entry(
+            name: ArraySlice(name.utf8), bytes: bytes, shared: shared,
+            fileID: UInt64(name.hashValue.magnitude),
+            modified: 1_700_000_000, count: count, flags: directory ? [.directory] : [],
+            kind: directory ? .folder : kind)
+    }
+
+    /// root
+    ///   a/            (dir)
+    ///     a1  100
+    ///     a2  200
+    ///   b/            (dir)
+    ///     b1  1000
+    ///   c   50
+    private func sampleTree() -> FileTree {
+        let builder = FileTreeBuilder()
+        builder.appendRoot(name: "root", fileID: 1, modified: 0, flags: [])
+        let top = builder.appendChildren(
+            of: 0,
+            [
+                entry("a", bytes: 0, directory: true), entry("b", bytes: 0, directory: true),
+                entry("c", bytes: 50),
+            ])
+        XCTAssertEqual(top, 1..<4)
+        builder.appendChildren(of: 1, [entry("a1", bytes: 100), entry("a2", bytes: 200)])
+        builder.appendChildren(of: 2, [entry("b1", bytes: 1000, shared: 400)])
+        return builder.build()
+    }
+
+    func testTotalsAccumulateUpTheChain() {
+        let tree = sampleTree()
+        XCTAssertEqual(tree.nodeCount, 7)
+        XCTAssertEqual(tree.bytes[0], 1350)
+        XCTAssertEqual(tree.bytes[1], 300)
+        XCTAssertEqual(tree.bytes[2], 1000)
+        XCTAssertEqual(tree.shared[0], 400)
+        XCTAssertEqual(tree.shared[2], 400)
+        // Root count: 3 top-level + 2 under a + 1 under b.
+        XCTAssertEqual(tree.count[0], 6)
+        XCTAssertEqual(tree.count[1], 3)
+        XCTAssertEqual(tree.count[2], 2)
+    }
+
+    func testChildrenAreContiguousAndSortable() {
+        let tree = sampleTree()
+        XCTAssertEqual(tree.children(of: 0), 1..<4)
+        XCTAssertEqual(tree.children(of: 1), 4..<6)
+        XCTAssertEqual(tree.children(of: 2), 6..<7)
+        XCTAssertEqual(tree.children(of: 3), 0..<0)
+        XCTAssertEqual(tree.childrenBySize(of: 0), [2, 1, 3])
+        XCTAssertTrue(tree.isDirectory(1))
+        XCTAssertFalse(tree.isDirectory(3))
+    }
+
+    func testNamesPathsAncestryAndDepth() {
+        let tree = sampleTree()
+        XCTAssertEqual(tree.name(of: 0), "root")
+        XCTAssertEqual(tree.name(of: 6), "b1")
+        XCTAssertEqual(tree.path(of: 6, rootPath: "/tmp/x"), "/tmp/x/b/b1")
+        XCTAssertEqual(tree.path(of: 0, rootPath: "/tmp/x"), "/tmp/x")
+        XCTAssertEqual(tree.path(of: 3, rootPath: "/"), "/c")
+        XCTAssertEqual(tree.ancestry(of: 6), [0, 2, 6])
+        XCTAssertEqual(tree.depth(of: 6), 2)
+        XCTAssertEqual(tree.depth(of: 0), 0)
+        XCTAssertTrue(tree.node(6, isWithin: 2))
+        XCTAssertTrue(tree.node(6, isWithin: 0))
+        XCTAssertFalse(tree.node(6, isWithin: 1))
+    }
+
+    func testFoldPathIsItsParents() {
+        let builder = FileTreeBuilder()
+        builder.appendRoot(name: "r", fileID: 1, modified: 0, flags: [])
+        builder.appendChildren(of: 0, [entry("d", bytes: 0, directory: true)])
+        builder.appendChildren(
+            of: 1,
+            [
+                FileTreeBuilder.Entry(
+                    name: [], bytes: 4096, count: 30, flags: [.smallFilesFold], kind: .image)
+            ])
+        let tree = builder.build()
+        XCTAssertEqual(tree.path(of: 2, rootPath: "/r"), "/r/d")
+        XCTAssertEqual(tree.name(of: 2), "")
+        XCTAssertEqual(tree.count[0], 31)
+    }
+
+    func testMarkTrashedReHomesBytes() {
+        var tree = sampleTree()
+        let removed = tree.markTrashed(2)
+        XCTAssertEqual(removed, 1000)
+        XCTAssertTrue(tree.flags[2].contains(.trashed))
+        XCTAssertEqual(tree.bytes[2], 1000, "the node keeps its own figure")
+        XCTAssertEqual(tree.bytes[0], 350)
+        XCTAssertEqual(tree.shared[0], 0)
+        XCTAssertEqual(tree.count[0], 4)
+        XCTAssertEqual(tree.markTrashed(2), 0, "idempotent")
+        XCTAssertEqual(tree.bytes[0], 350)
+    }
+
+    func testStructuralValidation() {
+        let good = sampleTree()
+        XCTAssertTrue(good.isStructurallyValid)
+        XCTAssertTrue(FileTree.empty.isStructurallyValid)
+
+        // Parent pointing forward.
+        var parent = good.parent
+        parent[1] = 5
+        XCTAssertFalse(rebuilt(good, parent: parent).isStructurallyValid)
+        // Child range out of bounds.
+        var childCount = good.childCount
+        childCount[2] = 40
+        XCTAssertFalse(rebuilt(good, childCount: childCount).isStructurallyValid)
+        // First child not after the parent.
+        var firstChild = good.firstChild
+        firstChild[1] = 0
+        XCTAssertFalse(rebuilt(good, firstChild: firstChild).isStructurallyValid)
+        // Name offsets not ending at the buffer end.
+        var offsets = good.nameOffsets
+        offsets[offsets.count - 1] += 1
+        XCTAssertFalse(rebuilt(good, nameOffsets: offsets).isStructurallyValid)
+    }
+
+    private func rebuilt(
+        _ tree: FileTree, parent: [Int32]? = nil, firstChild: [Int32]? = nil,
+        childCount: [Int32]? = nil, nameOffsets: [UInt32]? = nil
+    ) -> FileTree {
+        FileTree(
+            parent: parent ?? tree.parent, firstChild: firstChild ?? tree.firstChild,
+            childCount: childCount ?? tree.childCount, bytes: tree.bytes, shared: tree.shared,
+            fileID: tree.fileID, modified: tree.modified, count: tree.count, flags: tree.flags,
+            kind: tree.kind, nameOffsets: nameOffsets ?? tree.nameOffsets,
+            nameBytes: tree.nameBytes)
+    }
+
+    func testPreviewPrunesAndAggregates() {
+        let builder = FileTreeBuilder()
+        builder.appendRoot(name: "r", fileID: 1, modified: 0, flags: [])
+        builder.appendChildren(
+            of: 0,
+            [
+                entry("big", bytes: 0, directory: true), entry("mid", bytes: 500),
+                entry("tiny1", bytes: 1), entry("tiny2", bytes: 2),
+            ])
+        builder.appendChildren(of: 1, [entry("x", bytes: 5000), entry("y", bytes: 10)])
+        let preview = builder.preview(depthLimit: 3, minimumBytes: 100, maxChildren: 10)
+        XCTAssertEqual(preview.bytes, 5513)
+        XCTAssertEqual(preview.children.map(\.name), ["big", "mid"])
+        XCTAssertEqual(preview.omittedBytes, 3)
+        XCTAssertEqual(preview.omittedCount, 2)
+        XCTAssertEqual(preview.children[0].children.map(\.name), ["x"])
+        XCTAssertEqual(preview.children[0].omittedBytes, 10)
+
+        let capped = builder.preview(depthLimit: 0, minimumBytes: 0, maxChildren: 10)
+        XCTAssertTrue(capped.children.isEmpty, "depth 0 keeps only the root")
+        XCTAssertEqual(capped.omittedBytes, 0, "nothing was sorted through at depth 0")
+    }
+
+    func testEmptyBuilderPreviewDoesNotCrash() {
+        let preview = FileTreeBuilder().preview(depthLimit: 2, minimumBytes: 0, maxChildren: 4)
+        XCTAssertEqual(preview.bytes, 0)
+        XCTAssertTrue(preview.children.isEmpty)
+    }
+}

--- a/docs/disk-map-design.md
+++ b/docs/disk-map-design.md
@@ -1,0 +1,145 @@
+# Disk Map design notes
+
+The Disk Map is the Disk tab's second page: a scan of a volume or folder,
+kept as a compact in-memory tree, drawn as a zoomable treemap and sliced into
+Largest / Oldest / Kinds / Reclaim views, with Reveal in Finder, Quick Look and
+Move to Trash on every item. This document records the facts and decisions
+the implementation rests on so they are not rediscovered the hard way.
+
+## What the numbers mean
+
+- Every size is **allocated bytes** (`ATTR_FILE_ALLOCSIZE`, `st_blocks * 512`),
+  never logical length. Sparse and transparently compressed files count what
+  they occupy. This is the only figure that reconciles against the volume's
+  used space and it is what `du` reports.
+- **Hard links** are counted once, on first encounter, by file ID when the link
+  count is above one. Later encounters are zero-byte nodes flagged
+  `hardLinkDuplicate`.
+- **Clones and snapshot-held files** keep their full allocated size as the
+  map's weight and are flagged from `EF_MAY_SHARE_BLOCKS`.
+  `ATTR_CMNEXT_PRIVATESIZE` ("bytes that would be freed immediately if the
+  file were deleted") is the exact figure, and the engine can fetch it for
+  every entry and aggregate `allocated - private` up the tree as `shared`, but
+  measured over the 2 M entries of a home folder that turned a 15 s scan into
+  a 23 s one. It is therefore off by default (`--private-size` in the CLI)
+  and the app asks for it lazily, one `getattrlist`, for the item the user has
+  selected so "would free now" is still exact where it is read.
+- **Dataless files** (evicted iCloud Drive and file-provider items,
+  `SF_DATALESS`) contribute zero local bytes. Every scan thread sets
+  `IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES` to off, so no scan can ever
+  trigger a download; a dataless directory is never opened.
+- **Symlinks** are never followed and count only their own (usually zero)
+  allocation. Sockets, fifos and devices are zero-byte leaves.
+- **Packages** (`.app`, `.framework`, `.photoslibrary`, project bundles) are
+  scanned fully but flagged so the map treats them as leaves until drilled
+  into, and the Kinds view attributes their contents to the package.
+
+## Where a scan stops
+
+The startup disk is an APFS volume group. The sealed System volume mounts at
+`/`, the writable Data volume at `/System/Volumes/Data`, and the firmlink
+table in `/usr/share/firmlinks` grafts `/Users`, `/Applications`, `/Library`
+and others from Data onto the root. The scanner walks the Data volume so the
+total is one volume's `ATTR_VOL_SPACEUSED`, and `FirmlinkMap` canonicalises
+paths for display and for Finder.
+
+**A device-id check cannot find the boundary.** On this Mac `stat -f %d`
+returns 16777229 for `/`, `/System`, `/System/Volumes/Data` and `/Users`
+alike; only Preboot, VM and the simulator cryptex volumes differ. The signal is
+`ATTR_DIR_MOUNTSTATUS`: a directory carrying `DIR_MNTSTATUS_MNTPOINT` or
+`DIR_MNTSTATUS_TRIGGER` (autofs) is recorded as a `separateVolume` node with
+zero bytes and never opened. The `readdir` fallback lister compares `st_dev`
+with the parent, which is correct on the non-APFS volumes it exists for.
+
+`/` and `/System` are refused as folder scopes and redirected to the startup
+disk; scanning `/` would traverse both volumes of the group with no boundary
+and no volume figure to reconcile against.
+
+## How a scan runs
+
+- Enumeration is `getattrlistbulk(2)` with a 128 KiB buffer and one open
+  directory descriptor per worker at a time: name, object type, modification
+  time, BSD flags, file ID, mount status, link count, allocated size, extended
+  flags and private size in one record per entry, no per-entry `lstat`. The
+  record is walked by its returned-attributes bitmap (`ATTR_CMN_ERROR` sits
+  right after it when set), with unaligned loads for 8-byte values. `ENOTSUP`
+  on the root switches the whole scan to a `readdir` + `fstatat` lister.
+- Paths past `PATH_MAX` (deep `node_modules` trees) are opened through an
+  `openat` chain that holds one descriptor at a time.
+- Workers are `Foundation.Thread`s, not tasks, because the IO policies are per
+  thread and a cooperative-pool thread is shared with the sampler. Each worker
+  sets dataless materialisation off, access-time updates off and disk IO to
+  utility class, then pulls directories from a LIFO stack (depth first keeps
+  the frontier small) and posts listings into a bounded inbox. One coordinator
+  thread owns the tree, merges listings, dedupes hard links, folds small files
+  and pushes subdirectories. Cancellation finalises what was read into a
+  partial snapshot.
+- The tree is a struct-of-arrays arena with `Int32` indices and one UTF-8 name
+  buffer, about 80 bytes per node. Files below an adaptive threshold (0 on a
+  small volume, 16 KiB on a typical one, 64 KiB above 3.5 M inodes) fold into
+  one synthetic child per kind when a directory has more than 24 of them, so
+  totals stay exact while a 3 M-inode volume stays well under 1 M nodes.
+- Every 500 ms the coordinator emits progress plus a pruned preview
+  (directories to depth 3 above 0.1% of bytes so far) for progressive drawing;
+  the full tree is published once at the end.
+
+## Errors, by cause
+
+`EPERM` is privacy protection (TCC): Full Disk Access clears it, and only these
+directories feed the "grant Full Disk Access" banner. The exception is a
+**data vault** (`UF_DATAVAULT` on the directory, for example parts of
+`~/Library/Biome` and `/private/var/db`): it returns `EPERM` to everyone
+without an Apple entitlement, so it is counted separately and never blamed on
+a missing grant. A full-disk scan on this Mac with FDA still met 57 of them.
+`EACCES` is Unix permissions (`/.Spotlight-V100`, other users' folders) and no
+grant changes it. `ENOENT` mid-scan is a vanished directory. `EDEADLK` is a
+dataless directory. Per-entry errors from the bulk call keep the name and
+become zero-byte `unreadable` leaves.
+
+## Permissions
+
+Full Disk Access is the only gate that matters. The privileged helper is not
+used: root does not bypass TCC, and Move to Trash must run as the user for Put
+Back to work. FDA takes effect only after the app relaunches, so the pre-scan
+card offers Relaunch once the grant is detected as pending. Per-folder prompts
+(Desktop, Documents, Downloads) are preflighted on one thread before workers
+start so they appear one at a time and no worker blocks inside a system alert.
+
+## Reconciliation
+
+For the scanned volume: `used = scanned + unaccounted`, with unaccounted being
+metadata, local snapshots and drift. Purgeable space is an overlay, not a
+slice, because it overlaps files the scan counted as well as snapshot space it
+did not. Shared blocks come from private sizes. If scanned exceeds used the
+overshoot is shown as such. The volume is read after the scan so drift lands
+in unaccounted; a move of more than 1% is called out. For the startup disk the
+sibling volumes of the container (System, Preboot, VM, Update) are listed as
+non-removable macOS buckets so the total matches Finder's "Macintosh HD".
+
+## Verification
+
+`swift test --filter DiskMap` covers the tree, the classifier, firmlinks, the
+listers against a real temp tree (fields cross-checked with `lstat`, hard
+links, sparse and cloned files, 5 000-entry directories, long and non-ASCII
+names, paths past `PATH_MAX`, unreadable directories) and the scanner against
+scripted listings and a real tree compared with an `lstat` walk.
+
+`macperfmonitor-cli scan <path>` runs the engine headless with `--workers`,
+`--threshold`, `--no-fold`, `--private-size`, `--no-throttle`, `--top` and
+`--json`, printing throughput, peak RSS, descriptor count and the largest
+directories and files. Compare its total with `du -skx`; the two agree on hard
+links, sparse files and clones by construction.
+
+Measured on an M3 Pro (11 cores, 18 GiB) in August 2026, release build, warm
+cache:
+
+| Run | Entries | Time | Rate | Nodes | Arena | Peak RSS |
+|---|---|---|---|---|---|---|
+| `~/Library/Developer`, no fold | 145 k | 1.9 s | 77 k/s | 145 k | 11 MB | 30 MB |
+| Home, default (16 KiB fold) | 1.98 M | 15.1 s | 131 k/s | 1.24 M | 88 MB | 146 MB |
+| Home, no fold | 1.98 M | 22.1 s | 90 k/s | 1.98 M | 144 MB | 224 MB |
+| Home, with private size | 1.98 M | 23.3 s | 85 k/s | 1.24 M | 88 MB | 159 MB |
+
+The `~/Library/Developer` total (28,388,921,344 bytes) matched `du -skx` to
+the byte, in 2.0 s against du's 7.0 s. Descriptors stayed at 4 throughout.
+Workers on that tree: 1 = 11.3 s, 2 = 4.4 s, 4 = 2.4 s, 6 = 1.9 s, 8 = 1.7 s.


### PR DESCRIPTION
## Summary

Phase 1 of the Disk Map (the Disk tab's coming space analyser): the data layer, no UI yet.

- **`BulkAttributeLister`**: `getattrlistbulk` per directory (name, type, mtime, flags, file ID, mount status, link count, allocated size, extended flags, optional private size), records walked by their returned-attribute bitmap. **`ReaddirLister`** is the `fstatat` fallback for `ENOTSUP` filesystems. Paths past `PATH_MAX` open through an `openat` chain.
- **`FileTree`**: struct-of-arrays arena (`Int32` indices, one UTF-8 name buffer, contiguous child ranges) with structural validation for anything read back from disk. **`FileTreeBuilder`** keeps subtree totals current as listings land so previews can be cut mid-scan.
- **`DiskMapScanner`**: `Thread` workers with per-thread IO policies (never materialise dataless files, no atime updates, utility-class reads), LIFO frontier, bounded inbox into one coordinator; hard links deduped by file ID; small files folded per kind above an adaptive threshold; mount points and automount triggers never crossed; dataless directories never opened; cancel finalises a partial snapshot.
- **Error taxonomy** by cause: EPERM (TCC), data vaults (EPERM with `UF_DATAVAULT`, entitlement only), EACCES, vanished, dataless. Only the first will feed a "grant Full Disk Access" message.
- **`FirmlinkMap`** and **`DiskMapScope`**: the startup disk scans the Data volume and paths canonicalise back to `/Users/...`. The System and Data volumes share one device id, so mount status is the boundary, not `st_dev`.
- **`DiskMapReconciliation`**: `used = scanned + unaccounted`, purgeable as an overlay, overshoot for clones, drift detection, and the container's system volumes as non-removable buckets.
- **`macperfmonitor-cli scan <path>`** with `--workers`, `--threshold`, `--no-fold`, `--private-size`, `--no-throttle`, `--top`, `--json`.
- `docs/disk-map-design.md` records the space semantics, the boundary facts and the measurements.

## Measurements (M3 Pro, release build, warm cache)

| Run | Entries | Time | Rate | Nodes | Arena | Peak RSS |
|---|---|---|---|---|---|---|
| `~/Library/Developer`, no fold | 145 k | 1.9 s | 77 k/s | 145 k | 11 MB | 30 MB |
| Home, default (16 KiB fold) | 1.98 M | 15.1 s | 131 k/s | 1.24 M | 88 MB | 146 MB |
| Home, no fold | 1.98 M | 22.1 s | 90 k/s | 1.98 M | 144 MB | 224 MB |
| Home, with private size | 1.98 M | 23.3 s | 85 k/s | 1.24 M | 88 MB | 159 MB |
| Startup disk (Data volume) | 2.96 M | 20.5 s | 144 k/s | 1.76 M | 117 MB | 245 MB |

`~/Library/Developer` matched `du -skx` to the byte (28,388,921,344) in 2.0 s against du's 7.0 s. Descriptors stayed at 4 throughout. Worker sweep on that tree: 1 = 11.3 s, 2 = 4.4 s, 4 = 2.4 s, 6 = 1.9 s, 8 = 1.7 s (default stays 6). Fetching `ATTR_CMNEXT_PRIVATESIZE` per entry cost 54%, so it is opt-in and the app will fetch it lazily per selected item.

The full-disk run also found 32 data vaults returning EPERM despite Full Disk Access, which is what motivated splitting them out of the FDA count.

## Test plan

- [x] `swift test`: 529 tests, 0 failures (46 new). Lister fields cross-checked with `lstat`; readdir/bulk parity; hard links, sparse and cloned files; 5 000-entry directory continuation; 255-byte and non-ASCII names; paths past `PATH_MAX`; chmod-000 and missing directories; synthetic-listing tests for accumulation, folding, boundaries, error classes, hard-link dedupe, data vaults, reconciliation; cancellation yields a partial; the async stream emits progress then completes and cancels when its consumer task is cancelled; a real temp tree matches an independent `lstat` walk with and without folding.
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` clean.
- [x] CLI runs above; `brctl`/iCloud untouched (408 k dataless files in home, zero materialised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
