### PR TITLE
Disk Map phase 2: page, scope and scan controls, Full Disk Access, snapshot persistence, Largest and Oldest

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -66,6 +66,18 @@
 	<string>Mac Performance Monitor. No telemetry. All data stays on your Mac.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Scan your selected local subnet to identify devices and available services.</string>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>The Disk Map measures what is using space on your Desktop so it can show the largest items there.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>The Disk Map measures what is using space in Documents so it can show the largest items there.</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>The Disk Map measures what is using space in Downloads so it can show the largest items there.</string>
+	<key>NSRemovableVolumesUsageDescription</key>
+	<string>The Disk Map can measure what is using space on external drives you choose to scan.</string>
+	<key>NSNetworkVolumesUsageDescription</key>
+	<string>The Disk Map can measure what is using space on network volumes you choose to scan.</string>
+	<key>NSFileProviderDomainUsageDescription</key>
+	<string>The Disk Map lists cloud-synced folders by name and size without downloading anything.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUEnableAutomaticChecks</key>

--- a/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
+++ b/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
@@ -121,6 +121,7 @@ struct MacPerfMonitorApp: App {
                 .environmentObject(appDelegate.model.menuLists)
                 .environmentObject(appDelegate.appState)
                 .environmentObject(appDelegate.helperManager)
+                .environmentObject(appDelegate.fullDiskAccessManager)
                 .environmentObject(appDelegate.loginItemManager)
                 .environmentObject(appDelegate.monitorSelection)
                 .environmentObject(appDelegate.groupStore)
@@ -142,6 +143,19 @@ struct MacPerfMonitorApp: App {
                 }
                 .keyboardShortcut("l", modifiers: [.command, .shift])
             }
+            CommandMenu("Disk") {
+                Button("Disk Map") {
+                    AppLog.ui.notice("Disk Map command invoked")
+                    appDelegate.appState.mainWindowOpen = true
+                    appDelegate.appState.mainWindowVisible = true
+                    appDelegate.appState.showDiskMap = true
+                    appDelegate.appState.requestedMainTab = .diskUsage
+                    NotificationCenter.default.post(
+                        name: .macperfmonitorShowMainWindow, object: nil)
+                    NSApp.activate(ignoringOtherApps: true)
+                }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
+            }
         }
 
         Settings {
@@ -149,6 +163,7 @@ struct MacPerfMonitorApp: App {
                 .environmentObject(appDelegate.alertSettings)
                 .environmentObject(appDelegate.model)
                 .environmentObject(appDelegate.helperManager)
+                .environmentObject(appDelegate.fullDiskAccessManager)
                 .environmentObject(appDelegate.loginItemManager)
                 .environmentObject(appDelegate.appModeManager)
                 .environmentObject(appDelegate.menuBarConfiguration)
@@ -160,6 +175,7 @@ struct MacPerfMonitorApp: App {
                 .environmentObject(appDelegate.appModeManager)
                 .environmentObject(appDelegate.loginItemManager)
                 .environmentObject(appDelegate.helperManager)
+                .environmentObject(appDelegate.fullDiskAccessManager)
                 .environmentObject(appDelegate.menuBarConfiguration)
         }
         .windowResizability(.contentSize)
@@ -285,6 +301,10 @@ final class AppState: ObservableObject {
     /// `NetworkView` consumes and clears it when that tab mounts.
     @Published var showNetworkScanner = false
 
+    /// Set by the app command to open the Disk tab's Disk Map page.
+    /// `DiskUsageView` consumes and clears it when that tab mounts.
+    @Published var showDiskMap = false
+
     /// A `.mpmtrace` file opened from Finder, awaiting display. `ContentView`
     /// switches to the Analytics tab and `AnalyticsView` decodes and shows it,
     /// then clears this. Nil when nothing is pending.
@@ -338,6 +358,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
     let onboarding = OnboardingState()
     let helperManager = HelperManager()
     let loginItemManager = LoginItemManager()
+    let fullDiskAccessManager = FullDiskAccessManager()
     let updateController = UpdateController()
     let monitorSelection = MonitorSelection()
     let groupStore = ProcessGroupStore.shared
@@ -670,6 +691,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
     func applicationDidBecomeActive(_ notification: Notification) {
         helperManager.refresh()
         loginItemManager.refresh()
+        // Full Disk Access is also granted out of process; re-probe so the
+        // Disk Map's card and Settings reflect a fresh grant.
+        fullDiskAccessManager.refresh()
     }
 
     // MARK: - UNUserNotificationCenterDelegate

--- a/Sources/MacPerfMonitor/Onboarding/OnboardingView.swift
+++ b/Sources/MacPerfMonitor/Onboarding/OnboardingView.swift
@@ -280,6 +280,39 @@ private struct OnboardingToggleRow: View {
     }
 }
 
+/// A permission the app cannot toggle itself (it is granted in System
+/// Settings): the toggle row's layout with a button, or a checkmark once done.
+private struct OnboardingActionRow: View {
+    let symbol: String
+    let title: String
+    let subtitle: String
+    let actionTitle: String?
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: symbol)
+                .foregroundStyle(.secondary)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+            if let actionTitle {
+                Button(actionTitle, action: action)
+                    .controlSize(.small)
+            } else {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+        }
+    }
+}
+
 /// Step 1: choose the function mode (full history vs menu-bar-only).
 private struct OnboardingModeStep: View {
     @EnvironmentObject private var appMode: AppModeManager
@@ -354,12 +387,13 @@ private struct OnboardingModeCard: View {
 private struct OnboardingPermissionsStep: View {
     @EnvironmentObject private var loginItem: LoginItemManager
     @EnvironmentObject private var helper: HelperManager
+    @EnvironmentObject private var fullDiskAccess: FullDiskAccessManager
 
     var body: some View {
         OnboardingStepScaffold(
             symbol: "checkmark.shield", tint: .teal,
             title: "Set up access",
-            subtitle: "Both are optional and can be changed later in Settings."
+            subtitle: "All of these are optional and can be changed later in Settings."
         ) {
             VStack(spacing: 12) {
                 OnboardingToggleRow(
@@ -387,9 +421,27 @@ private struct OnboardingPermissionsStep: View {
                             .controlSize(.small)
                     }
                 }
+
+                OnboardingActionRow(
+                    symbol: "internaldrive",
+                    title: "Full Disk Access for the Disk Map",
+                    subtitle: fullDiskAccessSubtitle,
+                    actionTitle: fullDiskAccess.isGranted ? nil : "Open System Settings…",
+                    action: { fullDiskAccess.openSystemSettings() })
             }
             .padding(.top, 4)
         }
+    }
+
+    private var fullDiskAccessSubtitle: String {
+        if fullDiskAccess.isGranted {
+            return "Granted. The Disk Map can map every folder your account owns."
+        }
+        if fullDiskAccess.awaitingRelaunch {
+            return "Takes effect once \(AppInfo.displayName) relaunches."
+        }
+        return
+            "Lets the Disk Map see Mail, Messages, Safari, Time Machine and other apps' data when you scan for what is using space."
     }
 
     private var helperSubtitle: String {

--- a/Sources/MacPerfMonitor/Util/FullDiskAccessManager.swift
+++ b/Sources/MacPerfMonitor/Util/FullDiskAccessManager.swift
@@ -1,0 +1,106 @@
+import AppKit
+import Darwin
+import Foundation
+
+enum FullDiskAccessStatus: Equatable {
+    case granted
+    case notGranted
+    /// Neither probe path exists on this account; assume nothing and never nag.
+    case unknown
+}
+
+/// Tracks whether the app holds Full Disk Access, the one grant the Disk Map
+/// needs for a complete scan. FDA is a TCC decision made out of process in
+/// System Settings, keyed to the code signature, and it applies to a running
+/// app only after it relaunches; this manager probes without ever prompting,
+/// re-probes on activation like `HelperManager`, and remembers that the user
+/// was sent to Settings so the page can offer a relaunch.
+///
+/// Main-thread only (SwiftUI actions and app delegate callbacks), the same
+/// convention as `HelperManager`.
+final class FullDiskAccessManager: ObservableObject {
+    @Published private(set) var status: FullDiskAccessStatus = .unknown
+    /// True after the user opened Settings and the grant has not shown up in
+    /// this process yet, which is what a fresh grant looks like until relaunch.
+    @Published private(set) var awaitingRelaunch = false
+
+    private var openedSettingsAt: Date?
+    private static let relaunchWindow: TimeInterval = 30 * 60
+
+    init() {
+        refresh()
+    }
+
+    var isGranted: Bool { status == .granted }
+
+    /// Re-probe. Called at launch, on activation, and after Settings opens.
+    func refresh() {
+        let probed = Self.probe()
+        status = probed
+        if probed == .granted {
+            awaitingRelaunch = false
+            openedSettingsAt = nil
+        } else if let openedSettingsAt,
+            Date().timeIntervalSince(openedSettingsAt) < Self.relaunchWindow
+        {
+            awaitingRelaunch = true
+        }
+    }
+
+    /// The Privacy and Security pane, Full Disk Access list.
+    func openSystemSettings() {
+        openedSettingsAt = Date()
+        awaitingRelaunch = status != .granted
+        open("x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")
+        AppLog.ui.notice("Full Disk Access settings opened")
+    }
+
+    /// The Files and Folders list, for a Desktop / Documents / Downloads
+    /// prompt the user declined earlier.
+    func openFilesAndFoldersSettings() {
+        open("x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders")
+    }
+
+    /// Quit and reopen so a fresh grant applies. `open` runs after a short
+    /// delay from a detached shell so the new instance starts once this one
+    /// has exited (`LSMultipleInstancesProhibited` refuses a second copy while
+    /// the first is still up). The bundle path is passed as an argument, not
+    /// interpolated, so a space in `/Applications/Mac Performance Monitor.app`
+    /// cannot break the command.
+    func relaunch() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "sleep 1.5; /usr/bin/open \"$0\"", Bundle.main.bundlePath]
+        do {
+            try process.run()
+            AppLog.ui.notice("relaunching for Full Disk Access")
+            NSApp.terminate(nil)
+        } catch {
+            AppLog.ui.error("relaunch failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func open(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// The standard probe: TCC's own database is readable only with the grant
+    /// (EPERM without it). If it is missing on this account, Safari's folder is
+    /// the second-best signal. Neither call can trigger a prompt.
+    static func probe() -> FullDiskAccessStatus {
+        let home = NSHomeDirectory()
+        let tcc = home + "/Library/Application Support/com.apple.TCC/TCC.db"
+        let fd = Darwin.open(tcc, O_RDONLY | O_CLOEXEC)
+        if fd >= 0 {
+            close(fd)
+            return .granted
+        }
+        if errno == EPERM { return .notGranted }
+        if let dir = opendir(home + "/Library/Safari") {
+            closedir(dir)
+            return .granted
+        }
+        return errno == EPERM ? .notGranted : .unknown
+    }
+}

--- a/Sources/MacPerfMonitor/ViewModels/DiskMapModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/DiskMapModel.swift
@@ -1,0 +1,495 @@
+import AppKit
+import Combine
+import Foundation
+import MacPerfMonitorCore
+
+/// One line of a Disk Map slice (Largest, Oldest): a node flattened for a table.
+struct DiskMapRow: Identifiable, Hashable, Sendable {
+    let id: Int32
+    let name: String
+    /// The canonical path the user knows (firmlinks resolved).
+    let path: String
+    let bytes: UInt64
+    let modified: Date
+    let kind: FileKind
+    let isDirectory: Bool
+    let flags: FileNodeFlags
+    let count: UInt32
+    /// Share of everything the scan counted.
+    let fraction: Double
+
+    var kindLabel: String { isDirectory && kind == .folder ? "Folder" : kind.label }
+    var parentPath: String { (path as NSString).deletingLastPathComponent }
+}
+
+/// State for the Disk Map page: the scope, the last scan (restored from disk
+/// on open), the scan in flight, the selection, and the memoised rows of the
+/// active slice. One shared instance, like `HardwareExplorerModel`, because
+/// `TabGate` unmounts the page on every tab switch and a multi-minute scan
+/// must survive that. What it must not survive is the window closing: the
+/// arena is dropped then (memory budget) and comes back from the snapshot
+/// file on the next open. Nothing here runs on the sampler's tick.
+@MainActor
+final class DiskMapModel: ObservableObject {
+    static let shared = DiskMapModel()
+
+    /// Rows a slice keeps: enough to scroll through, few enough that a SwiftUI
+    /// `Table` stays cheap (it never ticks).
+    nonisolated static let rowLimit = 2_000
+
+    enum ViewMode: String, CaseIterable, Identifiable {
+        case largest = "Largest"
+        case oldest = "Oldest"
+        var id: String { rawValue }
+    }
+
+    enum LargestKind: String, CaseIterable, Identifiable {
+        case files = "Files"
+        case folders = "Folders"
+        var id: String { rawValue }
+    }
+
+    enum AgeBand: Int, CaseIterable, Identifiable {
+        case any = 0
+        case oneYear = 1
+        case twoYears = 2
+        case fiveYears = 5
+        var id: Int { rawValue }
+        var label: String {
+            switch self {
+            case .any: return "Any age"
+            case .oneYear: return "Untouched 1+ year"
+            case .twoYears: return "Untouched 2+ years"
+            case .fiveYears: return "Untouched 5+ years"
+            }
+        }
+        func cutoff(now: Date) -> Date? {
+            self == .any ? nil : now.addingTimeInterval(-Double(rawValue) * 365 * 86_400)
+        }
+    }
+
+    enum MinimumSize: UInt64, CaseIterable, Identifiable {
+        case any = 0
+        case oneMB = 1_048_576
+        case tenMB = 10_485_760
+        case hundredMB = 104_857_600
+        case oneGB = 1_073_741_824
+        var id: UInt64 { rawValue }
+        var label: String {
+            switch self {
+            case .any: return "Any size"
+            case .oneMB: return "1 MB and up"
+            case .tenMB: return "10 MB and up"
+            case .hundredMB: return "100 MB and up"
+            case .oneGB: return "1 GB and up"
+            }
+        }
+    }
+
+    @Published private(set) var scope: DiskMapScope = .startupDisk
+    @Published private(set) var snapshot: DiskMapSnapshot?
+    @Published private(set) var preview: DiskMapPreviewNode?
+    @Published private(set) var progress: DiskMapScanProgress?
+    @Published private(set) var isScanning = false
+    /// True while the Desktop / Documents / Downloads prompts are being
+    /// sequenced ahead of the workers (only without Full Disk Access).
+    @Published private(set) var isPreparing = false
+    @Published private(set) var isRestoring = false
+    @Published private(set) var lastError: String?
+    /// Mounted user volumes offered in the scope menu.
+    @Published private(set) var externalVolumes: [VolumeInfo] = []
+    @Published var selection: Int32?
+    @Published var viewMode: ViewMode = .largest
+    @Published var largestKind: LargestKind = .files
+    @Published var ageBand: AgeBand = .oneYear
+    @Published var minimumSize: MinimumSize = .oneMB
+    @Published var filterText = ""
+    /// The active slice, memoised per (snapshot revision, mode, filters) and
+    /// built off the main thread. `rowsRevision` is what views compare.
+    @Published private(set) var rows: [DiskMapRow] = []
+    @Published private(set) var rowsRevision = 0
+    @Published private(set) var rowsBuilding = false
+
+    private let scanner = DiskMapScanner()
+    private var scanTask: Task<Void, Never>?
+    private var scanID = UUID()
+    private var restoreID = UUID()
+    private var rowsGeneration = 0
+    private var cancellables = Set<AnyCancellable>()
+    private var windowCancellable: AnyCancellable?
+    private weak var fullDiskAccess: FullDiskAccessManager?
+
+    private init() {
+        // `@Published` emits on willSet, so a sink that reads the properties
+        // synchronously sees the value being replaced. Hopping through the main
+        // queue delivers after the assignment, which is the value to build for.
+        Publishers.CombineLatest4($viewMode, $largestKind, $ageBand, $minimumSize)
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _, _, _, _ in self?.rebuildRows() }
+            .store(in: &cancellables)
+        $filterText
+            .dropFirst()
+            .debounce(for: .milliseconds(150), scheduler: RunLoop.main)
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.rebuildRows() }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Lifecycle
+
+    /// Hook up the window gate and the access manager. Idempotent; the page
+    /// calls it on every appear.
+    func bind(appState: AppState, fullDiskAccess: FullDiskAccessManager) {
+        self.fullDiskAccess = fullDiskAccess
+        guard windowCancellable == nil else { return }
+        windowCancellable = appState.$mainWindowOpen
+            .removeDuplicates()
+            .sink { [weak self] open in
+                if !open { self?.windowClosed() }
+            }
+    }
+
+    /// The page appeared: bring back the last scan for this scope if nothing
+    /// is loaded, and refresh the volume list for the scope menu.
+    func appear() {
+        if snapshot == nil, !isScanning, !isRestoring {
+            restore(scope)
+        }
+        refreshVolumes()
+    }
+
+    private func windowClosed() {
+        // Drop the arena before MemoryReclaim's pressure relief runs; a scan
+        // in flight is abandoned (its partial result would only shadow the
+        // last complete one on disk).
+        cancelScan()
+        snapshot = nil
+        rows = []
+        rowsRevision += 1
+        selection = nil
+        AppLog.ui.notice("Disk Map released its tree on window close")
+    }
+
+    // MARK: - Scope
+
+    var scopeTitle: String { scope.rootName }
+
+    func setScope(_ newScope: DiskMapScope) {
+        guard newScope != scope else { return }
+        cancelScan()
+        scope = newScope
+        snapshot = nil
+        rows = []
+        rowsRevision += 1
+        selection = nil
+        lastError = nil
+        restore(newScope)
+    }
+
+    /// "Choose Folder…": any directory, normalised through `DiskMapScope`.
+    func chooseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Scan"
+        panel.message = "Choose a folder to map."
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        setScope(DiskMapScope.resolved(folder: url.path))
+    }
+
+    private func refreshVolumes() {
+        Task.detached(priority: .utility) {
+            let volumes = VolumeReader().read().volumes.filter {
+                $0.role == .user && $0.isLocal && $0.mountPoint != "/"
+                    && !$0.mountPoint.hasPrefix("/System/")
+                    && !$0.mountPoint.hasPrefix("/private/")
+            }
+            await MainActor.run { self.externalVolumes = volumes }
+        }
+    }
+
+    // MARK: - Scanning
+
+    var progressFraction: Double? { progress?.fraction }
+
+    var statusText: String {
+        if isPreparing { return "Checking folder access\u{2026}" }
+        guard let progress else { return "Starting\u{2026}" }
+        let items = Self.compactCount(progress.entries)
+        let elapsed = Int(progress.elapsed)
+        let clock = String(format: "%d:%02d", elapsed / 60, elapsed % 60)
+        return "\(items) items \u{00B7} \(ByteFormat.string(progress.bytes)) \u{00B7} \(clock)"
+    }
+
+    var currentPathText: String { progress?.currentPath ?? "" }
+
+    func startScan() {
+        guard !isScanning else { return }
+        cancelScan()
+        lastError = nil
+        isScanning = true
+        let id = UUID()
+        scanID = id
+        AppLog.ui.notice("Disk Map scan requested: \(self.scope.scanRoot, privacy: .public)")
+        let needsPreflight =
+            (fullDiskAccess?.isGranted != true) && (scope == .startupDisk || scope == .home)
+        guard needsPreflight else {
+            launch(id)
+            return
+        }
+        // Without Full Disk Access the first touch of Desktop, Documents and
+        // Downloads raises a system prompt on the thread that touched it. Six
+        // workers would stack three alerts and block inside them; one thread
+        // visiting the three folders in turn shows them one at a time.
+        isPreparing = true
+        let home = NSHomeDirectory()
+        Task.detached(priority: .userInitiated) {
+            let lister = BulkAttributeLister()
+            for folder in ["Desktop", "Documents", "Downloads"] {
+                _ = try? lister.list(path: home + "/" + folder)
+            }
+            await MainActor.run {
+                guard self.scanID == id else { return }
+                self.isPreparing = false
+                self.launch(id)
+            }
+        }
+    }
+
+    private func launch(_ id: UUID) {
+        guard scanID == id else { return }
+        let events = scanner.scan(scope, options: DiskMapScanOptions())
+        scanTask = Task { [weak self] in
+            for await event in events {
+                guard let self, !Task.isCancelled, self.scanID == id else { return }
+                self.apply(event)
+            }
+        }
+    }
+
+    func cancelScan() {
+        scanID = UUID()
+        scanTask?.cancel()
+        scanTask = nil
+        isScanning = false
+        isPreparing = false
+        progress = nil
+        preview = nil
+    }
+
+    private func apply(_ event: DiskMapScanEvent) {
+        switch event {
+        case .progress(let progress, let preview):
+            self.progress = progress
+            self.preview = preview
+        case .completed(let snapshot):
+            finish(snapshot)
+        case .failed(let error):
+            isScanning = false
+            scanTask = nil
+            progress = nil
+            preview = nil
+            lastError = error.localizedDescription
+            AppLog.ui.error("Disk Map scan failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func finish(_ snapshot: DiskMapSnapshot) {
+        self.snapshot = snapshot
+        isScanning = false
+        scanTask = nil
+        progress = nil
+        preview = nil
+        selection = nil
+        rebuildRows()
+        FDWatchdog.check(after: "disk map scan")
+        let counts = snapshot.reconciliation.counts
+        AppLog.ui.notice(
+            "Disk Map scan finished: \(snapshot.tree.nodeCount) nodes, \(counts.entries) entries, \(snapshot.reconciliation.scannedBytes) bytes, \(counts.notPermitted) not permitted"
+        )
+        guard !snapshot.partial else { return }
+        Task.detached(priority: .utility) {
+            do {
+                try DiskMapSnapshotStore.save(snapshot)
+                AppLog.ui.notice("Disk Map snapshot saved")
+            } catch {
+                AppLog.ui.error(
+                    "Disk Map snapshot save failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+
+    private func restore(_ scope: DiskMapScope) {
+        isRestoring = true
+        let id = UUID()
+        restoreID = id
+        Task.detached(priority: .userInitiated) {
+            let loaded: DiskMapSnapshot?
+            do {
+                loaded = try DiskMapSnapshotStore.load(for: scope)
+            } catch {
+                loaded = nil
+                AppLog.ui.error(
+                    "Disk Map snapshot load failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+            await MainActor.run {
+                guard self.restoreID == id else { return }
+                self.isRestoring = false
+                guard let loaded, self.scope == scope, self.snapshot == nil else { return }
+                self.snapshot = loaded
+                self.rebuildRows()
+                AppLog.ui.notice("Disk Map snapshot restored (\(loaded.tree.nodeCount) nodes)")
+            }
+        }
+    }
+
+    func clearError() {
+        lastError = nil
+    }
+
+    // MARK: - Selection and lookups
+
+    func select(_ node: Int32?) {
+        selection = node
+    }
+
+    func displayPath(of node: Int32) -> String? {
+        snapshot?.displayPath(of: node)
+    }
+
+    func filesystemPath(of node: Int32) -> String? {
+        snapshot?.filesystemPath(of: node)
+    }
+
+    /// Children of a directory, largest first, folds included.
+    func childrenBySize(of node: Int32) -> [Int32] {
+        snapshot?.tree.childrenBySize(of: node) ?? []
+    }
+
+    // MARK: - Rows
+
+    private func rebuildRows() {
+        guard let snapshot else {
+            rows = []
+            rowsRevision += 1
+            return
+        }
+        rowsGeneration += 1
+        let generation = rowsGeneration
+        let mode = viewMode
+        let kind = largestKind
+        let band = ageBand
+        let minimum = minimumSize
+        let filter = filterText.trimmingCharacters(in: .whitespaces)
+        rowsBuilding = true
+        Task.detached(priority: .userInitiated) {
+            let built = Self.buildRows(
+                snapshot: snapshot, mode: mode, largestKind: kind, ageBand: band,
+                minimumSize: minimum, filter: filter, now: Date(), limit: Self.rowLimit)
+            await MainActor.run {
+                guard self.rowsGeneration == generation else { return }
+                self.rows = built
+                self.rowsRevision += 1
+                self.rowsBuilding = false
+            }
+        }
+    }
+
+    /// One pass over the arena to pick the slice, then paths for the survivors
+    /// only. The filter matches a node or any ancestor by name, computed as a
+    /// forward pass (parents precede children) over raw name bytes so no
+    /// strings are made for the millions that do not match.
+    nonisolated static func buildRows(
+        snapshot: DiskMapSnapshot, mode: ViewMode, largestKind: LargestKind, ageBand: AgeBand,
+        minimumSize: MinimumSize, filter: String, now: Date, limit: Int
+    ) -> [DiskMapRow] {
+        let tree = snapshot.tree
+        let n = tree.nodeCount
+        guard n > 1 else { return [] }
+        let total = max(tree.bytes[0], 1)
+
+        var hit: [Bool] = []
+        let needle = Array(filter.lowercased().utf8)
+        if !needle.isEmpty {
+            hit = [Bool](repeating: false, count: n)
+            for i in 1..<n {
+                let p = Int(tree.parent[i])
+                hit[i] = hit[p] || nameContains(tree.nameBytes(of: Int32(i)), needle)
+            }
+        }
+
+        let cutoff = ageBand.cutoff(now: now).map {
+            UInt32(clamping: Int($0.timeIntervalSince1970))
+        }
+        var candidates: [(key: UInt64, node: Int32)] = []
+        candidates.reserveCapacity(min(n, 1 << 20))
+        for i in 1..<n {
+            let flags = tree.flags[i]
+            if flags.contains(.smallFilesFold) || flags.contains(.trashed) { continue }
+            if !needle.isEmpty, !hit[i] { continue }
+            let isDirectory = flags.contains(.directory)
+            switch mode {
+            case .largest:
+                switch largestKind {
+                case .files:
+                    if isDirectory { continue }
+                case .folders:
+                    if !isDirectory || flags.contains(.separateVolume) { continue }
+                }
+                if tree.bytes[i] == 0 { continue }
+                candidates.append((key: tree.bytes[i], node: Int32(i)))
+            case .oldest:
+                if isDirectory { continue }
+                if tree.bytes[i] < minimumSize.rawValue { continue }
+                if let cutoff, tree.modified[i] > cutoff { continue }
+                if tree.modified[i] == 0 { continue }
+                candidates.append((key: UInt64(tree.modified[i]), node: Int32(i)))
+            }
+        }
+        switch mode {
+        case .largest: candidates.sort { $0.key > $1.key }
+        case .oldest: candidates.sort { $0.key < $1.key }
+        }
+
+        return candidates.prefix(limit).map { entry in
+            let i = Int(entry.node)
+            return DiskMapRow(
+                id: entry.node, name: tree.name(of: entry.node),
+                path: snapshot.displayPath(of: entry.node), bytes: tree.bytes[i],
+                modified: tree.modifiedDate(of: entry.node), kind: tree.kind[i],
+                isDirectory: tree.flags[i].contains(.directory), flags: tree.flags[i],
+                count: tree.count[i], fraction: Double(tree.bytes[i]) / Double(total))
+        }
+    }
+
+    /// ASCII case-insensitive substring search on raw UTF-8.
+    private nonisolated static func nameContains(
+        _ name: ArraySlice<UInt8>, _ needle: [UInt8]
+    ) -> Bool {
+        let m = needle.count
+        guard m > 0, name.count >= m else { return false }
+        let start = name.startIndex
+        let last = name.count - m
+        outer: for offset in 0...last {
+            for j in 0..<m {
+                var byte = name[start + offset + j]
+                if byte >= UInt8(ascii: "A"), byte <= UInt8(ascii: "Z") { byte += 32 }
+                if byte != needle[j] { continue outer }
+            }
+            return true
+        }
+        return false
+    }
+
+    static func compactCount(_ value: UInt64) -> String {
+        switch value {
+        case 0..<1_000: return "\(value)"
+        case 1_000..<1_000_000: return String(format: "%.1f k", Double(value) / 1_000)
+        default: return String(format: "%.2f M", Double(value) / 1_000_000)
+        }
+    }
+}

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapDetailRail.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapDetailRail.swift
@@ -1,0 +1,324 @@
+import MacPerfMonitorCore
+import QuickLook
+import SwiftUI
+
+/// The right-hand rail: everything about the selected item and the ways to
+/// act on it. Facts the scan did not carry (logical length, the bytes a delete
+/// would free) are read on selection with one `getattrlist`, off the main
+/// thread, and shown when they arrive.
+struct DiskMapDetailRail: View {
+    @ObservedObject var model: DiskMapModel
+    @State private var facts: DiskMapItemFacts?
+    @State private var quickLookURL: URL?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                if let node = model.selection, let snapshot = model.snapshot,
+                    Int(node) < snapshot.tree.nodeCount
+                {
+                    content(node: node, snapshot: snapshot)
+                } else {
+                    placeholder
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .task(id: model.selection) { await loadFacts() }
+        .quickLookPreview($quickLookURL)
+    }
+
+    private var placeholder: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "cursorarrow.click.2")
+                .font(.title)
+                .foregroundStyle(.tertiary)
+            Text("Select an item")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text("Its size, age and location appear here, with Reveal in Finder and Quick Look.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 60)
+    }
+
+    @ViewBuilder
+    private func content(node: Int32, snapshot: DiskMapSnapshot) -> some View {
+        let tree = snapshot.tree
+        let i = Int(node)
+        let flags = tree.flags[i]
+        let isFold = flags.contains(.smallFilesFold)
+        let isDirectory = flags.contains(.directory)
+        let displayPath = snapshot.displayPath(of: node)
+        let name =
+            isFold
+            ? foldName(tree, node)
+            : (node == FileTree.root ? snapshot.scope.rootName : tree.name(of: node))
+        let parentBytes = node == FileTree.root ? tree.bytes[0] : tree.bytes[Int(tree.parent[i])]
+
+        header(
+            name: name, path: displayPath, isFold: isFold, kind: tree.kind[i],
+            isDirectory: isDirectory)
+
+        pathRow(displayPath)
+
+        factsGrid(
+            tree: tree, node: node, parentBytes: parentBytes, isDirectory: isDirectory,
+            isFold: isFold)
+
+        if !badges(flags).isEmpty {
+            badgeRow(badges(flags))
+        }
+
+        if !isFold {
+            actions(displayPath: displayPath, isDirectory: isDirectory)
+        }
+
+        if isDirectory, tree.childCount[i] > 0 {
+            topContents(tree: tree, node: node)
+        } else if flags.contains(.notPermitted) {
+            note(
+                "macOS did not allow \(AppInfo.displayName) to read this folder. Full Disk Access unlocks it."
+            )
+        } else if flags.contains(.dataVault) {
+            note("A data vault: only Apple's own software may read it, whatever access is granted.")
+        } else if flags.contains(.accessDenied) {
+            note("Owned by another user or by the system; your account cannot list it.")
+        } else if flags.contains(.separateVolume) {
+            note("Another volume is mounted here. Its contents are not part of this scan.")
+        } else if flags.contains(.dataless), isDirectory {
+            note("Stored in iCloud and not downloaded. Nothing here takes local space.")
+        }
+    }
+
+    private func header(
+        name: String, path: String, isFold: Bool, kind: FileKind, isDirectory: Bool
+    ) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            if isFold {
+                Image(systemName: "square.stack.3d.up")
+                    .font(.title)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 36, height: 36)
+            } else {
+                Image(nsImage: ProcessIconProvider.shared.icon(forPath: path))
+                    .resizable()
+                    .frame(width: 36, height: 36)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.headline)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+                Text(isDirectory && kind == .folder ? "Folder" : kind.label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func pathRow(_ path: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(path)
+                .font(.callout.monospaced())
+                .lineLimit(2)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 4)
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(path, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.borderless)
+            .help("Copy path")
+        }
+    }
+
+    @ViewBuilder
+    private func factsGrid(
+        tree: FileTree, node: Int32, parentBytes: UInt64, isDirectory: Bool, isFold: Bool
+    )
+        -> some View
+    {
+        let i = Int(node)
+        let bytes = tree.bytes[i]
+        let total = max(tree.bytes[0], 1)
+        Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 12, verticalSpacing: 6) {
+            factRow("Size", ByteFormat.string(bytes))
+            if let facts, !isDirectory, !isFold {
+                if facts.logicalBytes != facts.allocatedBytes {
+                    factRow("Length", ByteFormat.string(facts.logicalBytes), dim: true)
+                }
+                if facts.privateBytes != nil {
+                    factRow(
+                        "Would free now", ByteFormat.string(facts.wouldFreeBytes),
+                        dim: facts.wouldFreeBytes == bytes)
+                }
+                if facts.linkCount > 1 {
+                    factRow("Hard links", "\(facts.linkCount)", dim: true)
+                }
+            }
+            if isDirectory || isFold {
+                factRow("Items", tree.count[i].formatted())
+            }
+            factRow("Share of scan", shareText(Double(bytes) / Double(total)))
+            if node != FileTree.root, parentBytes > 0 {
+                factRow("Share of parent", shareText(Double(bytes) / Double(parentBytes)))
+            }
+            if tree.modified[i] > 0 {
+                factRow("Modified", modifiedText(tree.modifiedDate(of: node)))
+            }
+        }
+    }
+
+    private func factRow(_ label: String, _ value: String, dim: Bool = false) -> some View {
+        GridRow {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .gridColumnAlignment(.leading)
+            Text(value)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(dim ? .secondary : .primary)
+                .gridColumnAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    private func badges(_ flags: FileNodeFlags) -> [String] {
+        var out: [String] = []
+        if flags.contains(.package) { out.append("Package") }
+        if flags.contains(.mayShareBlocks) { out.append("Clone") }
+        if flags.contains(.hardLinkDuplicate) { out.append("Hard link (counted elsewhere)") }
+        if flags.contains(.dataless) { out.append("In iCloud, not on this disk") }
+        if flags.contains(.restricted) { out.append("Protected by SIP") }
+        if flags.contains(.immutable) { out.append("Locked") }
+        if flags.contains(.symlink) { out.append("Alias") }
+        if flags.contains(.hidden) { out.append("Hidden") }
+        if flags.contains(.smallFilesFold) { out.append("Small files") }
+        if flags.contains(.trashed) { out.append("In Trash") }
+        return out
+    }
+
+    private func badgeRow(_ badges: [String]) -> some View {
+        HardwareFlowLayout(spacing: 5) {
+            ForEach(badges, id: \.self) { badge in
+                Text(badge)
+                    .font(.caption2)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(.quaternary))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func actions(displayPath: String, isDirectory: Bool) -> some View {
+        HStack(spacing: 8) {
+            Button {
+                ProcessActions.revealInFinder(path: displayPath)
+            } label: {
+                Label("Reveal in Finder", systemImage: "folder")
+            }
+            .help("Show this item in the Finder")
+            Button {
+                quickLookURL = URL(fileURLWithPath: displayPath)
+            } label: {
+                Label("Quick Look", systemImage: "eye")
+            }
+            .help("Preview without opening (Space)")
+            .keyboardShortcut(.space, modifiers: [])
+        }
+        .controlSize(.small)
+    }
+
+    private func topContents(tree: FileTree, node: Int32) -> some View {
+        let children = tree.childrenBySize(of: node).prefix(8)
+        let parentBytes = max(tree.bytes[Int(node)], 1)
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("TOP CONTENTS")
+                .font(.caption2.weight(.semibold))
+                .tracking(0.6)
+                .foregroundStyle(.tertiary)
+            ForEach(Array(children), id: \.self) { child in
+                let c = Int(child)
+                Button {
+                    model.select(child)
+                } label: {
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 6) {
+                            Image(systemName: tree.flags[c].contains(.directory) ? "folder" : "doc")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .frame(width: 12)
+                            Text(childName(tree, child))
+                                .font(.caption)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Text(ByteFormat.string(tree.bytes[c]))
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                        GroupProportionBar(
+                            fraction: Double(tree.bytes[c]) / Double(parentBytes),
+                            tint: DiskStyle.read)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func note(_ text: String) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func childName(_ tree: FileTree, _ child: Int32) -> String {
+        tree.flags[Int(child)].contains(.smallFilesFold)
+            ? foldName(tree, child) : tree.name(of: child)
+    }
+
+    private func foldName(_ tree: FileTree, _ node: Int32) -> String {
+        let i = Int(node)
+        let kind = tree.kind[i]
+        let what = kind == .other ? "small items" : "small \(kind.label.lowercased())"
+        return "\(tree.count[i].formatted()) \(what)"
+    }
+
+    private func shareText(_ fraction: Double) -> String {
+        let percent = fraction * 100
+        if percent > 0 && percent < 0.1 { return "<0.1%" }
+        return String(format: "%.1f%%", percent)
+    }
+
+    private func modifiedText(_ date: Date) -> String {
+        let relative = date.formatted(.relative(presentation: .named))
+        return "\(relative)"
+    }
+
+    private func loadFacts() async {
+        facts = nil
+        guard let node = model.selection, let snapshot = model.snapshot,
+            Int(node) < snapshot.tree.nodeCount,
+            !snapshot.tree.flags[Int(node)].contains(.smallFilesFold)
+        else { return }
+        let path = snapshot.filesystemPath(of: node)
+        let read = await Task.detached(priority: .userInitiated) {
+            DiskMapItemFacts.read(path: path)
+        }.value
+        guard !Task.isCancelled, model.selection == node else { return }
+        facts = read
+    }
+}

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapReconciliationBar.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapReconciliationBar.swift
@@ -1,0 +1,223 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// Where every byte of the volume went, in one bar: what the scan counted,
+/// what it could not account for, the non-removable macOS volumes of the
+/// startup disk, and what is free. Beneath it, chips for the figures that
+/// qualify the bar (purgeable, shared blocks, folders that could not be read)
+/// so the total the user sees matches Finder's and the caveats are explicit.
+struct DiskMapReconciliationBar: View {
+    let reconciliation: DiskMapReconciliation
+    let scope: DiskMapScope
+    var onGrantAccess: (() -> Void)?
+    var onFolderAccess: (() -> Void)?
+
+    private struct Segment: Identifiable {
+        let id: String
+        let label: String
+        let bytes: UInt64
+        let color: Color
+    }
+
+    private var scanned: UInt64 { reconciliation.scannedBytes }
+    private var systemBytes: UInt64 { reconciliation.systemVolumes.reduce(0) { $0 + $1.usedBytes } }
+
+    private var segments: [Segment] {
+        var result: [Segment] = [
+            Segment(id: "scanned", label: scannedLabel, bytes: scanned, color: DiskStyle.read)
+        ]
+        if reconciliation.unaccountedBytes > 0 {
+            result.append(
+                Segment(
+                    id: "unaccounted", label: "Unaccounted", bytes: reconciliation.unaccountedBytes,
+                    color: Color.secondary.opacity(0.45)))
+        }
+        if systemBytes > 0 {
+            result.append(Segment(id: "macos", label: "macOS", bytes: systemBytes, color: .teal))
+        }
+        if let free = reconciliation.availableBytes, free > 0 {
+            result.append(
+                Segment(id: "free", label: "Free", bytes: free, color: DiskStyle.freeTrack))
+        }
+        return result
+    }
+
+    private var scannedLabel: String {
+        switch scope {
+        case .startupDisk, .volume: return "Scanned"
+        case .home, .folder: return scope.rootName
+        }
+    }
+
+    private var totalBytes: UInt64 { max(segments.reduce(0) { $0 + $1.bytes }, 1) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(headline)
+                    .font(.subheadline.weight(.semibold))
+                Text(subheadline)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer()
+            }
+            bar
+                .frame(height: 12)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Space accounting")
+                .accessibilityValue(accessibilitySummary)
+            legendAndChips
+        }
+    }
+
+    private var headline: String {
+        if let used = reconciliation.usedBytes {
+            let name = reconciliation.volumeName ?? "Volume"
+            return "\(name): \(ByteFormat.string(used)) used"
+        }
+        return "\(ByteFormat.string(scanned)) scanned"
+    }
+
+    private var subheadline: String {
+        var parts: [String] = []
+        parts.append(
+            "\(ByteFormat.string(scanned)) in \(compact(reconciliation.scannedItems)) items")
+        if let total = reconciliation.totalBytes {
+            parts.append("\(ByteFormat.string(total)) capacity")
+        }
+        if reconciliation.volumeChangedDuringScan {
+            parts.append("volume changed during the scan")
+        }
+        return parts.joined(separator: " \u{00B7} ")
+    }
+
+    private var bar: some View {
+        GeometryReader { geometry in
+            let gaps = CGFloat(max(segments.count - 1, 0)) * 2
+            let available = max(geometry.size.width - gaps, 1)
+            HStack(spacing: 2) {
+                ForEach(segments) { segment in
+                    RoundedRectangle(cornerRadius: 3, style: .continuous)
+                        .fill(segment.color)
+                        .frame(
+                            width: max(
+                                available * CGFloat(segment.bytes) / CGFloat(totalBytes),
+                                segment.bytes > 0 ? 3 : 0))
+                }
+            }
+        }
+    }
+
+    private var legendAndChips: some View {
+        HStack(spacing: 14) {
+            ForEach(segments) { segment in
+                HStack(spacing: 5) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(segment.color)
+                        .frame(width: 8, height: 8)
+                    Text(segment.label)
+                        .font(.caption)
+                    Text(ByteFormat.string(segment.bytes))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            chips
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private var chips: some View {
+        if let purgeable = reconciliation.purgeableBytes, purgeable > 0 {
+            chip("Purgeable \(ByteFormat.string(purgeable))", help: purgeableHelp)
+        }
+        if reconciliation.overshootBytes > 0 {
+            chip(
+                "Clones \(ByteFormat.string(reconciliation.overshootBytes)) over",
+                help:
+                    "Cloned files are counted at full size, so the scan exceeds the volume's used figure by their shared blocks."
+            )
+        } else if reconciliation.sharedBytes > 0 {
+            chip(
+                "Shared \(ByteFormat.string(reconciliation.sharedBytes))",
+                help: "Bytes shared with clones or held by snapshots.")
+        }
+        if let snapshots = reconciliation.localSnapshotCount, snapshots > 0 {
+            chip(
+                "\(snapshots) local snapshot\(snapshots == 1 ? "" : "s")",
+                help:
+                    "Time Machine local snapshots hold space the scan cannot attribute to files. macOS thins them when space is needed."
+            )
+        }
+        let counts = reconciliation.counts
+        if counts.notPermitted > 0 {
+            chipButton(
+                "\(counts.notPermitted) not permitted", tint: .orange,
+                help:
+                    "Folders macOS did not let \(AppInfo.displayName) read. Full Disk Access unlocks them.",
+                action: onGrantAccess)
+        }
+        if counts.dataVaults > 0 {
+            chip(
+                "\(counts.dataVaults) protected by macOS",
+                help: "Data vaults only Apple's own software may read; no setting changes this.")
+        }
+        if counts.accessDenied > 0 {
+            chip(
+                "\(counts.accessDenied) owned by others",
+                help:
+                    "Folders belonging to another user or to the system that your account cannot list."
+            )
+        }
+        if counts.separateVolumes > 0 {
+            chip(
+                "\(counts.separateVolumes) other volume\(counts.separateVolumes == 1 ? "" : "s")",
+                help:
+                    "Mount points inside this scope. Their contents belong to other volumes; scan them from the scope menu."
+            )
+        }
+    }
+
+    private var purgeableHelp: String {
+        "Space macOS can reclaim on its own when needed: caches, optimised originals, synced content. It overlaps the files the scan counted."
+    }
+
+    private func chip(_ text: String, help: String) -> some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(.quaternary))
+            .foregroundStyle(.secondary)
+            .help(help)
+    }
+
+    private func chipButton(
+        _ text: String, tint: Color, help: String, action: (() -> Void)?
+    ) -> some View {
+        Button(action: { action?() }) {
+            HStack(spacing: 4) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                Text(text)
+                    .font(.caption2.weight(.semibold))
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(tint.opacity(0.16)))
+            .foregroundStyle(tint)
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private func compact(_ value: UInt64) -> String {
+        DiskMapModel.compactCount(value)
+    }
+
+    private var accessibilitySummary: String {
+        segments.map { "\($0.label) \(ByteFormat.string($0.bytes))" }.joined(separator: ", ")
+    }
+}

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapTables.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapTables.swift
@@ -1,0 +1,177 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// The flat slices of a scan: Largest (files or folders) and Oldest. A SwiftUI
+/// `Table` is fine here because the rows are static and capped; the cost that
+/// pushed the Processes tab to `NSOutlineView` was re-hosting cells every tick.
+struct DiskMapSliceTable: View {
+    @ObservedObject var model: DiskMapModel
+    @State private var sortOrder: [KeyPathComparator<DiskMapRow>] = [
+        KeyPathComparator(\DiskMapRow.bytes, order: .reverse)
+    ]
+    @State private var sortedRows: [DiskMapRow] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            controls
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+            Divider()
+            if sortedRows.isEmpty {
+                emptyState
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                table
+            }
+        }
+        .onAppear { resort() }
+        .onChange(of: model.rowsRevision) { _, _ in resort() }
+        .onChange(of: sortOrder) { _, _ in resort() }
+        .onChange(of: model.viewMode) { _, mode in
+            sortOrder = [
+                mode == .oldest
+                    ? KeyPathComparator(\DiskMapRow.modified, order: .forward)
+                    : KeyPathComparator(\DiskMapRow.bytes, order: .reverse)
+            ]
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 12) {
+            switch model.viewMode {
+            case .largest:
+                Picker("Show", selection: $model.largestKind) {
+                    ForEach(DiskMapModel.LargestKind.allCases) { Text($0.rawValue).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .controlSize(.small)
+                .labelsHidden()
+                .fixedSize()
+            case .oldest:
+                Picker("Age", selection: $model.ageBand) {
+                    ForEach(DiskMapModel.AgeBand.allCases) { Text($0.label).tag($0) }
+                }
+                .controlSize(.small)
+                .fixedSize()
+                Picker("Size", selection: $model.minimumSize) {
+                    ForEach(DiskMapModel.MinimumSize.allCases) { Text($0.label).tag($0) }
+                }
+                .controlSize(.small)
+                .fixedSize()
+            }
+            Spacer()
+            if model.rowsBuilding {
+                ProgressView().controlSize(.small)
+            }
+            Text(countText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    private var countText: String {
+        let shown = sortedRows.count
+        if shown >= DiskMapModel.rowLimit { return "Top \(shown)" }
+        return shown == 1 ? "1 item" : "\(shown) items"
+    }
+
+    private var table: some View {
+        Table(sortedRows, selection: selectionBinding, sortOrder: $sortOrder) {
+            TableColumn("Name", value: \.name) { row in
+                HStack(spacing: 6) {
+                    Image(nsImage: ProcessIconProvider.shared.icon(forPath: row.path))
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                    Text(row.name.isEmpty ? row.path : row.name)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            .width(min: 160, ideal: 260)
+            TableColumn("Size", value: \.bytes) { row in
+                Text(ByteFormat.string(row.bytes))
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .width(min: 70, ideal: 84)
+            TableColumn("Share", value: \.fraction) { row in
+                Text(shareText(row.fraction))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .width(min: 50, ideal: 56)
+            TableColumn("Modified", value: \.modified) { row in
+                Text(row.modified.formatted(date: .abbreviated, time: .omitted))
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 90, ideal: 104)
+            TableColumn("Kind", value: \.kindLabel) { row in
+                Text(row.kindLabel)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .width(min: 90, ideal: 130)
+            TableColumn("Location", value: \.parentPath) { row in
+                Text(row.parentPath)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .width(min: 140, ideal: 320)
+        }
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
+        .contextMenu(forSelectionType: Int32.self) { ids in
+            if let id = ids.first, let path = model.displayPath(of: id) {
+                Button {
+                    ProcessActions.revealInFinder(path: path)
+                } label: {
+                    Label("Reveal in Finder", systemImage: "folder")
+                }
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(path, forType: .string)
+                } label: {
+                    Label("Copy Path", systemImage: "doc.on.doc")
+                }
+            }
+        } primaryAction: { ids in
+            if let id = ids.first, let path = model.displayPath(of: id) {
+                ProcessActions.revealInFinder(path: path)
+            }
+        }
+    }
+
+    private var selectionBinding: Binding<Int32?> {
+        Binding(get: { model.selection }, set: { model.select($0) })
+    }
+
+    private var emptyState: some View {
+        let title: String
+        let detail: String
+        switch model.viewMode {
+        case .largest:
+            title = model.filterText.isEmpty ? "Nothing to show" : "No matches"
+            detail =
+                model.filterText.isEmpty
+                ? "The scan found no \(model.largestKind == .files ? "files" : "folders") here."
+                : "Nothing named like \u{201C}\(model.filterText)\u{201D} in this scan."
+        case .oldest:
+            title = "Nothing that old"
+            detail =
+                "No files match \(model.ageBand.label.lowercased()) and \(model.minimumSize.label.lowercased()). Widen the filters to see more."
+        }
+        return ContentUnavailableView(title, systemImage: "tray", description: Text(detail))
+    }
+
+    private func resort() {
+        sortedRows = model.rows.sorted(using: sortOrder)
+    }
+
+    private func shareText(_ fraction: Double) -> String {
+        let percent = fraction * 100
+        if percent > 0 && percent < 0.1 { return "<0.1%" }
+        return String(format: "%.1f%%", percent)
+    }
+}

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapView.swift
@@ -1,0 +1,293 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// The Disk tab's second page: scan a volume or folder and see what is using
+/// the space. This page hosts the scope and scan controls, the reconciliation
+/// bar, the active slice (Largest, Oldest) and the detail rail. The model is
+/// shared so a scan survives switching tabs; the page merely observes it.
+struct DiskMapView: View {
+    @ObservedObject private var model = DiskMapModel.shared
+    @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var fullDiskAccess: FullDiskAccessManager
+
+    static let railWidth: CGFloat = 330
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
+            Divider()
+            Group {
+                if let snapshot = model.snapshot {
+                    ready(snapshot)
+                } else if model.isScanning {
+                    scanning
+                } else if model.isRestoring {
+                    ProgressView("Loading the last scan\u{2026}")
+                        .controlSize(.small)
+                } else {
+                    empty
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .onAppear {
+            model.bind(appState: appState, fullDiskAccess: fullDiskAccess)
+            model.appear()
+        }
+        .alert(
+            "Scan failed",
+            isPresented: Binding(
+                get: { model.lastError != nil },
+                set: { if !$0 { model.clearError() } })
+        ) {
+            Button("OK", role: .cancel) { model.clearError() }
+        } message: {
+            Text(model.lastError ?? "")
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 12) {
+            scopeMenu
+            if model.isScanning {
+                Button("Cancel") { model.cancelScan() }
+                    .controlSize(.small)
+                Group {
+                    if let fraction = model.progressFraction {
+                        ProgressView(value: fraction)
+                    } else {
+                        ProgressView()
+                    }
+                }
+                .progressViewStyle(.linear)
+                .frame(width: 140)
+                Text(model.statusText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .lineLimit(1)
+            } else {
+                Button {
+                    model.startScan()
+                } label: {
+                    Label(model.snapshot == nil ? "Scan" : "Rescan", systemImage: "arrow.clockwise")
+                }
+                .keyboardShortcut("r", modifiers: .command)
+                .help("Scan \(model.scopeTitle) again (Command-R)")
+                if let snapshot = model.snapshot {
+                    Text(scannedText(snapshot))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 12)
+            if model.snapshot != nil {
+                Picker("View", selection: $model.viewMode) {
+                    ForEach(DiskMapModel.ViewMode.allCases) { Text($0.rawValue).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .controlSize(.small)
+                .labelsHidden()
+                .fixedSize()
+                searchField
+            }
+        }
+    }
+
+    private var scopeMenu: some View {
+        Menu {
+            Button {
+                model.setScope(.startupDisk)
+            } label: {
+                Label("Macintosh HD", systemImage: "internaldrive")
+            }
+            Button {
+                model.setScope(.home)
+            } label: {
+                Label("Home", systemImage: "house")
+            }
+            Button {
+                model.setScope(.folder("/Applications"))
+            } label: {
+                Label("Applications", systemImage: "square.grid.2x2")
+            }
+            if !model.externalVolumes.isEmpty {
+                Divider()
+                ForEach(model.externalVolumes) { volume in
+                    Button {
+                        model.setScope(.volume(volume.mountPoint))
+                    } label: {
+                        Label(volume.name, systemImage: "externaldrive")
+                    }
+                }
+            }
+            Divider()
+            Button("Choose Folder\u{2026}") { model.chooseFolder() }
+        } label: {
+            Label(model.scopeTitle, systemImage: scopeSymbol)
+                .font(.headline)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .disabled(model.isScanning)
+        .help("Choose what to map")
+    }
+
+    private var scopeSymbol: String {
+        switch model.scope {
+        case .startupDisk: return "internaldrive"
+        case .home: return "house"
+        case .folder: return "folder"
+        case .volume: return "externaldrive"
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Filter by name", text: $model.filterText)
+                .textFieldStyle(.plain)
+            if !model.filterText.isEmpty {
+                Button {
+                    model.filterText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Clear")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(.quaternary.opacity(0.5))
+        )
+        .frame(width: 220)
+    }
+
+    private func scannedText(_ snapshot: DiskMapSnapshot) -> String {
+        let when = snapshot.scannedAt.formatted(.relative(presentation: .named))
+        return snapshot.partial ? "Partial scan \(when)" : "Scanned \(when)"
+    }
+
+    // MARK: - States
+
+    private func ready(_ snapshot: DiskMapSnapshot) -> some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 10) {
+                DiskMapReconciliationBar(
+                    reconciliation: snapshot.reconciliation, scope: snapshot.scope,
+                    onGrantAccess: { fullDiskAccess.openSystemSettings() })
+                if snapshot.reconciliation.counts.notPermitted > 0, !fullDiskAccess.isGranted {
+                    FullDiskAccessCard(
+                        notPermittedCount: snapshot.reconciliation.counts.notPermitted)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            Divider()
+            HStack(spacing: 0) {
+                DiskMapSliceTable(model: model)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                Divider()
+                DiskMapDetailRail(model: model)
+                    .frame(width: Self.railWidth)
+            }
+        }
+    }
+
+    private var scanning: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Scanning \(model.scopeTitle)")
+                    .font(.headline)
+                Text(model.currentPathText)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            if let preview = model.preview, !preview.children.isEmpty {
+                Text("LARGEST SO FAR")
+                    .font(.caption2.weight(.semibold))
+                    .tracking(0.6)
+                    .foregroundStyle(.tertiary)
+                let total = max(preview.bytes, 1)
+                ForEach(Array(preview.children.prefix(16).enumerated()), id: \.offset) { _, child in
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 6) {
+                            Image(systemName: child.isDirectory ? "folder" : "doc")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .frame(width: 12)
+                            Text(child.name)
+                                .font(.caption)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Text(ByteFormat.string(child.bytes))
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                        GroupProportionBar(
+                            fraction: Double(child.bytes) / Double(total), tint: DiskStyle.read)
+                    }
+                }
+                Text("Folders fill in as the scan runs.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text(model.isPreparing ? "Checking folder access" : "Reading the first folders")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .frame(maxWidth: 560, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(20)
+    }
+
+    private var empty: some View {
+        VStack(spacing: 18) {
+            Image(systemName: "internaldrive")
+                .font(.system(size: 44))
+                .foregroundStyle(.tertiary)
+            VStack(spacing: 6) {
+                Text("Map \(model.scopeTitle)")
+                    .font(.title3.weight(.semibold))
+                Text(
+                    "Scan to see what is using the space, largest first, with a way to act on each item."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            }
+            if !fullDiskAccess.isGranted, model.scope == .startupDisk || model.scope == .home {
+                FullDiskAccessCard(onScanAnyway: { model.startScan() })
+                    .frame(maxWidth: 520)
+            } else {
+                Button {
+                    model.startScan()
+                } label: {
+                    Label("Scan \(model.scopeTitle)", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+            }
+        }
+        .padding(40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Sources/MacPerfMonitor/Views/DiskMap/FullDiskAccessCard.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/FullDiskAccessCard.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// The in-context request for Full Disk Access, in the app's advisory
+/// language (the Settings `WarningBanner` recipe). Shown on the Disk Map's
+/// empty state before a first scan and, compactly, above a scan that ran
+/// without the grant. Never a modal: the ask is made where it matters.
+struct FullDiskAccessCard: View {
+    @EnvironmentObject private var fullDiskAccess: FullDiskAccessManager
+    /// Folders the last scan could not read because of the missing grant.
+    var notPermittedCount: Int = 0
+    var onScanAnyway: (() -> Void)?
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "lock.shield")
+                .font(.title2)
+                .foregroundStyle(.orange)
+                .frame(width: 26)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(explanation)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 8) {
+                    if fullDiskAccess.awaitingRelaunch {
+                        Button("Relaunch \(AppInfo.displayName)") { fullDiskAccess.relaunch() }
+                            .buttonStyle(.borderedProminent)
+                        Button("Open Privacy Settings") { fullDiskAccess.openSystemSettings() }
+                    } else {
+                        Button("Open Privacy Settings") { fullDiskAccess.openSystemSettings() }
+                            .buttonStyle(.borderedProminent)
+                    }
+                    if let onScanAnyway {
+                        Button("Scan Anyway", action: onScanAnyway)
+                    }
+                }
+                .controlSize(.small)
+                .padding(.top, 2)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 12))
+        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Color.orange.opacity(0.28)))
+    }
+
+    private var title: String {
+        if notPermittedCount > 0 {
+            let folders = notPermittedCount == 1 ? "1 folder" : "\(notPermittedCount) folders"
+            return "\(folders) could not be read without Full Disk Access"
+        }
+        return "Grant Full Disk Access for a complete map"
+    }
+
+    private var explanation: String {
+        if fullDiskAccess.awaitingRelaunch {
+            return
+                "If you turned Full Disk Access on, it takes effect once \(AppInfo.displayName) relaunches. Then scan again."
+        }
+        return
+            "Without it macOS asks about Desktop, Documents and Downloads one at a time, and Mail, Messages, Safari, Photos internals, iOS backups, Time Machine and the Trash stay hidden. The grant takes effect after \(AppInfo.displayName) relaunches."
+    }
+}

--- a/Sources/MacPerfMonitor/Views/DiskUsageView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskUsageView.swift
@@ -20,6 +20,16 @@ struct DiskUsageView: View {
     @State private var loadedRange: HistoryWindow?
     @State private var topDiskConsumers: [ProcessConsumer] = []
 
+    /// The tab's two pages. Remembered across launches: someone who came for
+    /// the Disk Map keeps landing on it.
+    enum SubPage: String, CaseIterable, Identifiable {
+        case overview = "Overview"
+        case map = "Disk Map"
+        var id: String { rawValue }
+    }
+
+    @AppStorage("diskSubPage") private var subPage: SubPage = .overview
+
     private var awaitingData: Bool { loadedRange != range }
 
     private var chartDomain: ClosedRange<Date>? {
@@ -27,6 +37,41 @@ struct DiskUsageView: View {
     }
 
     var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Picker("Page", selection: $subPage) {
+                    ForEach(SubPage.allCases) { Text($0.rawValue).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .fixedSize()
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+            Divider()
+            switch subPage {
+            case .overview: overview
+            case .map: DiskMapView()
+            }
+        }
+        .onAppear { consumeDiskMapRequest() }
+        .onChange(of: appState.showDiskMap) { _, requested in
+            if requested { consumeDiskMapRequest() }
+        }
+    }
+
+    /// A menu command asked for the Disk Map; the same observe-then-clear
+    /// idiom as the Network Scan request.
+    private func consumeDiskMapRequest() {
+        guard appState.showDiskMap else { return }
+        subPage = .map
+        appState.showDiskMap = false
+    }
+
+    /// The original Disk page. Its slow-cadence detail model runs only while
+    /// this page is the one showing.
+    private var overview: some View {
         ScrollView {
             MainRailLayout {
                 pageHeader

--- a/Sources/MacPerfMonitor/Views/SettingsView.swift
+++ b/Sources/MacPerfMonitor/Views/SettingsView.swift
@@ -379,6 +379,7 @@ private struct AlertsSettingsView: View {
 /// helper) and the on-disk storage cap.
 private struct AdvancedSettingsView: View {
     @EnvironmentObject private var helper: HelperManager
+    @EnvironmentObject private var fullDiskAccess: FullDiskAccessManager
     @EnvironmentObject private var model: SamplerModel
 
     /// The database size cap in MB, read by the retention pass (same key).
@@ -440,6 +441,24 @@ private struct AdvancedSettingsView: View {
             } footer: {
                 Text(
                     "\(AppInfo.displayName) can install a small privileged helper so it can read the memory of system and other-user processes (such as WindowServer) that it otherwise cannot see. The helper runs only to read memory statistics and sends nothing off your Mac."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Section {
+                caption(fullDiskAccessStatus)
+                HStack(spacing: 8) {
+                    Button("Open System Settings\u{2026}") { fullDiskAccess.openSystemSettings() }
+                    if fullDiskAccess.awaitingRelaunch {
+                        Button("Relaunch \(AppInfo.displayName)") { fullDiskAccess.relaunch() }
+                    }
+                }
+            } header: {
+                Text("Disk Map Access")
+            } footer: {
+                Text(
+                    "The Disk Map scans your disk to show what is using space. With Full Disk Access it can see Mail, Messages, Safari, Time Machine and other apps' data; without it those stay hidden and macOS asks about Desktop, Documents and Downloads separately. The grant takes effect after \(AppInfo.displayName) relaunches."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -561,6 +580,20 @@ private struct AdvancedSettingsView: View {
             return "Waiting for your approval in System Settings \u{203A} Login Items."
         case .enabled:
             return "On. \(AppInfo.displayName) can read every process, including system processes."
+        }
+    }
+
+    /// A plain-language description of the Full Disk Access state.
+    private var fullDiskAccessStatus: String {
+        switch fullDiskAccess.status {
+        case .granted:
+            return "On. The Disk Map can read every folder your account owns."
+        case .notGranted:
+            return fullDiskAccess.awaitingRelaunch
+                ? "Waiting for a relaunch. If you turned it on, relaunch to apply it."
+                : "Off. Some folders will be missing from the Disk Map."
+        case .unknown:
+            return "Could not be determined on this account."
         }
     }
 

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapItemFacts.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapItemFacts.swift
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+
+import Darwin
+import Foundation
+
+/// Facts about one item read on demand with a single `getattrlist`, for the
+/// detail rail: the logical length (shown when it differs from the allocated
+/// size), and `ATTR_CMNEXT_PRIVATESIZE`, the bytes that would actually be
+/// freed if the item were deleted, which the scan itself does not fetch
+/// because it cost half again the scan time over millions of entries.
+public struct DiskMapItemFacts: Sendable, Equatable {
+    public var allocatedBytes: UInt64
+    public var logicalBytes: UInt64
+    /// Nil when the filesystem does not report it (non-APFS volumes).
+    public var privateBytes: UInt64?
+    public var linkCount: UInt32
+    public var mayShareBlocks: Bool
+    public var cloneID: UInt64?
+    public var isDirectory: Bool
+
+    /// What deleting this item frees right now: the private size when known,
+    /// else the allocated size.
+    public var wouldFreeBytes: UInt64 { privateBytes ?? allocatedBytes }
+
+    /// Bytes held in common with a clone or a snapshot.
+    public var sharedBytes: UInt64 {
+        guard let privateBytes, privateBytes < allocatedBytes else { return 0 }
+        return allocatedBytes - privateBytes
+    }
+
+    public static func read(path: String) -> DiskMapItemFacts? {
+        var request = attrlist()
+        request.bitmapcount = u_short(ATTR_BIT_MAP_COUNT)
+        request.commonattr = attrgroup_t(ATTR_CMN_RETURNED_ATTRS) | attrgroup_t(ATTR_CMN_OBJTYPE)
+        request.fileattr =
+            attrgroup_t(ATTR_FILE_LINKCOUNT) | attrgroup_t(ATTR_FILE_ALLOCSIZE)
+            | attrgroup_t(ATTR_FILE_DATALENGTH)
+        request.forkattr =
+            attrgroup_t(ATTR_CMNEXT_PRIVATESIZE) | attrgroup_t(ATTR_CMNEXT_CLONEID)
+            | attrgroup_t(ATTR_CMNEXT_EXT_FLAGS)
+        let options = UInt32(FSOPT_NOFOLLOW) | UInt32(FSOPT_ATTR_CMN_EXTENDED)
+        var buffer = [UInt8](repeating: 0, count: 128)
+        let status = buffer.withUnsafeMutableBytes { raw in
+            getattrlist(path, &request, raw.baseAddress, raw.count, options)
+        }
+        guard status == 0 else { return nil }
+
+        return buffer.withUnsafeBytes { raw -> DiskMapItemFacts? in
+            let base = raw.baseAddress!
+            let length = Int(base.loadUnaligned(as: UInt32.self))
+            guard length >= 24, length <= buffer.count else { return nil }
+            var field = base + 4
+            let commonReturned = field.loadUnaligned(as: UInt32.self)
+            let fileReturned = (field + 12).loadUnaligned(as: UInt32.self)
+            let forkReturned = (field + 16).loadUnaligned(as: UInt32.self)
+            field += 20
+
+            var isDirectory = false
+            if commonReturned & UInt32(ATTR_CMN_OBJTYPE) != 0 {
+                isDirectory = field.loadUnaligned(as: UInt32.self) == UInt32(VDIR.rawValue)
+                field += 4
+            }
+            var linkCount: UInt32 = 1
+            if fileReturned & UInt32(ATTR_FILE_LINKCOUNT) != 0 {
+                linkCount = field.loadUnaligned(as: UInt32.self)
+                field += 4
+            }
+            var allocated: UInt64 = 0
+            if fileReturned & UInt32(ATTR_FILE_ALLOCSIZE) != 0 {
+                allocated = UInt64(max(0, field.loadUnaligned(as: Int64.self)))
+                field += 8
+            }
+            var logical: UInt64 = 0
+            if fileReturned & UInt32(ATTR_FILE_DATALENGTH) != 0 {
+                logical = UInt64(max(0, field.loadUnaligned(as: Int64.self)))
+                field += 8
+            }
+            var privateBytes: UInt64?
+            if forkReturned & UInt32(ATTR_CMNEXT_PRIVATESIZE) != 0 {
+                privateBytes = UInt64(max(0, field.loadUnaligned(as: Int64.self)))
+                field += 8
+            }
+            var cloneID: UInt64?
+            if forkReturned & UInt32(ATTR_CMNEXT_CLONEID) != 0 {
+                cloneID = field.loadUnaligned(as: UInt64.self)
+                field += 8
+            }
+            var mayShareBlocks = false
+            if forkReturned & UInt32(ATTR_CMNEXT_EXT_FLAGS) != 0 {
+                let flags = field.loadUnaligned(as: UInt64.self)
+                mayShareBlocks = flags & UInt64(EF_MAY_SHARE_BLOCKS) != 0
+                field += 8
+            }
+            return DiskMapItemFacts(
+                allocatedBytes: allocated, logicalBytes: logical, privateBytes: privateBytes,
+                linkCount: linkCount, mayShareBlocks: mayShareBlocks, cloneID: cloneID,
+                isDirectory: isDirectory)
+        }
+    }
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapReconciliation.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapReconciliation.swift
@@ -5,7 +5,7 @@ import os
 
 /// Tallies the scanner keeps as it goes. Published in progress events and
 /// frozen into the reconciliation at the end.
-public struct DiskMapScanCounts: Sendable, Equatable {
+public struct DiskMapScanCounts: Sendable, Equatable, Codable {
     /// Every entry read from a listing, whatever became of it.
     public var entries: UInt64 = 0
     /// Directories listed successfully.
@@ -50,7 +50,7 @@ public struct DiskMapScanCounts: Sendable, Equatable {
 /// A sibling volume of the scanned one that shares its container: the sealed
 /// System volume, Preboot, VM, Update. Not scannable, not removable, but part
 /// of what Finder calls "Macintosh HD used".
-public struct DiskMapSystemVolume: Sendable, Equatable, Identifiable {
+public struct DiskMapSystemVolume: Sendable, Equatable, Identifiable, Codable {
     public var id: String { mountPoint }
     public var mountPoint: String
     public var name: String
@@ -63,7 +63,7 @@ public struct DiskMapSystemVolume: Sendable, Equatable, Identifiable {
 /// overlay (it overlaps files the scan counted as well as snapshot space it
 /// did not), shared blocks come straight from the tree, and the overshoot case
 /// (scanned exceeds used, which clones cause) is reported rather than hidden.
-public struct DiskMapReconciliation: Sendable, Equatable {
+public struct DiskMapReconciliation: Sendable, Equatable, Codable {
     public var volumeMountPoint: String
     public var volumeName: String?
     public var totalBytes: UInt64?

--- a/Sources/MacPerfMonitorCore/Models/VolumeInfo.swift
+++ b/Sources/MacPerfMonitorCore/Models/VolumeInfo.swift
@@ -13,7 +13,7 @@ public struct VolumeSnapshot: Sendable, Equatable {
 /// The role a volume plays inside its APFS container, mapped from the
 /// IORegistry role strings with a well-known mount point fallback for non-APFS
 /// or unmatched volumes.
-public enum VolumeRole: String, Sendable, Equatable {
+public enum VolumeRole: String, Sendable, Equatable, Codable {
     case system
     case data
     case preboot

--- a/Sources/MacPerfMonitorCore/Persistence/DiskMapSnapshotCodec.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/DiskMapSnapshotCodec.swift
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: MIT
+
+import Compression
+import Foundation
+
+public enum DiskMapSnapshotError: Error, LocalizedError, Equatable {
+    case notASnapshot
+    case unsupportedVersion(UInt8)
+    case corrupt
+    case tooLarge
+
+    public var errorDescription: String? {
+        switch self {
+        case .notASnapshot: return "This file is not a Disk Map snapshot."
+        case .unsupportedVersion(let v):
+            return "This snapshot uses a newer format (v\(v)). Update the app to open it."
+        case .corrupt: return "This snapshot is damaged and could not be read."
+        case .tooLarge: return "This snapshot is too large to open safely."
+        }
+    }
+}
+
+/// Reads and writes the `.mpmdisk` container that keeps the last scan between
+/// launches, so the Disk Map opens instantly instead of rescanning three
+/// million files.
+///
+/// Layout: a fixed 8-byte header (magic `MPMD`, container version, algorithm,
+/// two reserved bytes) then an LZFSE payload. The payload is the arena's raw
+/// little-endian arrays plus the name buffer, with the small structured parts
+/// (scope, reconciliation) as JSON: a million nodes decode in the time it
+/// takes to memcpy them, which JSON could never do. Every length is checked
+/// against a cap before allocation and the decoded tree must pass
+/// `FileTree.isStructurallyValid`, so a corrupt or hostile file cannot crash
+/// a later walk.
+public enum DiskMapSnapshotCodec {
+    public static let fileExtension = "mpmdisk"
+
+    /// "MPMD": Mac Performance Monitor Disk map.
+    private static let magic: [UInt8] = [0x4D, 0x50, 0x4D, 0x44]
+    private static let containerVersion: UInt8 = 1
+    private static let payloadVersion: UInt32 = 1
+    private static let headerLength = 8
+    private static let algorithmLZFSE: UInt8 = 1
+    public static let maximumContainerBytes = 512 * 1024 * 1024
+    public static let maximumPayloadBytes = 1536 * 1024 * 1024
+    public static let maximumNodeCount = 16_000_000
+    public static let maximumNameBytes = 768 * 1024 * 1024
+    private static let maximumJSONBytes = 4 * 1024 * 1024
+    private static let decompressionChunkBytes = 256 * 1024
+
+    // MARK: Encoding
+
+    public static func encode(_ snapshot: DiskMapSnapshot) throws -> Data {
+        let tree = snapshot.tree
+        guard tree.nodeCount <= maximumNodeCount, tree.nameBytes.count <= maximumNameBytes else {
+            throw DiskMapSnapshotError.tooLarge
+        }
+        var writer = PayloadWriter()
+        writer.append(payloadVersion)
+        let encoder = JSONEncoder()
+        writer.appendBlob(try encoder.encode(snapshot.scope))
+        writer.appendBlob(Data(snapshot.rootPath.utf8))
+        writer.append(snapshot.scannedAt.timeIntervalSince1970.bitPattern)
+        writer.append(snapshot.duration.bitPattern)
+        writer.append(UInt8(snapshot.partial ? 1 : 0))
+        writer.append(snapshot.smallFileThreshold)
+        writer.append(UInt32(clamping: snapshot.revision))
+        writer.appendBlob(try encoder.encode(snapshot.reconciliation))
+
+        writer.append(UInt32(tree.nodeCount))
+        writer.appendArray(tree.parent)
+        writer.appendArray(tree.firstChild)
+        writer.appendArray(tree.childCount)
+        writer.appendArray(tree.bytes)
+        writer.appendArray(tree.shared)
+        writer.appendArray(tree.fileID)
+        writer.appendArray(tree.modified)
+        writer.appendArray(tree.count)
+        writer.appendArray(tree.flags.map(\.rawValue))
+        writer.appendArray(tree.kind.map(\.rawValue))
+        writer.appendArray(tree.nameOffsets)
+        writer.append(UInt32(tree.nameBytes.count))
+        writer.appendArray(tree.nameBytes)
+
+        guard writer.data.count <= maximumPayloadBytes else { throw DiskMapSnapshotError.tooLarge }
+        let compressed = try (writer.data as NSData).compressed(using: .lzfse) as Data
+        guard compressed.count <= maximumContainerBytes - headerLength else {
+            throw DiskMapSnapshotError.tooLarge
+        }
+        var out = Data(capacity: headerLength + compressed.count)
+        out.append(contentsOf: magic)
+        out.append(containerVersion)
+        out.append(algorithmLZFSE)
+        out.append(contentsOf: [0, 0])
+        out.append(compressed)
+        return out
+    }
+
+    /// Write atomically with owner-only permissions: the file is an index of
+    /// paths the user may have granted Full Disk Access to read.
+    public static func write(_ snapshot: DiskMapSnapshot, to url: URL) throws {
+        let data = try encode(snapshot)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    // MARK: Decoding
+
+    public static func decode(contentsOf url: URL) throws -> DiskMapSnapshot {
+        if let size = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+            size > maximumContainerBytes
+        {
+            throw DiskMapSnapshotError.tooLarge
+        }
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: maximumContainerBytes + 1) ?? Data()
+        guard data.count <= maximumContainerBytes else { throw DiskMapSnapshotError.tooLarge }
+        return try decode(data)
+    }
+
+    public static func decode(_ data: Data) throws -> DiskMapSnapshot {
+        guard data.count > headerLength else { throw DiskMapSnapshotError.notASnapshot }
+        guard data.count <= maximumContainerBytes else { throw DiskMapSnapshotError.tooLarge }
+        let header = [UInt8](data.prefix(headerLength))
+        guard Array(header[0..<4]) == magic else { throw DiskMapSnapshotError.notASnapshot }
+        guard header[4] == containerVersion else {
+            throw DiskMapSnapshotError.unsupportedVersion(header[4])
+        }
+        guard header[5] == algorithmLZFSE, header[6] == 0, header[7] == 0 else {
+            throw DiskMapSnapshotError.corrupt
+        }
+        let compressed = data.subdata(
+            in: data.startIndex.advanced(by: headerLength)..<data.endIndex)
+        let payload = try decompress(compressed, maximumOutputSize: maximumPayloadBytes)
+
+        var reader = PayloadReader(data: payload)
+        guard try reader.read(UInt32.self) == payloadVersion else {
+            throw DiskMapSnapshotError.corrupt
+        }
+        let decoder = JSONDecoder()
+        let scope: DiskMapScope
+        do {
+            scope = try decoder.decode(
+                DiskMapScope.self, from: try reader.readBlob(maximumJSONBytes))
+        } catch {
+            throw DiskMapSnapshotError.corrupt
+        }
+        let rootPath = String(decoding: try reader.readBlob(64 * 1024), as: UTF8.self)
+        let scannedAt = Date(
+            timeIntervalSince1970: Double(bitPattern: try reader.read(UInt64.self)))
+        let duration = Double(bitPattern: try reader.read(UInt64.self))
+        let partial = try reader.read(UInt8.self) != 0
+        let threshold = try reader.read(UInt64.self)
+        let revision = Int(try reader.read(UInt32.self))
+        let reconciliation: DiskMapReconciliation
+        do {
+            reconciliation = try decoder.decode(
+                DiskMapReconciliation.self, from: try reader.readBlob(maximumJSONBytes))
+        } catch {
+            throw DiskMapSnapshotError.corrupt
+        }
+        guard scannedAt.timeIntervalSince1970.isFinite, duration.isFinite, duration >= 0 else {
+            throw DiskMapSnapshotError.corrupt
+        }
+
+        let nodeCount = Int(try reader.read(UInt32.self))
+        guard nodeCount <= maximumNodeCount else { throw DiskMapSnapshotError.tooLarge }
+        let parent: [Int32] = try reader.readArray(count: nodeCount)
+        let firstChild: [Int32] = try reader.readArray(count: nodeCount)
+        let childCount: [Int32] = try reader.readArray(count: nodeCount)
+        let bytes: [UInt64] = try reader.readArray(count: nodeCount)
+        let shared: [UInt64] = try reader.readArray(count: nodeCount)
+        let fileID: [UInt64] = try reader.readArray(count: nodeCount)
+        let modified: [UInt32] = try reader.readArray(count: nodeCount)
+        let count: [UInt32] = try reader.readArray(count: nodeCount)
+        let rawFlags: [UInt16] = try reader.readArray(count: nodeCount)
+        let rawKinds: [UInt8] = try reader.readArray(count: nodeCount)
+        let nameOffsets: [UInt32] = try reader.readArray(count: nodeCount + 1)
+        let nameBytesCount = Int(try reader.read(UInt32.self))
+        guard nameBytesCount <= maximumNameBytes else { throw DiskMapSnapshotError.tooLarge }
+        let nameBytes: [UInt8] = try reader.readArray(count: nameBytesCount)
+        guard reader.isAtEnd else { throw DiskMapSnapshotError.corrupt }
+
+        let tree = FileTree(
+            parent: parent, firstChild: firstChild, childCount: childCount, bytes: bytes,
+            shared: shared, fileID: fileID, modified: modified, count: count,
+            flags: rawFlags.map(FileNodeFlags.init(rawValue:)),
+            kind: rawKinds.map { FileKind(rawValue: $0) ?? .other },
+            nameOffsets: nameOffsets, nameBytes: nameBytes)
+        guard tree.isStructurallyValid else { throw DiskMapSnapshotError.corrupt }
+
+        return DiskMapSnapshot(
+            scope: scope, rootPath: rootPath, tree: tree, reconciliation: reconciliation,
+            scannedAt: scannedAt, duration: duration, partial: partial,
+            smallFileThreshold: threshold, revision: max(1, revision))
+    }
+
+    // MARK: - Payload helpers
+
+    private struct PayloadWriter {
+        var data = Data()
+
+        mutating func append<T: FixedWidthInteger>(_ value: T) {
+            var little = value.littleEndian
+            withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
+        }
+
+        mutating func appendBlob(_ blob: Data) {
+            append(UInt32(blob.count))
+            data.append(blob)
+        }
+
+        mutating func appendArray<T: FixedWidthInteger>(_ array: [T]) {
+            array.withUnsafeBytes { data.append(contentsOf: $0) }
+        }
+    }
+
+    private struct PayloadReader {
+        let data: Data
+        var offset = 0
+
+        init(data: Data) {
+            self.data = data
+        }
+
+        var isAtEnd: Bool { offset == data.count }
+
+        mutating func read<T: FixedWidthInteger>(_ type: T.Type) throws -> T {
+            let size = MemoryLayout<T>.size
+            guard offset + size <= data.count else { throw DiskMapSnapshotError.corrupt }
+            var value: T = 0
+            withUnsafeMutableBytes(of: &value) { target in
+                data.copyBytes(
+                    to: target, from: (data.startIndex + offset)..<(data.startIndex + offset + size)
+                )
+            }
+            offset += size
+            return T(littleEndian: value)
+        }
+
+        mutating func readBlob(_ maximum: Int) throws -> Data {
+            let length = Int(try read(UInt32.self))
+            guard length <= maximum, offset + length <= data.count else {
+                throw DiskMapSnapshotError.corrupt
+            }
+            let start = data.startIndex + offset
+            let blob = data.subdata(in: start..<(start + length))
+            offset += length
+            return blob
+        }
+
+        mutating func readArray<T: FixedWidthInteger>(count: Int) throws -> [T] {
+            let size = MemoryLayout<T>.size
+            guard count >= 0, count <= Int.max / max(size, 1), offset + count * size <= data.count
+            else { throw DiskMapSnapshotError.corrupt }
+            let start = data.startIndex + offset
+            let end = start + count * size
+            let array = [T](unsafeUninitializedCapacity: count) { buffer, initialized in
+                data.copyBytes(to: UnsafeMutableRawBufferPointer(buffer), from: start..<end)
+                initialized = count
+            }
+            offset += count * size
+            return array
+        }
+    }
+
+    /// Bounded LZFSE decompression: output is capped so a crafted file cannot
+    /// balloon memory, and a truncated stream is rejected rather than trusted.
+    static func decompress(_ data: Data, maximumOutputSize: Int) throws -> Data {
+        guard maximumOutputSize > 0, !data.isEmpty else { throw DiskMapSnapshotError.corrupt }
+        let destination = UnsafeMutablePointer<UInt8>.allocate(capacity: decompressionChunkBytes)
+        defer { destination.deallocate() }
+        return try data.withUnsafeBytes { sourceBytes -> Data in
+            guard let source = sourceBytes.bindMemory(to: UInt8.self).baseAddress else {
+                throw DiskMapSnapshotError.corrupt
+            }
+            var stream = compression_stream(
+                dst_ptr: destination, dst_size: decompressionChunkBytes, src_ptr: source,
+                src_size: sourceBytes.count, state: nil)
+            guard
+                compression_stream_init(&stream, COMPRESSION_STREAM_DECODE, COMPRESSION_LZFSE)
+                    != COMPRESSION_STATUS_ERROR
+            else { throw DiskMapSnapshotError.corrupt }
+            defer { compression_stream_destroy(&stream) }
+            stream.src_ptr = source
+            stream.src_size = sourceBytes.count
+
+            var output = Data()
+            output.reserveCapacity(
+                min(maximumOutputSize, max(decompressionChunkBytes, data.count * 3)))
+            while true {
+                let sourceBefore = stream.src_size
+                stream.dst_ptr = destination
+                stream.dst_size = decompressionChunkBytes
+                let status = compression_stream_process(
+                    &stream, Int32(COMPRESSION_STREAM_FINALIZE.rawValue))
+                let produced = decompressionChunkBytes - stream.dst_size
+                guard produced <= maximumOutputSize - output.count else {
+                    throw DiskMapSnapshotError.tooLarge
+                }
+                output.append(destination, count: produced)
+                switch status {
+                case COMPRESSION_STATUS_END:
+                    guard stream.src_size == 0 else { throw DiskMapSnapshotError.corrupt }
+                    return output
+                case COMPRESSION_STATUS_OK:
+                    guard produced > 0 || stream.src_size < sourceBefore else {
+                        throw DiskMapSnapshotError.corrupt
+                    }
+                default:
+                    throw DiskMapSnapshotError.corrupt
+                }
+            }
+        }
+    }
+}
+
+/// Where snapshots live and how they roll over: one file per scope under the
+/// app's Application Support directory (beside the history database), the
+/// previous scan kept as `.prev` for the changed-since-last-scan view.
+public enum DiskMapSnapshotStore {
+    public static func directory() -> URL {
+        MacPerfMonitorDatabase.defaultURL().deletingLastPathComponent()
+            .appendingPathComponent("diskmap", isDirectory: true)
+    }
+
+    public static func url(
+        for scope: DiskMapScope, previous: Bool = false, in directory: URL = directory()
+    ) -> URL {
+        directory.appendingPathComponent(
+            scope.id + (previous ? ".prev." : ".") + DiskMapSnapshotCodec.fileExtension)
+    }
+
+    /// Persist a completed scan, rolling the existing file to `.prev`.
+    public static func save(_ snapshot: DiskMapSnapshot, in directory: URL = directory()) throws {
+        let current = url(for: snapshot.scope, in: directory)
+        let previous = url(for: snapshot.scope, previous: true, in: directory)
+        let fm = FileManager.default
+        if fm.fileExists(atPath: current.path) {
+            try? fm.removeItem(at: previous)
+            try? fm.moveItem(at: current, to: previous)
+        }
+        try DiskMapSnapshotCodec.write(snapshot, to: current)
+    }
+
+    public static func load(
+        for scope: DiskMapScope, previous: Bool = false, in directory: URL = directory()
+    ) throws -> DiskMapSnapshot? {
+        let file = url(for: scope, previous: previous, in: directory)
+        guard FileManager.default.fileExists(atPath: file.path) else { return nil }
+        return try DiskMapSnapshotCodec.decode(contentsOf: file)
+    }
+
+    public static func remove(for scope: DiskMapScope, in directory: URL = directory()) {
+        try? FileManager.default.removeItem(at: url(for: scope, in: directory))
+        try? FileManager.default.removeItem(at: url(for: scope, previous: true, in: directory))
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/DiskMapSnapshotCodecTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskMapSnapshotCodecTests.swift
@@ -1,0 +1,193 @@
+import Darwin
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class DiskMapSnapshotCodecTests: XCTestCase {
+    private var root: URL!
+    private var storeDirectory: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiskMapCodecTests-\(UUID().uuidString)", isDirectory: true)
+        storeDirectory = root.appendingPathComponent("store", isDirectory: true)
+        let tree = root.appendingPathComponent("tree/a/b", isDirectory: true)
+        try FileManager.default.createDirectory(at: tree, withIntermediateDirectories: true)
+        try Data(repeating: 1, count: 70_000).write(to: tree.appendingPathComponent("big.mov"))
+        for i in 0..<30 {
+            try Data(repeating: 2, count: 10 + i).write(
+                to: tree.appendingPathComponent("s\(i).txt"))
+        }
+        try Data(repeating: 3, count: 5_000).write(
+            to: root.appendingPathComponent("tree/日本語.jpg"))
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func scan(threshold: UInt64 = 16_384) throws -> DiskMapSnapshot {
+        try DiskMapScanner().scanBlocking(
+            .folder(root.appendingPathComponent("tree").path),
+            options: DiskMapScanOptions(
+                smallFileThreshold: threshold, workerCount: 2, previewInterval: 10,
+                countLocalSnapshots: false))
+    }
+
+    func testRoundTripPreservesEverything() throws {
+        let original = try scan()
+        let data = try DiskMapSnapshotCodec.encode(original)
+        XCTAssertEqual(Array(data.prefix(4)), [0x4D, 0x50, 0x4D, 0x44])
+        let decoded = try DiskMapSnapshotCodec.decode(data)
+
+        XCTAssertEqual(decoded.scope, original.scope)
+        XCTAssertEqual(decoded.rootPath, original.rootPath)
+        XCTAssertEqual(
+            decoded.scannedAt.timeIntervalSince1970, original.scannedAt.timeIntervalSince1970,
+            accuracy: 0.000_001)
+        XCTAssertEqual(decoded.duration, original.duration)
+        XCTAssertEqual(decoded.partial, original.partial)
+        XCTAssertEqual(decoded.smallFileThreshold, original.smallFileThreshold)
+        XCTAssertEqual(decoded.revision, original.revision)
+        XCTAssertEqual(decoded.reconciliation, original.reconciliation)
+
+        let a = original.tree
+        let b = decoded.tree
+        XCTAssertEqual(b.nodeCount, a.nodeCount)
+        XCTAssertEqual(b.parent, a.parent)
+        XCTAssertEqual(b.firstChild, a.firstChild)
+        XCTAssertEqual(b.childCount, a.childCount)
+        XCTAssertEqual(b.bytes, a.bytes)
+        XCTAssertEqual(b.shared, a.shared)
+        XCTAssertEqual(b.fileID, a.fileID)
+        XCTAssertEqual(b.modified, a.modified)
+        XCTAssertEqual(b.count, a.count)
+        XCTAssertEqual(b.flags, a.flags)
+        XCTAssertEqual(b.kind, a.kind)
+        XCTAssertEqual(b.nameOffsets, a.nameOffsets)
+        XCTAssertEqual(b.nameBytes, a.nameBytes)
+        XCTAssertTrue(b.isStructurallyValid)
+        XCTAssertTrue(b.flags.contains { $0.contains(.smallFilesFold) }, "the fold survived")
+        XCTAssertEqual(decoded.displayPath(of: 1), original.displayPath(of: 1))
+    }
+
+    func testHeaderAndPayloadCorruptionIsRejected() throws {
+        let data = try DiskMapSnapshotCodec.encode(try scan())
+
+        XCTAssertThrowsError(try DiskMapSnapshotCodec.decode(Data([1, 2, 3]))) { error in
+            XCTAssertEqual(error as? DiskMapSnapshotError, .notASnapshot)
+        }
+        var wrongMagic = data
+        wrongMagic[0] = 0x58
+        XCTAssertThrowsError(try DiskMapSnapshotCodec.decode(wrongMagic)) { error in
+            XCTAssertEqual(error as? DiskMapSnapshotError, .notASnapshot)
+        }
+        var newerVersion = data
+        newerVersion[4] = 9
+        XCTAssertThrowsError(try DiskMapSnapshotCodec.decode(newerVersion)) { error in
+            XCTAssertEqual(error as? DiskMapSnapshotError, .unsupportedVersion(9))
+        }
+        let truncated = data.prefix(data.count / 2)
+        XCTAssertThrowsError(try DiskMapSnapshotCodec.decode(Data(truncated))) { error in
+            XCTAssertEqual(error as? DiskMapSnapshotError, .corrupt)
+        }
+        var badReserved = data
+        badReserved[6] = 1
+        XCTAssertThrowsError(try DiskMapSnapshotCodec.decode(badReserved)) { error in
+            XCTAssertEqual(error as? DiskMapSnapshotError, .corrupt)
+        }
+    }
+
+    func testStructurallyInvalidTreesNeverComeBack() throws {
+        var snapshot = try scan()
+        // A parent index pointing forward is the classic corrupt-file shape.
+        var parent = snapshot.tree.parent
+        parent[1] = Int32(snapshot.tree.nodeCount - 1)
+        snapshot = DiskMapSnapshot(
+            scope: snapshot.scope, rootPath: snapshot.rootPath,
+            tree: FileTree(
+                parent: parent, firstChild: snapshot.tree.firstChild,
+                childCount: snapshot.tree.childCount, bytes: snapshot.tree.bytes,
+                shared: snapshot.tree.shared, fileID: snapshot.tree.fileID,
+                modified: snapshot.tree.modified, count: snapshot.tree.count,
+                flags: snapshot.tree.flags, kind: snapshot.tree.kind,
+                nameOffsets: snapshot.tree.nameOffsets, nameBytes: snapshot.tree.nameBytes),
+            reconciliation: snapshot.reconciliation, scannedAt: snapshot.scannedAt,
+            duration: snapshot.duration, partial: false, smallFileThreshold: 0, revision: 1)
+        let data = try DiskMapSnapshotCodec.encode(snapshot)
+        XCTAssertThrowsError(try DiskMapSnapshotCodec.decode(data)) { error in
+            XCTAssertEqual(error as? DiskMapSnapshotError, .corrupt)
+        }
+    }
+
+    func testStoreSavesLoadsAndRollsOver() throws {
+        let scope = DiskMapScope.folder(root.appendingPathComponent("tree").path)
+        XCTAssertNil(try DiskMapSnapshotStore.load(for: scope, in: storeDirectory))
+
+        let first = try scan(threshold: 0)
+        try DiskMapSnapshotStore.save(first, in: storeDirectory)
+        let file = DiskMapSnapshotStore.url(for: scope, in: storeDirectory)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+        let permissions =
+            try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions] as? Int
+        XCTAssertEqual(permissions, 0o600)
+        let loaded = try XCTUnwrap(try DiskMapSnapshotStore.load(for: scope, in: storeDirectory))
+        XCTAssertEqual(loaded.tree.nodeCount, first.tree.nodeCount)
+        XCTAssertNil(try DiskMapSnapshotStore.load(for: scope, previous: true, in: storeDirectory))
+
+        let second = try scan(threshold: 16_384)
+        try DiskMapSnapshotStore.save(second, in: storeDirectory)
+        let previous = try XCTUnwrap(
+            try DiskMapSnapshotStore.load(for: scope, previous: true, in: storeDirectory))
+        XCTAssertEqual(previous.tree.nodeCount, first.tree.nodeCount, "the old scan rolled over")
+        let current = try XCTUnwrap(try DiskMapSnapshotStore.load(for: scope, in: storeDirectory))
+        XCTAssertEqual(current.tree.nodeCount, second.tree.nodeCount)
+
+        DiskMapSnapshotStore.remove(for: scope, in: storeDirectory)
+        XCTAssertNil(try DiskMapSnapshotStore.load(for: scope, in: storeDirectory))
+        XCTAssertNil(try DiskMapSnapshotStore.load(for: scope, previous: true, in: storeDirectory))
+    }
+
+    func testStoreURLsAreScopedAndSafe() {
+        let a = DiskMapSnapshotStore.url(for: .startupDisk, in: storeDirectory)
+        let b = DiskMapSnapshotStore.url(for: .folder("/Users/x/Movies"), in: storeDirectory)
+        XCTAssertEqual(a.lastPathComponent, "startup.mpmdisk")
+        XCTAssertTrue(b.lastPathComponent.hasPrefix("folder-"))
+        XCTAssertEqual(b.deletingLastPathComponent(), storeDirectory)
+        XCTAssertTrue(
+            DiskMapSnapshotStore.url(for: .home, previous: true, in: storeDirectory)
+                .lastPathComponent.hasSuffix(".prev.mpmdisk"))
+    }
+
+    // MARK: - Item facts
+
+    func testItemFactsReadOneItem() throws {
+        let file = root.appendingPathComponent("tree/a/b/big.mov").path
+        let facts = try XCTUnwrap(DiskMapItemFacts.read(path: file))
+        XCTAssertFalse(facts.isDirectory)
+        XCTAssertEqual(facts.logicalBytes, 70_000)
+        XCTAssertGreaterThanOrEqual(facts.allocatedBytes, 70_000)
+        XCTAssertEqual(facts.linkCount, 1)
+        if let privateBytes = facts.privateBytes {
+            XCTAssertLessThanOrEqual(privateBytes, facts.allocatedBytes)
+        }
+        XCTAssertEqual(facts.wouldFreeBytes, facts.privateBytes ?? facts.allocatedBytes)
+
+        let directory = try XCTUnwrap(
+            DiskMapItemFacts.read(path: root.appendingPathComponent("tree/a").path))
+        XCTAssertTrue(directory.isDirectory)
+        XCTAssertNil(DiskMapItemFacts.read(path: root.appendingPathComponent("nope").path))
+    }
+
+    func testItemFactsSeeClones() throws {
+        let original = root.appendingPathComponent("tree/a/b/big.mov").path
+        let clone = root.appendingPathComponent("tree/a/b/clone.mov").path
+        guard clonefile(original, clone, 0) == 0 else {
+            throw XCTSkip("clonefile unsupported here")
+        }
+        let facts = try XCTUnwrap(DiskMapItemFacts.read(path: clone))
+        XCTAssertTrue(facts.mayShareBlocks)
+        XCTAssertGreaterThan(facts.sharedBytes, 0)
+        XCTAssertLessThan(facts.wouldFreeBytes, facts.allocatedBytes)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Disk Map (plan: engine → **page** → treemap → act → remember). The Disk tab gains an **Overview | Disk Map** picker and the Disk Map page on top of the phase 1 engine (#38).

- **`DiskMapModel.shared`**: scope, scan in flight (`Task` + `scanID`), frozen snapshot, selection, memoised slice rows built off-main. Survives tab switches; on window close cancels the scan and drops the arena, restoring from disk on the next open.
- **Toolbar**: scope menu (Macintosh HD, Home, Applications, mounted user volumes, Choose Folder…), Scan / Rescan (⌘R) or Cancel with a determinate progress bar and live read-out, Largest | Oldest picker, name filter. While scanning: current path and the largest folders so far.
- **Reconciliation bar**: Scanned / Unaccounted / macOS / Free plus chips (purgeable, clone overshoot or shared, local snapshots, not permitted → Privacy Settings, data vaults, owned by others, other volumes).
- **Largest** (files or folders) and **Oldest** (age band, minimum size): SwiftUI `Table` capped at 2 000 rows, Reveal in Finder / Copy Path.
- **Detail rail**: size, length when different, **Would free now** from a lazy `ATTR_CMNEXT_PRIVATESIZE` read, shares, modified, badges, Reveal in Finder, Quick Look, top contents.
- **Full Disk Access**: `FullDiskAccessManager` (prompt-free probe, activation refresh, Settings deep link, relaunch), `FullDiskAccessCard` on the empty state and after a scan that met EPERM folders, Settings section, onboarding row, folder usage strings in `Info.plist`, sequenced Desktop / Documents / Downloads preflight without the grant.
- **Persistence**: `DiskMapSnapshotCodec` (`.mpmdisk`, LZFSE, raw arrays + JSON, caps, bounded decompression, structural validation, 0600) and `DiskMapSnapshotStore` (per-scope file beside the database, `.prev` rollover).
- Disk > Disk Map command (⇧⌘D).

## Verified

- Full startup-disk scan from the page (2.96 M items in ~20 s), reconciliation figures identical to the CLI run, instant restore after relaunch ("Scanned 2 minutes ago").
- The rail on a 21.1 GB `Disk.img` that is an APFS clone: Size 21.1 GB, Length 64.0 GB, **Would free now: 0 bytes**, badge Clone.
- Fixed in review of the live build: rows lagged one click behind the Files/Folders segment because a `@Published` sink read the value being replaced (`willSet`); now delivered on the main queue.

## Test plan

- [x] `swift test`: 536 tests, 0 failures (7 new: codec round trip field by field, header/version/truncation/reserved-byte rejection, structurally invalid trees never decode, store save/load/`.prev` rollover with 0600, item facts on a file, a directory and a clone).
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` clean, no build warnings.
- [x] Live: `Scripts/run.sh --developer-id`, scan, tab away and back, relaunch and restore.

Next: phase 3, the treemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
