### PR TITLE
Disk Map phase 4: advisor, Reclaim and Kinds views, Move to Trash

### DIFF
--- a/Sources/MacPerfMonitor/Util/DiskMapStyle.swift
+++ b/Sources/MacPerfMonitor/Util/DiskMapStyle.swift
@@ -6,6 +6,7 @@ import SwiftUI
 enum DiskMapColorMode: String, CaseIterable, Identifiable {
     case kind = "Kind"
     case age = "Age"
+    case safety = "Safety"
     case depth = "Depth"
     var id: String { rawValue }
 
@@ -14,6 +15,9 @@ enum DiskMapColorMode: String, CaseIterable, Identifiable {
         case .kind: return "Colour by what a file is: video, images, code, archives and so on."
         case .age:
             return "Colour by when a file was last modified, cool for recent and warm for old."
+        case .safety:
+            return
+                "Colour by how safe it is to remove: caches in green, your files in blue, app-managed in orange, macOS in grey."
         case .depth: return "One hue, darker the deeper an item sits in the folder tree."
         }
     }
@@ -82,6 +86,24 @@ enum DiskMapStyle {
         return NSColor(hex: dark ? pair.dark : pair.light)
     }
 
+    // MARK: - Safety
+
+    private static let safetyHex: [DiskMapSafetyTier: (light: UInt32, dark: UInt32)] = [
+        .systemProtected: (0x64748B, 0x707E94),
+        .managedByApp: (0xF97316, 0xF08030),
+        .reviewBeforeRemoving: (0x3B82F6, 0x4F8DF7),
+        .safeToRemove: (0x16A34A, 0x2BB85E),
+    ]
+
+    static func safetyColor(_ tier: DiskMapSafetyTier, dark: Bool) -> NSColor {
+        let pair = safetyHex[tier]!
+        return NSColor(hex: dark ? pair.dark : pair.light)
+    }
+
+    static func safetyTint(_ tier: DiskMapSafetyTier) -> Color {
+        dynamic { safetyColor(tier, dark: $0) }
+    }
+
     // MARK: - Depth
 
     /// One blue, stepping darker and more saturated with each level so the
@@ -101,13 +123,15 @@ enum DiskMapStyle {
 
     static func cellColor(
         mode: DiskMapColorMode, kind: FileKind, isDirectory: Bool, modified: UInt32, depth: Int,
-        now: UInt32, dark: Bool
+        tier: DiskMapSafetyTier, now: UInt32, dark: Bool
     ) -> NSColor {
         switch mode {
         case .kind:
             return kindColor(isDirectory && kind == .folder ? .folder : kind, dark: dark)
         case .age:
             return ageColor(band: ageBand(modified: modified, now: now), dark: dark)
+        case .safety:
+            return safetyColor(tier, dark: dark)
         case .depth:
             return depthColor(depth: depth, dark: dark)
         }
@@ -156,6 +180,13 @@ enum DiskMapStyle {
         case .age:
             return ageBandLabels.enumerated().map { band, label in
                 LegendEntry(label: label, color: dynamic { ageColor(band: band, dark: $0) })
+            }
+        case .safety:
+            return [
+                DiskMapSafetyTier.safeToRemove, .reviewBeforeRemoving, .managedByApp,
+                .systemProtected,
+            ].map { tier in
+                LegendEntry(label: tier.label, color: dynamic { safetyColor(tier, dark: $0) })
             }
         case .depth:
             return (0..<4).map { depth in

--- a/Sources/MacPerfMonitor/ViewModels/DiskMapModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/DiskMapModel.swift
@@ -3,7 +3,8 @@ import Combine
 import Foundation
 import MacPerfMonitorCore
 
-/// One line of a Disk Map slice (Largest, Oldest): a node flattened for a table.
+/// One line of a Disk Map slice (Largest, Oldest, Kinds): a node flattened
+/// for a table.
 struct DiskMapRow: Identifiable, Hashable, Sendable {
     let id: Int32
     let name: String
@@ -22,13 +23,21 @@ struct DiskMapRow: Identifiable, Hashable, Sendable {
     var parentPath: String { (path as NSString).deletingLastPathComponent }
 }
 
+/// One file behind a small-files fold, listed live from the directory.
+struct DiskMapFoldEntry: Identifiable, Hashable, Sendable {
+    var id: String { name }
+    let name: String
+    let bytes: UInt64
+}
+
 /// State for the Disk Map page: the scope, the last scan (restored from disk
-/// on open), the scan in flight, the selection, and the memoised rows of the
-/// active slice. One shared instance, like `HardwareExplorerModel`, because
-/// `TabGate` unmounts the page on every tab switch and a multi-minute scan
-/// must survive that. What it must not survive is the window closing: the
-/// arena is dropped then (memory budget) and comes back from the snapshot
-/// file on the next open. Nothing here runs on the sampler's tick.
+/// on open), the scan in flight, the selection, the map's zoom, the advisor's
+/// analysis and the memoised rows of the active slice. One shared instance,
+/// like `HardwareExplorerModel`, because `TabGate` unmounts the page on every
+/// tab switch and a multi-minute scan must survive that. What it must not
+/// survive is the window closing: the arena is dropped then (memory budget)
+/// and comes back from the snapshot file on the next open. Nothing here runs
+/// on the sampler's tick.
 @MainActor
 final class DiskMapModel: ObservableObject {
     static let shared = DiskMapModel()
@@ -41,6 +50,8 @@ final class DiskMapModel: ObservableObject {
         case map = "Map"
         case largest = "Largest"
         case oldest = "Oldest"
+        case kinds = "Kinds"
+        case reclaim = "Reclaim"
         var id: String { rawValue }
     }
 
@@ -99,6 +110,8 @@ final class DiskMapModel: ObservableObject {
     @Published private(set) var lastError: String?
     /// Mounted user volumes offered in the scope menu.
     @Published private(set) var externalVolumes: [VolumeInfo] = []
+    /// The advisor's tiers, Reclaim items and kind totals for the snapshot.
+    @Published private(set) var analysis: DiskMapAnalysis?
     @Published var selection: Int32?
     @Published var viewMode: ViewMode = .map
     @Published var colorMode: DiskMapColorMode = .kind
@@ -109,18 +122,25 @@ final class DiskMapModel: ObservableObject {
     @Published var largestKind: LargestKind = .files
     @Published var ageBand: AgeBand = .oneYear
     @Published var minimumSize: MinimumSize = .oneMB
+    @Published var selectedKind: FileKind?
     @Published var filterText = ""
     /// The active slice, memoised per (snapshot revision, mode, filters) and
     /// built off the main thread. `rowsRevision` is what views compare.
     @Published private(set) var rows: [DiskMapRow] = []
     @Published private(set) var rowsRevision = 0
     @Published private(set) var rowsBuilding = false
+    /// A node awaiting the Move to Trash confirmation.
+    @Published var pendingTrash: Int32?
+    @Published var trashError: String?
+
+    let advisor = DiskMapAdvisor()
 
     private let scanner = DiskMapScanner()
     private var scanTask: Task<Void, Never>?
     private var scanID = UUID()
     private var restoreID = UUID()
     private var rowsGeneration = 0
+    private var analysisGeneration = 0
     private var cancellables = Set<AnyCancellable>()
     private var windowCancellable: AnyCancellable?
     private weak var fullDiskAccess: FullDiskAccessManager?
@@ -133,6 +153,11 @@ final class DiskMapModel: ObservableObject {
             .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _, _, _, _ in self?.rebuildRows() }
+            .store(in: &cancellables)
+        $selectedKind
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.rebuildRows() }
             .store(in: &cancellables)
         $filterText
             .dropFirst()
@@ -174,13 +199,19 @@ final class DiskMapModel: ObservableObject {
         // in flight is abandoned (its partial result would only shadow the
         // last complete one on disk).
         cancelScan()
+        clearSnapshot()
+        AppLog.ui.notice("Disk Map released its tree on window close")
+    }
+
+    private func clearSnapshot() {
         snapshot = nil
+        analysis = nil
         rows = []
         rowsRevision += 1
         selection = nil
         zoomRoot = FileTree.root
         hover = nil
-        AppLog.ui.notice("Disk Map released its tree on window close")
+        pendingTrash = nil
     }
 
     // MARK: - Scope
@@ -191,12 +222,7 @@ final class DiskMapModel: ObservableObject {
         guard newScope != scope else { return }
         cancelScan()
         scope = newScope
-        snapshot = nil
-        rows = []
-        rowsRevision += 1
-        selection = nil
-        zoomRoot = FileTree.root
-        hover = nil
+        clearSnapshot()
         lastError = nil
         restore(newScope)
     }
@@ -311,21 +337,32 @@ final class DiskMapModel: ObservableObject {
     }
 
     private func finish(_ snapshot: DiskMapSnapshot) {
-        self.snapshot = snapshot
+        install(snapshot)
         isScanning = false
         scanTask = nil
         progress = nil
         preview = nil
-        selection = nil
-        zoomRoot = FileTree.root
-        hover = nil
-        rebuildRows()
         FDWatchdog.check(after: "disk map scan")
         let counts = snapshot.reconciliation.counts
         AppLog.ui.notice(
             "Disk Map scan finished: \(snapshot.tree.nodeCount) nodes, \(counts.entries) entries, \(snapshot.reconciliation.scannedBytes) bytes, \(counts.notPermitted) not permitted"
         )
         guard !snapshot.partial else { return }
+        persist(snapshot)
+    }
+
+    private func install(_ snapshot: DiskMapSnapshot) {
+        self.snapshot = snapshot
+        analysis = nil
+        selection = nil
+        zoomRoot = FileTree.root
+        hover = nil
+        pendingTrash = nil
+        rebuildRows()
+        analyze()
+    }
+
+    private func persist(_ snapshot: DiskMapSnapshot) {
         Task.detached(priority: .utility) {
             do {
                 try DiskMapSnapshotStore.save(snapshot)
@@ -356,9 +393,7 @@ final class DiskMapModel: ObservableObject {
                 guard self.restoreID == id else { return }
                 self.isRestoring = false
                 guard let loaded, self.scope == scope, self.snapshot == nil else { return }
-                self.snapshot = loaded
-                self.zoomRoot = FileTree.root
-                self.rebuildRows()
+                self.install(loaded)
                 AppLog.ui.notice("Disk Map snapshot restored (\(loaded.tree.nodeCount) nodes)")
             }
         }
@@ -367,6 +402,46 @@ final class DiskMapModel: ObservableObject {
     func clearError() {
         lastError = nil
     }
+
+    // MARK: - Analysis
+
+    /// Run the advisor over the snapshot off the main thread; results are
+    /// applied only if the snapshot has not been replaced meanwhile.
+    private func analyze() {
+        guard let snapshot else { return }
+        analysisGeneration += 1
+        let generation = analysisGeneration
+        let advisor = advisor
+        Task.detached(priority: .userInitiated) {
+            let result = advisor.analyze(snapshot)
+            await MainActor.run {
+                guard self.analysisGeneration == generation,
+                    self.snapshot?.revision == snapshot.revision
+                else { return }
+                self.analysis = result
+                if self.viewMode == .kinds, self.selectedKind == nil {
+                    self.selectedKind = result.kinds.first?.kind
+                }
+            }
+        }
+    }
+
+    /// What the advisor says about a node: from the analysis when it has
+    /// landed, else from the path directly.
+    func advice(for node: Int32) -> DiskMapAdvice? {
+        guard let snapshot, Int(node) < snapshot.tree.nodeCount else { return nil }
+        if let analysis, analysis.revision == snapshot.revision,
+            Int(node) < analysis.ruleIndex.count
+        {
+            return advisor.advice(for: node, in: analysis, tree: snapshot.tree)
+        }
+        let flags = snapshot.tree.flags[Int(node)]
+        return advisor.advice(
+            forCanonicalPath: snapshot.displayPath(of: node),
+            isDirectory: flags.contains(.directory), flags: flags)
+    }
+
+    var trashedBytes: UInt64 { analysis?.trashedBytes ?? 0 }
 
     // MARK: - Map navigation
 
@@ -392,9 +467,7 @@ final class DiskMapModel: ObservableObject {
         hover = nil
     }
 
-    /// Show a node in the map: zoom to its parent (or to the node itself when
-    /// it is a directory with children the user came from a list to see) and
-    /// select it.
+    /// Show a node in the map: zoom to its parent and select it.
     func reveal(_ node: Int32) {
         guard let tree = snapshot?.tree, Int(node) < tree.nodeCount else { return }
         viewMode = .map
@@ -415,10 +488,7 @@ final class DiskMapModel: ObservableObject {
     func installForBenchmark(_ snapshot: DiskMapSnapshot) {
         cancelScan()
         scope = snapshot.scope
-        self.snapshot = snapshot
-        zoomRoot = FileTree.root
-        selection = nil
-        rebuildRows()
+        install(snapshot)
     }
 
     // MARK: - Selection and lookups
@@ -440,6 +510,111 @@ final class DiskMapModel: ObservableObject {
         snapshot?.tree.childrenBySize(of: node) ?? []
     }
 
+    /// The files behind a small-files fold, read live from its directory
+    /// (the arena keeps only their total). Largest first, capped.
+    func foldListing(for node: Int32, limit: Int = 40) async -> [DiskMapFoldEntry] {
+        guard let snapshot, Int(node) < snapshot.tree.nodeCount,
+            snapshot.tree.flags[Int(node)].contains(.smallFilesFold)
+        else { return [] }
+        let tree = snapshot.tree
+        let parent = tree.parent[Int(node)]
+        let kind = tree.kind[Int(node)]
+        let threshold = snapshot.smallFileThreshold
+        let path = snapshot.filesystemPath(of: parent)
+        return await Task.detached(priority: .userInitiated) {
+            guard let listing = try? BulkAttributeLister().list(path: path) else { return [] }
+            var entries: [DiskMapFoldEntry] = []
+            for entry in listing.entries where entry.type == .regular && entry.error == 0 {
+                guard threshold == 0 || entry.allocated < threshold else { continue }
+                let name = listing.nameString(of: entry)
+                guard FileKindClassifier.kind(forName: name, isDirectory: false) == kind else {
+                    continue
+                }
+                entries.append(DiskMapFoldEntry(name: name, bytes: entry.allocated))
+            }
+            entries.sort { $0.bytes > $1.bytes }
+            return Array(entries.prefix(limit))
+        }.value
+    }
+
+    // MARK: - Trash
+
+    /// Whether Move to Trash is offered for a node: not a fold, not already
+    /// trashed, not a place the app refuses, and not tiered as protected.
+    func canTrash(_ node: Int32) -> Bool {
+        guard let snapshot, Int(node) < snapshot.tree.nodeCount else { return false }
+        let flags = snapshot.tree.flags[Int(node)]
+        if flags.contains(.smallFilesFold) || flags.contains(.trashed)
+            || flags.contains(.separateVolume) || flags.contains(.restricted)
+            || flags.contains(.immutable) || node == FileTree.root
+        {
+            return false
+        }
+        if advisor.isRefusedForTrash(
+            canonicalPath: snapshot.displayPath(of: node), scanRoot: snapshot.scope.displayRoot)
+        {
+            return false
+        }
+        return advice(for: node)?.canTrash ?? true
+    }
+
+    /// Ask for confirmation; the page hosts the dialog.
+    func requestTrash(_ node: Int32) {
+        guard canTrash(node) else { return }
+        pendingTrash = node
+    }
+
+    /// The confirmed move. The inode is checked first so a scan that is days
+    /// old never removes something that replaced the item the user saw; on
+    /// success the tree is patched in place (bytes re-homed to In Trash) and
+    /// the revision bumps so every view follows.
+    func performTrash(_ node: Int32) {
+        pendingTrash = nil
+        guard let snapshot, Int(node) < snapshot.tree.nodeCount, canTrash(node) else { return }
+        let path = snapshot.filesystemPath(of: node)
+        let displayPath = snapshot.displayPath(of: node)
+        let fileID = snapshot.tree.fileID[Int(node)]
+        let revision = snapshot.revision
+        let advisor = advisor
+        let scanRoot = snapshot.scope.displayRoot
+        Task.detached(priority: .userInitiated) {
+            let check = DiskMapTrash.precheck(
+                path: path, expectedFileID: fileID, advisor: advisor, scanRoot: scanRoot)
+            let outcome: DiskMapTrash.Outcome
+            switch check {
+            case .ok: outcome = DiskMapTrash.trash(path: path)
+            case .vanished: outcome = .alreadyGone
+            case .replaced:
+                outcome = .failed(
+                    "\u{201C}\((displayPath as NSString).lastPathComponent)\u{201D} has changed since the scan. Scan again before removing it."
+                )
+            case .refused(let reason): outcome = .failed(reason)
+            }
+            await MainActor.run {
+                self.finishTrash(node: node, revision: revision, outcome: outcome)
+            }
+        }
+    }
+
+    private func finishTrash(node: Int32, revision: Int, outcome: DiskMapTrash.Outcome) {
+        guard var snapshot, snapshot.revision == revision else { return }
+        switch outcome {
+        case .trashed, .alreadyGone:
+            let removed = snapshot.tree.markTrashed(node)
+            snapshot.revision += 1
+            self.snapshot = snapshot
+            rebuildRows()
+            analyze()
+            AppLog.ui.notice(
+                "Disk Map moved \(removed) bytes to the Trash (\(outcome == .alreadyGone ? "already gone" : "ok", privacy: .public))"
+            )
+        case .failed(let message):
+            // Deferred so the confirmation dialog has fully dismissed; SwiftUI
+            // swallows an alert presented in the same tick.
+            DispatchQueue.main.async { self.trashError = message }
+        }
+    }
+
     // MARK: - Rows
 
     private func rebuildRows() {
@@ -455,11 +630,15 @@ final class DiskMapModel: ObservableObject {
         let band = ageBand
         let minimum = minimumSize
         let filter = filterText.trimmingCharacters(in: .whitespaces)
+        let kindItems = selectedKind.flatMap { selected in
+            analysis?.kinds.first { $0.kind == selected }?.topItems
+        }
         rowsBuilding = true
         Task.detached(priority: .userInitiated) {
             let built = Self.buildRows(
                 snapshot: snapshot, mode: mode, largestKind: kind, ageBand: band,
-                minimumSize: minimum, filter: filter, now: Date(), limit: Self.rowLimit)
+                minimumSize: minimum, filter: filter, kindItems: kindItems, now: Date(),
+                limit: Self.rowLimit)
             await MainActor.run {
                 guard self.rowsGeneration == generation else { return }
                 self.rows = built
@@ -475,7 +654,7 @@ final class DiskMapModel: ObservableObject {
     /// strings are made for the millions that do not match.
     nonisolated static func buildRows(
         snapshot: DiskMapSnapshot, mode: ViewMode, largestKind: LargestKind, ageBand: AgeBand,
-        minimumSize: MinimumSize, filter: String, now: Date, limit: Int
+        minimumSize: MinimumSize, filter: String, kindItems: [Int32]?, now: Date, limit: Int
     ) -> [DiskMapRow] {
         let tree = snapshot.tree
         let n = tree.nodeCount
@@ -492,6 +671,30 @@ final class DiskMapModel: ObservableObject {
             }
         }
 
+        func row(_ node: Int32) -> DiskMapRow {
+            let i = Int(node)
+            return DiskMapRow(
+                id: node, name: tree.name(of: node), path: snapshot.displayPath(of: node),
+                bytes: tree.bytes[i], modified: tree.modifiedDate(of: node), kind: tree.kind[i],
+                isDirectory: tree.flags[i].contains(.directory), flags: tree.flags[i],
+                count: tree.count[i], fraction: Double(tree.bytes[i]) / Double(total))
+        }
+
+        switch mode {
+        case .map, .reclaim:
+            return []
+        case .kinds:
+            guard let kindItems else { return [] }
+            return kindItems.prefix(limit).compactMap { node in
+                let i = Int(node)
+                guard i < n, !tree.flags[i].contains(.trashed) else { return nil }
+                if !needle.isEmpty, !hit[i] { return nil }
+                return row(node)
+            }
+        case .largest, .oldest:
+            break
+        }
+
         let cutoff = ageBand.cutoff(now: now).map {
             UInt32(clamping: Int($0.timeIntervalSince1970))
         }
@@ -503,8 +706,6 @@ final class DiskMapModel: ObservableObject {
             if !needle.isEmpty, !hit[i] { continue }
             let isDirectory = flags.contains(.directory)
             switch mode {
-            case .map:
-                return []
             case .largest:
                 switch largestKind {
                 case .files:
@@ -520,29 +721,24 @@ final class DiskMapModel: ObservableObject {
                 if let cutoff, tree.modified[i] > cutoff { continue }
                 if tree.modified[i] == 0 { continue }
                 candidates.append((key: UInt64(tree.modified[i]), node: Int32(i)))
+            case .map, .kinds, .reclaim:
+                break
             }
         }
         switch mode {
-        case .map: break
         case .largest: candidates.sort { $0.key > $1.key }
         case .oldest: candidates.sort { $0.key < $1.key }
+        case .map, .kinds, .reclaim: break
         }
-
-        return candidates.prefix(limit).map { entry in
-            let i = Int(entry.node)
-            return DiskMapRow(
-                id: entry.node, name: tree.name(of: entry.node),
-                path: snapshot.displayPath(of: entry.node), bytes: tree.bytes[i],
-                modified: tree.modifiedDate(of: entry.node), kind: tree.kind[i],
-                isDirectory: tree.flags[i].contains(.directory), flags: tree.flags[i],
-                count: tree.count[i], fraction: Double(tree.bytes[i]) / Double(total))
-        }
+        return candidates.prefix(limit).map { row($0.node) }
     }
 
     /// ASCII case-insensitive substring search on raw UTF-8.
     private nonisolated static func nameContains(
         _ name: ArraySlice<UInt8>, _ needle: [UInt8]
-    ) -> Bool {
+    )
+        -> Bool
+    {
         let m = needle.count
         guard m > 0, name.count >= m else { return false }
         let start = name.startIndex

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapDetailRail.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapDetailRail.swift
@@ -5,10 +5,12 @@ import SwiftUI
 /// The right-hand rail: everything about the selected item and the ways to
 /// act on it. Facts the scan did not carry (logical length, the bytes a delete
 /// would free) are read on selection with one `getattrlist`, off the main
-/// thread, and shown when they arrive.
+/// thread, and shown when they arrive; the advisor's verdict says how safe
+/// removing it is and what the proper way to reclaim the space would be.
 struct DiskMapDetailRail: View {
     @ObservedObject var model: DiskMapModel
     @State private var facts: DiskMapItemFacts?
+    @State private var foldEntries: [DiskMapFoldEntry] = []
     @State private var quickLookURL: URL?
 
     var body: some View {
@@ -25,7 +27,7 @@ struct DiskMapDetailRail: View {
             .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .task(id: model.selection) { await loadFacts() }
+        .task(id: model.selection) { await loadDetails() }
         .quickLookPreview($quickLookURL)
     }
 
@@ -37,10 +39,12 @@ struct DiskMapDetailRail: View {
             Text("Select an item")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.secondary)
-            Text("Its size, age and location appear here, with Reveal in Finder and Quick Look.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .multilineTextAlignment(.center)
+            Text(
+                "Its size, age, location and how safe it is to remove appear here, with Reveal in Finder, Quick Look and Move to Trash."
+            )
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+            .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
         .padding(.top, 60)
@@ -62,7 +66,7 @@ struct DiskMapDetailRail: View {
 
         header(
             name: name, path: displayPath, isFold: isFold, kind: tree.kind[i],
-            isDirectory: isDirectory)
+            isDirectory: isDirectory, trashed: flags.contains(.trashed))
 
         pathRow(displayPath)
 
@@ -74,15 +78,18 @@ struct DiskMapDetailRail: View {
             badgeRow(badges(flags))
         }
 
-        if !isFold {
-            actions(
-                node: node, displayPath: displayPath,
-                canOpen: isDirectory && tree.childCount[i] > 0)
-        } else {
-            showInMap(node)
+        if !isFold, !flags.contains(.trashed), let advice = model.advice(for: node) {
+            verdict(advice)
         }
 
-        if isDirectory, tree.childCount[i] > 0 {
+        actions(
+            node: node, displayPath: displayPath, isFold: isFold,
+            canOpen: isDirectory && !isFold && tree.childCount[i] > 0,
+            trashed: flags.contains(.trashed))
+
+        if isFold {
+            foldList
+        } else if isDirectory, tree.childCount[i] > 0 {
             topContents(tree: tree, node: node)
         } else if flags.contains(.notPermitted) {
             note(
@@ -100,11 +107,16 @@ struct DiskMapDetailRail: View {
     }
 
     private func header(
-        name: String, path: String, isFold: Bool, kind: FileKind, isDirectory: Bool
+        name: String, path: String, isFold: Bool, kind: FileKind, isDirectory: Bool, trashed: Bool
     ) -> some View {
         HStack(alignment: .top, spacing: 10) {
             if isFold {
                 Image(systemName: "square.stack.3d.up")
+                    .font(.title)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 36, height: 36)
+            } else if trashed {
+                Image(systemName: "trash")
                     .font(.title)
                     .foregroundStyle(.secondary)
                     .frame(width: 36, height: 36)
@@ -118,9 +130,12 @@ struct DiskMapDetailRail: View {
                     .font(.headline)
                     .lineLimit(2)
                     .truncationMode(.middle)
-                Text(isDirectory && kind == .folder ? "Folder" : kind.label)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Text(
+                    trashed
+                        ? "In the Trash" : (isDirectory && kind == .folder ? "Folder" : kind.label)
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
         }
     }
@@ -148,9 +163,7 @@ struct DiskMapDetailRail: View {
     @ViewBuilder
     private func factsGrid(
         tree: FileTree, node: Int32, parentBytes: UInt64, isDirectory: Bool, isFold: Bool
-    )
-        -> some View
-    {
+    ) -> some View {
         let i = Int(node)
         let bytes = tree.bytes[i]
         let total = max(tree.bytes[0], 1)
@@ -177,7 +190,9 @@ struct DiskMapDetailRail: View {
                 factRow("Share of parent", shareText(Double(bytes) / Double(parentBytes)))
             }
             if tree.modified[i] > 0 {
-                factRow("Modified", modifiedText(tree.modifiedDate(of: node)))
+                factRow(
+                    "Modified",
+                    tree.modifiedDate(of: node).formatted(.relative(presentation: .named)))
             }
         }
     }
@@ -224,21 +239,64 @@ struct DiskMapDetailRail: View {
         }
     }
 
-    private func actions(node: Int32, displayPath: String, canOpen: Bool) -> some View {
+    /// The advisor's verdict: tier, the rule that applied, why, and how to
+    /// reclaim the space properly.
+    private func verdict(_ advice: DiskMapAdvice) -> some View {
+        let tint = DiskMapStyle.safetyTint(advice.tier)
+        return VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(tint)
+                    .frame(width: 8, height: 8)
+                Text(advice.tier.label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(tint)
+                Text("\u{00B7}")
+                    .foregroundStyle(.tertiary)
+                Text(advice.title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+            }
+            Text(advice.reason)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if let how = advice.howToReclaim {
+                Text(how)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(tint.opacity(0.25)))
+    }
+
+    private func actions(
+        node: Int32, displayPath: String, isFold: Bool, canOpen: Bool, trashed: Bool
+    )
+        -> some View
+    {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                Button {
-                    ProcessActions.revealInFinder(path: displayPath)
-                } label: {
-                    Label("Reveal in Finder", systemImage: "folder")
+            if !isFold {
+                HStack(spacing: 8) {
+                    Button {
+                        ProcessActions.revealInFinder(path: displayPath)
+                    } label: {
+                        Label("Reveal in Finder", systemImage: "folder")
+                    }
+                    .help("Show this item in the Finder")
+                    .disabled(trashed)
+                    Button {
+                        quickLookURL = URL(fileURLWithPath: displayPath)
+                    } label: {
+                        Label("Quick Look", systemImage: "eye")
+                    }
+                    .help("Preview without opening")
+                    .disabled(trashed)
                 }
-                .help("Show this item in the Finder")
-                Button {
-                    quickLookURL = URL(fileURLWithPath: displayPath)
-                } label: {
-                    Label("Quick Look", systemImage: "eye")
-                }
-                .help("Preview without opening")
             }
             HStack(spacing: 8) {
                 if canOpen, model.viewMode == .map, model.zoomRoot != node {
@@ -249,24 +307,26 @@ struct DiskMapDetailRail: View {
                     }
                     .help("Zoom the map into this folder")
                 }
-                showInMap(node)
+                if model.viewMode != .map {
+                    Button {
+                        model.reveal(node)
+                    } label: {
+                        Label("Show in Map", systemImage: "rectangle.3.group")
+                    }
+                    .help("Switch to the map with this item selected")
+                }
+                if model.canTrash(node) {
+                    Button(role: .destructive) {
+                        model.requestTrash(node)
+                    } label: {
+                        Label("Move to Trash", systemImage: "trash")
+                    }
+                    .keyboardShortcut(.delete, modifiers: .command)
+                    .help("Move to the Trash (Command-Delete). You can put it back from the Trash.")
+                }
             }
         }
         .controlSize(.small)
-    }
-
-    /// From a list, jump to where the item sits in the map.
-    @ViewBuilder
-    private func showInMap(_ node: Int32) -> some View {
-        if model.viewMode != .map {
-            Button {
-                model.reveal(node)
-            } label: {
-                Label("Show in Map", systemImage: "rectangle.3.group")
-            }
-            .controlSize(.small)
-            .help("Switch to the map with this item selected")
-        }
     }
 
     private func topContents(tree: FileTree, node: Int32) -> some View {
@@ -308,6 +368,46 @@ struct DiskMapDetailRail: View {
         }
     }
 
+    /// The files behind a fold, listed live.
+    private var foldList: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text("LARGEST OF THESE")
+                    .font(.caption2.weight(.semibold))
+                    .tracking(0.6)
+                    .foregroundStyle(.tertiary)
+                Text("live")
+                    .font(.caption2)
+                    .padding(.horizontal, 5)
+                    .background(Capsule().fill(.quaternary))
+                    .foregroundStyle(.secondary)
+            }
+            if foldEntries.isEmpty {
+                Text("Reading the folder\u{2026}")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                let top = max(foldEntries.first?.bytes ?? 1, 1)
+                ForEach(foldEntries) { entry in
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 6) {
+                            Text(entry.name)
+                                .font(.caption)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Text(ByteFormat.string(entry.bytes))
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                        GroupProportionBar(
+                            fraction: Double(entry.bytes) / Double(top), tint: DiskStyle.read)
+                    }
+                }
+            }
+        }
+    }
+
     private func note(_ text: String) -> some View {
         Text(text)
             .font(.caption)
@@ -333,17 +433,18 @@ struct DiskMapDetailRail: View {
         return String(format: "%.1f%%", percent)
     }
 
-    private func modifiedText(_ date: Date) -> String {
-        let relative = date.formatted(.relative(presentation: .named))
-        return "\(relative)"
-    }
-
-    private func loadFacts() async {
+    private func loadDetails() async {
         facts = nil
+        foldEntries = []
         guard let node = model.selection, let snapshot = model.snapshot,
-            Int(node) < snapshot.tree.nodeCount,
-            !snapshot.tree.flags[Int(node)].contains(.smallFilesFold)
+            Int(node) < snapshot.tree.nodeCount
         else { return }
+        if snapshot.tree.flags[Int(node)].contains(.smallFilesFold) {
+            let entries = await model.foldListing(for: node)
+            guard !Task.isCancelled, model.selection == node else { return }
+            foldEntries = entries
+            return
+        }
         let path = snapshot.filesystemPath(of: node)
         let read = await Task.detached(priority: .userInitiated) {
             DiskMapItemFacts.read(path: path)

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapReclaimView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapReclaimView.swift
@@ -1,0 +1,228 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// The "which of this can I remove safely" answer: the known locations the
+/// advisor found in the scan, grouped by how safe they are, largest first,
+/// each with its reason and the proper way to reclaim the space.
+struct DiskMapReclaimView: View {
+    @ObservedObject var model: DiskMapModel
+
+    private static let tierOrder: [DiskMapSafetyTier] = [
+        .safeToRemove, .reviewBeforeRemoving, .managedByApp, .systemProtected,
+    ]
+
+    var body: some View {
+        if let analysis = model.analysis, let snapshot = model.snapshot,
+            analysis.revision == snapshot.revision
+        {
+            if analysis.reclaim.isEmpty {
+                ContentUnavailableView(
+                    "Nothing recognised", systemImage: "sparkles",
+                    description: Text(
+                        "None of the folders this scan covered is a known cache, library or download location."
+                    ))
+            } else {
+                list(analysis, snapshot: snapshot)
+            }
+        } else {
+            VStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Looking through the scan\u{2026}")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func list(_ analysis: DiskMapAnalysis, snapshot: DiskMapSnapshot) -> some View {
+        let total = max(snapshot.tree.bytes[0], 1)
+        let grouped = Dictionary(grouping: analysis.reclaim, by: \.advice.tier)
+        return List(selection: selectionBinding) {
+            ForEach(Self.tierOrder, id: \.self) { tier in
+                if let items = grouped[tier], !items.isEmpty {
+                    Section {
+                        ForEach(items.prefix(150)) { item in
+                            row(item, snapshot: snapshot, total: total)
+                                .tag(item.node)
+                        }
+                    } header: {
+                        header(tier, items: items)
+                    }
+                }
+            }
+        }
+        .listStyle(.inset)
+    }
+
+    private func header(_ tier: DiskMapSafetyTier, items: [DiskMapReclaimItem]) -> some View {
+        let bytes = items.reduce(UInt64(0)) { $0 &+ $1.bytes }
+        return HStack(spacing: 8) {
+            Circle()
+                .fill(DiskMapStyle.safetyTint(tier))
+                .frame(width: 8, height: 8)
+            Text(tier.label)
+                .font(.caption.weight(.semibold))
+            Text(ByteFormat.string(bytes))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+            Text(tierHint(tier))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+            Spacer()
+        }
+        .textCase(nil)
+    }
+
+    private func tierHint(_ tier: DiskMapSafetyTier) -> String {
+        switch tier {
+        case .safeToRemove: return "regenerates when needed"
+        case .reviewBeforeRemoving: return "your files, look first"
+        case .managedByApp: return "use the app's own controls"
+        case .systemProtected: return "shown for the accounting, not removable"
+        }
+    }
+
+    private func row(
+        _ item: DiskMapReclaimItem, snapshot: DiskMapSnapshot, total: UInt64
+    )
+        -> some View
+    {
+        let path = snapshot.displayPath(of: item.node)
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(item.advice.title)
+                    .font(.subheadline.weight(.semibold))
+                Text(path)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 8)
+                Text(ByteFormat.string(item.bytes))
+                    .font(.subheadline.monospacedDigit().weight(.semibold))
+                Text(item.count == 1 ? "1 item" : "\(item.count.formatted()) items")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 84, alignment: .trailing)
+            }
+            GroupProportionBar(
+                fraction: Double(item.bytes) / Double(total),
+                tint: DiskMapStyle.safetyTint(item.advice.tier))
+            Text(item.advice.reason)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if let how = item.advice.howToReclaim {
+                Text(how)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button {
+                model.reveal(item.node)
+            } label: {
+                Label("Show in Map", systemImage: "rectangle.3.group")
+            }
+            Button {
+                ProcessActions.revealInFinder(path: path)
+            } label: {
+                Label("Reveal in Finder", systemImage: "folder")
+            }
+            if model.canTrash(item.node) {
+                Divider()
+                Button(role: .destructive) {
+                    model.requestTrash(item.node)
+                } label: {
+                    Label("Move to Trash", systemImage: "trash")
+                }
+            }
+        }
+    }
+
+    private var selectionBinding: Binding<Int32?> {
+        Binding(get: { model.selection }, set: { model.select($0) })
+    }
+}
+
+/// Bytes by kind, with the largest items of the chosen kind beside it.
+struct DiskMapKindsView: View {
+    @ObservedObject var model: DiskMapModel
+
+    var body: some View {
+        HStack(spacing: 0) {
+            kindsColumn
+                .frame(width: 280)
+            Divider()
+            DiskMapSliceTable(model: model)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    @ViewBuilder
+    private var kindsColumn: some View {
+        if let analysis = model.analysis, let snapshot = model.snapshot,
+            analysis.revision == snapshot.revision
+        {
+            let total = max(snapshot.tree.bytes[0], 1)
+            List(selection: kindBinding) {
+                ForEach(analysis.kinds) { entry in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 6) {
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(kindColor(entry.kind))
+                                .frame(width: 9, height: 9)
+                            Text(entry.kind.label)
+                                .font(.subheadline)
+                                .lineLimit(1)
+                            Spacer()
+                            Text(ByteFormat.string(entry.bytes))
+                                .font(.subheadline.monospacedDigit())
+                        }
+                        GroupProportionBar(
+                            fraction: Double(entry.bytes) / Double(total),
+                            tint: kindColor(entry.kind))
+                        Text(
+                            "\(Self.percent(entry.bytes, of: total)) \u{00B7} \(Self.count(entry.count))"
+                        )
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 3)
+                    .tag(entry.kind)
+                }
+            }
+            .listStyle(.inset)
+        } else {
+            VStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Totalling by kind\u{2026}")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var kindBinding: Binding<FileKind?> {
+        Binding(get: { model.selectedKind }, set: { model.selectedKind = $0 })
+    }
+
+    private func kindColor(_ kind: FileKind) -> Color {
+        DiskMapStyle.legend(for: .kind).first { $0.label == kind.label }?.color ?? .secondary
+    }
+
+    private static func percent(_ bytes: UInt64, of total: UInt64) -> String {
+        let value = Double(bytes) / Double(total) * 100
+        return value < 0.1 ? "<0.1%" : String(format: "%.1f%%", value)
+    }
+
+    private static func count(_ value: UInt64) -> String {
+        value == 1 ? "1 item" : "\(DiskMapModel.compactCount(value)) items"
+    }
+}

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapReconciliationBar.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapReconciliationBar.swift
@@ -9,6 +9,9 @@ import SwiftUI
 struct DiskMapReconciliationBar: View {
     let reconciliation: DiskMapReconciliation
     let scope: DiskMapScope
+    /// Bytes moved to the Trash from this page since the scan; the volume
+    /// does not shrink until Finder empties it.
+    var inTrashBytes: UInt64 = 0
     var onGrantAccess: (() -> Void)?
     var onFolderAccess: (() -> Void)?
 
@@ -130,6 +133,13 @@ struct DiskMapReconciliationBar: View {
 
     @ViewBuilder
     private var chips: some View {
+        if inTrashBytes > 0 {
+            chipButton(
+                "In Trash \(ByteFormat.string(inTrashBytes))", tint: .green,
+                help:
+                    "Moved to the Trash from here. The space is freed when the Trash is emptied in Finder.",
+                action: nil)
+        }
         if let purgeable = reconciliation.purgeableBytes, purgeable > 0 {
             chip("Purgeable \(ByteFormat.string(purgeable))", help: purgeableHelp)
         }
@@ -199,7 +209,7 @@ struct DiskMapReconciliationBar: View {
     ) -> some View {
         Button(action: { action?() }) {
             HStack(spacing: 4) {
-                Image(systemName: "exclamationmark.triangle.fill")
+                Image(systemName: tint == .green ? "trash" : "exclamationmark.triangle.fill")
                     .font(.caption2)
                 Text(text)
                     .font(.caption2.weight(.semibold))

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapTables.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapTables.swift
@@ -39,8 +39,13 @@ struct DiskMapSliceTable: View {
     private var controls: some View {
         HStack(spacing: 12) {
             switch model.viewMode {
-            case .map:
+            case .map, .reclaim:
                 EmptyView()
+            case .kinds:
+                if let kind = model.selectedKind {
+                    Text(kind.label)
+                        .font(.subheadline.weight(.semibold))
+                }
             case .largest:
                 Picker("Show", selection: $model.largestKind) {
                     ForEach(DiskMapModel.LargestKind.allCases) { Text($0.rawValue).tag($0) }
@@ -137,6 +142,19 @@ struct DiskMapSliceTable: View {
                 } label: {
                     Label("Copy Path", systemImage: "doc.on.doc")
                 }
+                Button {
+                    model.reveal(id)
+                } label: {
+                    Label("Show in Map", systemImage: "rectangle.3.group")
+                }
+                if model.canTrash(id) {
+                    Divider()
+                    Button(role: .destructive) {
+                        model.requestTrash(id)
+                    } label: {
+                        Label("Move to Trash", systemImage: "trash")
+                    }
+                }
             }
         } primaryAction: { ids in
             if let id = ids.first, let path = model.displayPath(of: id) {
@@ -153,7 +171,13 @@ struct DiskMapSliceTable: View {
         let title: String
         let detail: String
         switch model.viewMode {
-        case .map, .largest:
+        case .kinds:
+            title = model.selectedKind == nil ? "Choose a kind" : "Nothing of this kind"
+            detail =
+                model.selectedKind == nil
+                ? "Pick a kind on the left to list its largest items."
+                : "The scan found nothing of this kind."
+        case .map, .largest, .reclaim:
             title = model.filterText.isEmpty ? "Nothing to show" : "No matches"
             detail =
                 model.filterText.isEmpty

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapView.swift
@@ -40,6 +40,26 @@ struct DiskMapView: View {
             model.appear()
         }
         .quickLookPreview($quickLookURL)
+        .confirmationDialog(
+            trashTitle, isPresented: trashConfirming, titleVisibility: .visible
+        ) {
+            Button("Move to Trash", role: .destructive) {
+                if let node = model.pendingTrash { model.performTrash(node) }
+            }
+            Button("Cancel", role: .cancel) { model.pendingTrash = nil }
+        } message: {
+            Text(trashMessage)
+        }
+        .alert(
+            "Couldn\u{2019}t move to the Trash",
+            isPresented: Binding(
+                get: { model.trashError != nil },
+                set: { if !$0 { model.trashError = nil } })
+        ) {
+            Button("OK", role: .cancel) { model.trashError = nil }
+        } message: {
+            Text(model.trashError ?? "")
+        }
         .alert(
             "Scan failed",
             isPresented: Binding(
@@ -50,6 +70,42 @@ struct DiskMapView: View {
         } message: {
             Text(model.lastError ?? "")
         }
+    }
+
+    // MARK: - Trash
+
+    private var trashConfirming: Binding<Bool> {
+        Binding(
+            get: { model.pendingTrash != nil },
+            set: { if !$0 { model.pendingTrash = nil } })
+    }
+
+    private var trashTitle: String {
+        guard let node = model.pendingTrash, let snapshot = model.snapshot,
+            Int(node) < snapshot.tree.nodeCount
+        else { return "Move to the Trash?" }
+        return "Move \u{201C}\(snapshot.tree.name(of: node))\u{201D} to the Trash?"
+    }
+
+    private var trashMessage: String {
+        guard let node = model.pendingTrash, let snapshot = model.snapshot,
+            Int(node) < snapshot.tree.nodeCount
+        else { return "" }
+        let tree = snapshot.tree
+        let i = Int(node)
+        var parts = [ByteFormat.string(tree.bytes[i])]
+        if tree.flags[i].contains(.directory) {
+            parts.append(tree.count[i] == 1 ? "1 item" : "\(tree.count[i].formatted()) items")
+        }
+        var text = parts.joined(separator: ", ") + ". "
+        if let advice = model.advice(for: node), advice.tier == .managedByApp,
+            let how = advice.howToReclaim
+        {
+            text += "\(advice.title) is managed by an app; the recommended way is: \(how) "
+        }
+        text +=
+            "The space is freed when you empty the Trash in Finder, and you can put the item back until then."
+        return text
     }
 
     // MARK: - Toolbar
@@ -199,6 +255,7 @@ struct DiskMapView: View {
             VStack(alignment: .leading, spacing: 10) {
                 DiskMapReconciliationBar(
                     reconciliation: snapshot.reconciliation, scope: snapshot.scope,
+                    inTrashBytes: model.trashedBytes,
                     onGrantAccess: { fullDiskAccess.openSystemSettings() })
                 if snapshot.reconciliation.counts.notPermitted > 0, !fullDiskAccess.isGranted {
                     FullDiskAccessCard(
@@ -215,6 +272,10 @@ struct DiskMapView: View {
                         mapContent(snapshot)
                     case .largest, .oldest:
                         DiskMapSliceTable(model: model)
+                    case .kinds:
+                        DiskMapKindsView(model: model)
+                    case .reclaim:
+                        DiskMapReclaimView(model: model)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -237,6 +298,8 @@ struct DiskMapView: View {
                     TreemapSurface(
                         tree: snapshot.tree, revision: snapshot.revision, zoomRoot: model.zoomRoot,
                         selection: model.selection, colorMode: model.colorMode,
+                        tiers: model.analysis?.revision == snapshot.revision
+                            ? model.analysis?.tiers : nil,
                         onSelect: { model.select($0) },
                         onOpen: { model.zoom(into: $0) },
                         onBack: { model.zoomOut() },
@@ -405,6 +468,11 @@ struct DiskMapView: View {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(path, forType: .string)
             })
+        if model.canTrash(node) {
+            menu.addItem(.separator())
+            menu.addItem(
+                ClosureMenuItem("Move to Trash", symbol: "trash") { model.requestTrash(node) })
+        }
         return menu
     }
 

--- a/Sources/MacPerfMonitor/Views/DiskMap/TreemapSurfaceView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/TreemapSurfaceView.swift
@@ -26,6 +26,8 @@ struct TreemapSurface: NSViewRepresentable {
     let zoomRoot: Int32
     let selection: Int32?
     let colorMode: DiskMapColorMode
+    /// Safety tiers per node from the advisor, for the Safety colour mode.
+    let tiers: [UInt8]?
     let onSelect: (Int32?) -> Void
     let onOpen: (Int32) -> Void
     let onBack: () -> Void
@@ -48,6 +50,7 @@ struct TreemapSurface: NSViewRepresentable {
             onSelect: onSelect, onOpen: onOpen, onBack: onBack, onHover: onHover,
             onQuickLook: onQuickLook, menu: menu)
         view.setTree(tree, revision: revision, zoomRoot: zoomRoot)
+        view.setTiers(tiers)
         view.colorMode = colorMode
         view.selection = selection
     }
@@ -84,6 +87,13 @@ final class TreemapSurfaceView: LiveSurfaceView {
     /// room), so a repaint never formats a byte count or decodes a name.
     private var cellTexts: [CellText?] = []
     private var palette: Palette?
+    private var tiers: [UInt8]?
+
+    func setTiers(_ tiers: [UInt8]?) {
+        let changed = (tiers?.count ?? -1) != (self.tiers?.count ?? -1)
+        self.tiers = tiers
+        if changed, colorMode == .safety { invalidateContent() }
+    }
 
     private struct CellText {
         let name: String
@@ -102,6 +112,8 @@ final class TreemapSurfaceView: LiveSurfaceView {
         let ageLight: [Bool]
         let depth: [CGColor]
         let depthLight: [Bool]
+        let safety: [CGColor]
+        let safetyLight: [Bool]
         let container: CGColor
         let containerBorder: CGColor
         let aggregate: CGColor
@@ -130,6 +142,10 @@ final class TreemapSurfaceView: LiveSurfaceView {
             let depths = (0..<6).map { DiskMapStyle.depthColor(depth: $0, dark: dark) }
             depth = depths.map(\.cgColor)
             depthLight = depths.map(light)
+            let tiersInOrder = DiskMapSafetyTier.allCases.sorted { $0.rawValue < $1.rawValue }
+            let safetyColors = tiersInOrder.map { DiskMapStyle.safetyColor($0, dark: dark) }
+            safety = safetyColors.map(\.cgColor)
+            safetyLight = safetyColors.map(light)
             container = DiskMapStyle.containerFill(dark: dark).cgColor
             containerBorder = DiskMapStyle.containerBorder(dark: dark).cgColor
             let aggregateColor = DiskMapStyle.aggregateFill(dark: dark)
@@ -139,7 +155,8 @@ final class TreemapSurfaceView: LiveSurfaceView {
         }
 
         func fill(
-            kind: FileKind, isDirectory: Bool, modified: UInt32, depth level: Int, now: UInt32
+            kind: FileKind, isDirectory: Bool, modified: UInt32, depth level: Int, tier: Int,
+            now: UInt32
         )
             -> (CGColor, Bool)
         {
@@ -150,6 +167,9 @@ final class TreemapSurfaceView: LiveSurfaceView {
             case .age:
                 let band = DiskMapStyle.ageBand(modified: modified, now: now)
                 return (age[band], ageLight[band])
+            case .safety:
+                let t = min(max(tier, 0), safety.count - 1)
+                return (safety[t], safetyLight[t])
             case .depth:
                 let d = min(max(level, 0), depth.count - 1)
                 return (depth[d], depthLight[d])
@@ -372,9 +392,12 @@ final class TreemapSurfaceView: LiveSurfaceView {
             }
             return
         }
+        let tier =
+            (tiers != nil && i < tiers!.count)
+            ? Int(tiers![i]) : DiskMapSafetyTier.reviewBeforeRemoving.rawValue
         let (fill, light) = palette.fill(
             kind: tree.kind[i], isDirectory: flags.contains(.directory), modified: tree.modified[i],
-            depth: cell.depth, now: now)
+            depth: cell.depth, tier: tier, now: now)
         fillCell(rect, color: fill, in: ctx)
         if flags.contains(.directory), !flags.contains(.smallFilesFold), rect.width >= 40,
             rect.height >= 24

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapAdvisor.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapAdvisor.swift
@@ -1,0 +1,689 @@
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// How safe it is to remove something, from the point of view of someone out
+/// of disk space who wants to act without breaking anything.
+public enum DiskMapSafetyTier: Int, Sendable, CaseIterable, Codable, Comparable {
+    /// Part of macOS or protected by it: cannot or must not be removed.
+    case systemProtected = 0
+    /// Owned by an app that has its own way of reclaiming the space; trashing
+    /// by hand risks corrupting a library or is simply the wrong tool.
+    case managedByApp = 1
+    /// The user's own files: fine to remove, but only after looking.
+    case reviewBeforeRemoving = 2
+    /// Caches, logs and build products that regenerate on demand.
+    case safeToRemove = 3
+
+    public static func < (lhs: DiskMapSafetyTier, rhs: DiskMapSafetyTier) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    public var label: String {
+        switch self {
+        case .systemProtected: return "Protected by macOS"
+        case .managedByApp: return "Managed by an app"
+        case .reviewBeforeRemoving: return "Review before removing"
+        case .safeToRemove: return "Safe to remove"
+        }
+    }
+}
+
+/// What the advisor says about one item.
+public struct DiskMapAdvice: Sendable, Equatable {
+    public var tier: DiskMapSafetyTier
+    /// The rule that matched (for example "Xcode DerivedData"), or a generic
+    /// name when nothing specific did.
+    public var title: String
+    public var reason: String
+    /// The proper way to reclaim the space, when there is one.
+    public var howToReclaim: String?
+    /// Whether the app offers Move to Trash at all.
+    public var canTrash: Bool { tier != .systemProtected }
+}
+
+/// A known location found in a scan, for the Reclaim view.
+public struct DiskMapReclaimItem: Sendable, Equatable, Identifiable {
+    public var id: Int32 { node }
+    public var node: Int32
+    public var bytes: UInt64
+    public var count: UInt32
+    public var advice: DiskMapAdvice
+}
+
+/// Bytes per kind with the biggest items of each, for the Kinds view. Files
+/// inside a package count towards the package's kind (an app's PNGs are
+/// "Applications", not "Images") and the package itself is the item listed.
+public struct DiskMapKindTotal: Sendable, Equatable, Identifiable {
+    public var id: FileKind { kind }
+    public var kind: FileKind
+    public var bytes: UInt64
+    public var count: UInt64
+    /// Largest items of this kind, nodes, largest first.
+    public var topItems: [Int32]
+}
+
+/// Everything the advisor derives from a finished scan in one pass over the
+/// arena: a safety tier per node (rules inherit down the tree), the known
+/// locations for the Reclaim view, and the per-kind totals.
+public struct DiskMapAnalysis: Sendable, Equatable {
+    public var revision: Int
+    /// `DiskMapSafetyTier` raw values, one per node.
+    public var tiers: [UInt8]
+    /// Index into `DiskMapAdvisor.rules` per node, or -1 when only the
+    /// default advice applies.
+    public var ruleIndex: [Int16]
+    public var reclaim: [DiskMapReclaimItem]
+    public var kinds: [DiskMapKindTotal]
+    public var trashedBytes: UInt64
+
+    public func tier(of node: Int32) -> DiskMapSafetyTier {
+        DiskMapSafetyTier(rawValue: Int(tiers[Int(node)])) ?? .reviewBeforeRemoving
+    }
+}
+
+/// Knows which places on a Mac are safe to clear, which belong to an app, and
+/// which must be left alone, and can say why in a sentence. Paths are the
+/// canonical ones (`/Users/...`, not `/System/Volumes/Data/Users/...`).
+public struct DiskMapAdvisor: Sendable {
+    /// One rule. `pattern` is a canonical path with `~` for the home folder;
+    /// a leading `**/` matches at any depth, `*` matches one component, and
+    /// `*.ext` matches a component by extension.
+    public struct Rule: Sendable, Equatable {
+        public var pattern: String
+        public var tier: DiskMapSafetyTier
+        public var title: String
+        public var reason: String
+        public var howToReclaim: String?
+        /// The rule names a file rather than a folder.
+        public var isFile: Bool
+    }
+
+    public let home: String
+    public let rules: [Rule]
+
+    public init(home: String = NSHomeDirectory(), rules: [Rule] = DiskMapAdvisor.defaultRules) {
+        self.home = home.hasSuffix("/") && home.count > 1 ? String(home.dropLast()) : home
+        self.rules = rules
+        var exact: [String: Int] = [:]
+        var byName: [String: [Int]] = [:]
+        var byExtension: [String: [Int]] = [:]
+        for (index, rule) in rules.enumerated() {
+            let expanded =
+                rule.pattern.hasPrefix("~") ? self.home + rule.pattern.dropFirst() : rule.pattern
+            if expanded.hasPrefix("**/") {
+                let tail = String(expanded.dropFirst(3))
+                if tail.hasPrefix("*.") {
+                    byExtension[String(tail.dropFirst(2)).lowercased(), default: []].append(index)
+                } else {
+                    byName[tail, default: []].append(index)
+                }
+            } else if expanded.contains("*") {
+                wildcard.append((expanded.split(separator: "/").map(String.init), index))
+            } else {
+                exact[expanded] = index
+            }
+        }
+        self.exactPaths = exact
+        self.anyDepthNames = byName
+        self.anyDepthExtensions = byExtension
+    }
+
+    private let exactPaths: [String: Int]
+    private let anyDepthNames: [String: [Int]]
+    private let anyDepthExtensions: [String: [Int]]
+    private var wildcard: [(components: [String], rule: Int)] = []
+
+    // MARK: - Single items
+
+    /// Advice for one canonical path, considering its own flags and the rule
+    /// that matches it or its nearest matching ancestor.
+    public func advice(
+        forCanonicalPath path: String, isDirectory: Bool, flags: FileNodeFlags
+    )
+        -> DiskMapAdvice
+    {
+        if let override = flagAdvice(flags) { return override }
+        var components = path.split(separator: "/").map(String.init)
+        var isDir = isDirectory
+        while true {
+            if let index = match(components: components, isDirectory: isDir) {
+                return advice(for: rules[index])
+            }
+            guard !components.isEmpty else { break }
+            components.removeLast()
+            isDir = true
+        }
+        return Self.defaultAdvice
+    }
+
+    /// The hard refusals for Move to Trash, independent of tier: the roots
+    /// and the containers that hold everything, and places already in a Trash.
+    public func isRefusedForTrash(canonicalPath path: String, scanRoot: String) -> Bool {
+        let trimmed = path.count > 1 && path.hasSuffix("/") ? String(path.dropLast()) : path
+        if trimmed == "/" || trimmed == scanRoot || trimmed == home { return true }
+        let fixed: Set<String> = [
+            home + "/Library", home + "/Desktop", home + "/Documents", home + "/Downloads",
+            "/Applications", "/Library", "/System", "/usr", "/usr/local", "/bin", "/sbin",
+            "/private", "/private/var", "/private/etc", "/private/tmp", "/opt", "/Users",
+            "/Volumes", "/System/Volumes/Data", "/cores", "/etc", "/tmp", "/var", "/dev",
+        ]
+        if fixed.contains(trimmed) { return true }
+        if trimmed.hasPrefix("/System/")
+            || trimmed.hasPrefix("/usr/") && !trimmed.hasPrefix("/usr/local/")
+            || trimmed.hasPrefix("/bin/") || trimmed.hasPrefix("/sbin/")
+            || trimmed.hasPrefix("/private/var/db/") || trimmed.hasPrefix("/private/var/vm")
+        {
+            return true
+        }
+        if trimmed.contains("/.Trash/") || trimmed.contains("/.Trashes/")
+            || trimmed.hasSuffix("/.Trash")
+            || trimmed.hasSuffix("/.Trashes")
+        {
+            return true
+        }
+        if let bundle = Self.ownBundlePath, trimmed == bundle || trimmed.hasPrefix(bundle + "/") {
+            return true
+        }
+        return false
+    }
+
+    /// The running app's bundle, never trashed from inside itself.
+    static var ownBundlePath: String? {
+        let path = Bundle.main.bundlePath
+        return path.hasSuffix(".app") ? path : nil
+    }
+
+    // MARK: - Whole-tree analysis
+
+    /// One forward pass (parents precede children): each node's rule is its
+    /// own match or its parent's, tiers follow, Reclaim items are the nodes
+    /// where a rule first applies, and kinds are totalled over leaves with
+    /// packages rolled up.
+    public func analyze(
+        _ snapshot: DiskMapSnapshot, firmlinks: FirmlinkMap = .system
+    ) -> DiskMapAnalysis {
+        let tree = snapshot.tree
+        let n = tree.nodeCount
+        var tiers = [UInt8](
+            repeating: UInt8(DiskMapSafetyTier.reviewBeforeRemoving.rawValue), count: n)
+        var ruleIndex = [Int16](repeating: -1, count: n)
+        var reclaim: [DiskMapReclaimItem] = []
+        var kindBytes = [UInt64](repeating: 0, count: FileKind.allCases.count)
+        var kindCount = [UInt64](repeating: 0, count: FileKind.allCases.count)
+        var kindItems = [[(bytes: UInt64, node: Int32)]](
+            repeating: [], count: FileKind.allCases.count)
+        var trashedBytes: UInt64 = 0
+        guard n > 0 else {
+            return DiskMapAnalysis(
+                revision: snapshot.revision, tiers: [], ruleIndex: [], reclaim: [], kinds: [],
+                trashedBytes: 0)
+        }
+
+        // Canonical path per directory, built from the parent's so no walk up
+        // the tree is ever repeated. Files never need theirs.
+        var directoryPath = [String?](repeating: nil, count: n)
+        let rootPath = firmlinks.canonicalPath(snapshot.rootPath)
+        directoryPath[0] = rootPath
+        // Package roll-up: the kind a node's bytes count towards, when an
+        // ancestor (or the node) is a package.
+        var packageKind = [UInt8](repeating: UInt8.max, count: n)
+        if tree.flags[0].contains(.package) { packageKind[0] = tree.kind[0].rawValue }
+
+        for i in 1..<n {
+            let p = Int(tree.parent[i])
+            let flags = tree.flags[i]
+            let isDirectory = flags.contains(.directory)
+            let isFold = flags.contains(.smallFilesFold)
+
+            // Paths and rules.
+            var own: Int? = nil
+            if isDirectory && !isFold {
+                let parentPath = directoryPath[p] ?? rootPath
+                let name = tree.name(of: Int32(i))
+                let full = firmlinks.canonicalPath(
+                    parentPath == "/" ? "/" + name : parentPath + "/" + name)
+                directoryPath[i] = full
+                own = matchDirectory(path: full, name: name)
+            } else if !isFold {
+                let name = tree.name(of: Int32(i))
+                own = matchFile(name: name, parentPath: directoryPath[p] ?? rootPath)
+            }
+            let inherited = ruleIndex[p]
+            let effective: Int16 = own.map { Int16($0) } ?? inherited
+            ruleIndex[i] = effective
+            var tier: DiskMapSafetyTier
+            if let override = flagAdvice(flags) {
+                tier = override.tier
+            } else if effective >= 0 {
+                tier = rules[Int(effective)].tier
+            } else {
+                tier = .reviewBeforeRemoving
+            }
+            tiers[i] = UInt8(tier.rawValue)
+            if let own, Int16(own) != inherited, tree.bytes[i] > 0, !flags.contains(.trashed) {
+                reclaim.append(
+                    DiskMapReclaimItem(
+                        node: Int32(i), bytes: tree.bytes[i], count: tree.count[i],
+                        advice: advice(for: rules[own])))
+            }
+            // Kinds.
+            if flags.contains(.trashed) {
+                if !isDirectory || packageKind[p] == UInt8.max { trashedBytes &+= tree.bytes[i] }
+                packageKind[i] = packageKind[p]
+                continue
+            }
+            let inheritedKind = packageKind[p]
+            if inheritedKind != UInt8.max {
+                // Inside a package: the package node already counted this
+                // subtree, so only the kind is inherited.
+                packageKind[i] = inheritedKind
+                continue
+            }
+            if flags.contains(.package) {
+                let kind = tree.kind[i]
+                packageKind[i] = kind.rawValue
+                kindBytes[Int(kind.rawValue)] &+= tree.bytes[i]
+                kindCount[Int(kind.rawValue)] &+= 1
+                if tree.bytes[i] > 0 {
+                    kindItems[Int(kind.rawValue)].append((tree.bytes[i], Int32(i)))
+                }
+                continue
+            }
+            if !isDirectory || isFold {
+                let kind = tree.kind[i]
+                kindBytes[Int(kind.rawValue)] &+= tree.bytes[i]
+                kindCount[Int(kind.rawValue)] &+= UInt64(isFold ? tree.count[i] : 1)
+                if !isFold, tree.bytes[i] > 0 {
+                    kindItems[Int(kind.rawValue)].append((tree.bytes[i], Int32(i)))
+                }
+            }
+        }
+
+        reclaim.sort { $0.bytes > $1.bytes }
+        var kinds: [DiskMapKindTotal] = []
+        for kind in FileKind.displayOrder where kindBytes[Int(kind.rawValue)] > 0 {
+            var items = kindItems[Int(kind.rawValue)]
+            items.sort { $0.bytes > $1.bytes }
+            kinds.append(
+                DiskMapKindTotal(
+                    kind: kind, bytes: kindBytes[Int(kind.rawValue)],
+                    count: kindCount[Int(kind.rawValue)],
+                    topItems: items.prefix(Self.topItemsPerKind).map(\.node)))
+        }
+        kinds.sort { $0.bytes > $1.bytes }
+        return DiskMapAnalysis(
+            revision: snapshot.revision, tiers: tiers, ruleIndex: ruleIndex, reclaim: reclaim,
+            kinds: kinds, trashedBytes: trashedBytes)
+    }
+
+    public static let topItemsPerKind = 200
+
+    /// The advice for a node given a finished analysis.
+    public func advice(
+        for node: Int32, in analysis: DiskMapAnalysis, tree: FileTree
+    ) -> DiskMapAdvice {
+        let flags = tree.flags[Int(node)]
+        if let override = flagAdvice(flags) { return override }
+        let index = analysis.ruleIndex[Int(node)]
+        guard index >= 0, Int(index) < rules.count else { return Self.defaultAdvice }
+        return advice(for: rules[Int(index)])
+    }
+
+    // MARK: - Matching
+
+    private func matchDirectory(path: String, name: String) -> Int? {
+        if let exact = exactPaths[path] { return exact }
+        if let named = anyDepthNames[name] {
+            for index in named where !rules[index].isFile { return index }
+        }
+        if let ext = Self.extension(of: name), let byExt = anyDepthExtensions[ext] {
+            for index in byExt where !rules[index].isFile { return index }
+        }
+        if !wildcard.isEmpty {
+            let components = path.split(separator: "/").map(String.init)
+            for entry in wildcard where !rules[entry.rule].isFile {
+                if Self.matches(components, pattern: entry.components) { return entry.rule }
+            }
+        }
+        return nil
+    }
+
+    private func matchFile(name: String, parentPath: String) -> Int? {
+        if let named = anyDepthNames[name] {
+            for index in named where rules[index].isFile { return index }
+        }
+        if let ext = Self.extension(of: name), let byExt = anyDepthExtensions[ext] {
+            for index in byExt where rules[index].isFile { return index }
+        }
+        if let exact = exactPaths[parentPath == "/" ? "/" + name : parentPath + "/" + name],
+            rules[exact].isFile
+        {
+            return exact
+        }
+        if !wildcard.isEmpty {
+            var components = parentPath.split(separator: "/").map(String.init)
+            components.append(name)
+            for entry in wildcard where rules[entry.rule].isFile {
+                if Self.matches(components, pattern: entry.components) { return entry.rule }
+            }
+        }
+        return nil
+    }
+
+    private func match(components: [String], isDirectory: Bool) -> Int? {
+        guard let name = components.last else { return nil }
+        let path = "/" + components.joined(separator: "/")
+        if isDirectory {
+            return matchDirectory(path: path, name: name)
+        }
+        let parent = "/" + components.dropLast().joined(separator: "/")
+        return matchFile(name: name, parentPath: parent)
+    }
+
+    private static func matches(_ components: [String], pattern: [String]) -> Bool {
+        guard components.count == pattern.count else { return false }
+        for (component, token) in zip(components, pattern) {
+            if token == "*" { continue }
+            if token.hasPrefix("*.") {
+                guard let ext = Self.extension(of: component),
+                    ext == token.dropFirst(2).lowercased()
+                else { return false }
+                continue
+            }
+            if token != component { return false }
+        }
+        return true
+    }
+
+    private static func `extension`(of name: String) -> String? {
+        guard let dot = name.lastIndex(of: "."), dot != name.startIndex,
+            name.index(after: dot) < name.endIndex
+        else { return nil }
+        return name[name.index(after: dot)...].lowercased()
+    }
+
+    private func flagAdvice(_ flags: FileNodeFlags) -> DiskMapAdvice? {
+        if flags.contains(.restricted) || flags.contains(.immutable) {
+            return DiskMapAdvice(
+                tier: .systemProtected, title: "Protected by macOS",
+                reason:
+                    "System Integrity Protection locks this item; macOS will not let it be removed.",
+                howToReclaim: nil)
+        }
+        if flags.contains(.separateVolume) {
+            return DiskMapAdvice(
+                tier: .systemProtected, title: "Another volume",
+                reason:
+                    "A volume is mounted here; its contents belong to that volume, not this one.",
+                howToReclaim: "Scan the volume itself from the scope menu.")
+        }
+        if flags.contains(.dataless) {
+            return DiskMapAdvice(
+                tier: .managedByApp, title: "Stored in iCloud",
+                reason: "This item lives in the cloud and takes no local space until downloaded.",
+                howToReclaim: nil)
+        }
+        if flags.contains(.dataVault) {
+            return DiskMapAdvice(
+                tier: .systemProtected, title: "Data vault",
+                reason: "Only Apple's own software may read or change this folder.",
+                howToReclaim: nil)
+        }
+        return nil
+    }
+
+    private func advice(for rule: Rule) -> DiskMapAdvice {
+        DiskMapAdvice(
+            tier: rule.tier, title: rule.title, reason: rule.reason, howToReclaim: rule.howToReclaim
+        )
+    }
+
+    static let defaultAdvice = DiskMapAdvice(
+        tier: .reviewBeforeRemoving, title: "Your files",
+        reason:
+            "Nothing here is known to be a cache or to belong to macOS, so check what it is before removing it.",
+        howToReclaim: "Move it to the Trash, then empty the Trash in Finder to free the space.")
+
+    // MARK: - The rules
+
+    private static func rule(
+        _ pattern: String, _ tier: DiskMapSafetyTier, _ title: String, _ reason: String,
+        how: String? = nil, file: Bool = false
+    ) -> Rule {
+        Rule(
+            pattern: pattern, tier: tier, title: title, reason: reason, howToReclaim: how,
+            isFile: file)
+    }
+
+    public static let defaultRules: [Rule] = [
+        // Protected.
+        rule(
+            "/System", .systemProtected, "macOS", "The operating system itself.",
+            how: nil),
+        rule("/usr", .systemProtected, "macOS", "Unix tools and libraries the system depends on."),
+        rule("/bin", .systemProtected, "macOS", "Core Unix tools."),
+        rule("/sbin", .systemProtected, "macOS", "Core Unix tools."),
+        rule(
+            "/Library/Apple", .systemProtected, "macOS", "Apple software installed with the system."
+        ),
+        rule(
+            "/private/var/vm", .systemProtected, "Virtual memory",
+            "Swap and sleep images; macOS grows and shrinks them itself.",
+            how: "Quitting memory-hungry apps lets macOS release swap."),
+        rule(
+            "/private/var/folders", .systemProtected, "System caches",
+            "Per-user caches and temporary files that macOS manages and clears on restart.",
+            how: "Restart the Mac to let macOS clear what it no longer needs."),
+        rule(
+            "/private/var/db", .systemProtected, "System databases",
+            "Databases macOS keeps for Spotlight, the unified log, updates and more."),
+        rule(
+            "/private/var/db/diagnostics", .systemProtected, "Unified log",
+            "The system log store; macOS trims it on its own schedule."),
+        rule(
+            "/private/var/db/uuidtext", .systemProtected, "Unified log",
+            "Symbol data for the system log; macOS trims it on its own schedule."),
+        rule(
+            "/System/Library/AssetsV2", .systemProtected, "System assets",
+            "Downloaded system content such as simulator runtimes and dictionaries.",
+            how: "Simulator runtimes: xcrun simctl runtime delete <id>."),
+        rule(
+            "/Library/Developer/CoreSimulator/Volumes", .systemProtected, "Simulator runtimes",
+            "Mounted simulator runtime images; their space is in the images, not here."),
+        rule("/Library/Updates", .systemProtected, "macOS updates", "Staged system updates."),
+        // Managed by an app.
+        rule(
+            "**/*.photoslibrary", .managedByApp, "Photos library",
+            "Photos keeps its database and originals in here; changing it by hand corrupts the library.",
+            how:
+                "Delete photos in Photos, then empty its Recently Deleted album, or turn on Optimise Mac Storage."
+        ),
+        rule(
+            "~/Library/Mail", .managedByApp, "Mail",
+            "Mail's downloaded messages and attachments.",
+            how:
+                "In Mail, remove attachments or set Settings > Accounts > Download Attachments to None."
+        ),
+        rule(
+            "~/Library/Messages", .managedByApp, "Messages",
+            "Messages history and attachments.",
+            how:
+                "Messages > Settings > General > Keep Messages, or delete large conversations in Messages."
+        ),
+        rule(
+            "~/Library/Application Support/MobileSync/Backup", .managedByApp,
+            "iPhone and iPad backups",
+            "Local device backups made by Finder.",
+            how: "Finder > the device > Manage Backups to delete old ones safely."),
+        rule(
+            "~/Library/Containers/com.docker.docker/Data/vms/*/data/Docker.raw", .managedByApp,
+            "Docker disk image",
+            "Docker's virtual disk. It is sparse, so its true size is what the map shows.",
+            how: "docker system prune, or Docker Desktop > Settings > Resources to shrink it.",
+            file: true),
+        rule(
+            "~/Library/Developer/CoreSimulator/Devices", .managedByApp, "Simulator devices",
+            "Data of every iOS, watchOS and tvOS simulator created by Xcode.",
+            how: "xcrun simctl delete unavailable, or Xcode > Window > Devices and Simulators."),
+        rule(
+            "/Library/Developer/CoreSimulator/Images", .managedByApp, "Simulator runtime images",
+            "Simulator runtimes downloaded by Xcode.",
+            how: "xcrun simctl runtime delete <id>, or Xcode > Settings > Components."),
+        rule(
+            "/Library/Developer/CoreSimulator/Caches", .managedByApp, "Simulator caches",
+            "Shared caches built for each simulator runtime.",
+            how: "Deleting the runtime removes its cache."),
+        rule(
+            "~/Library/CloudStorage", .managedByApp, "Cloud storage",
+            "Files synced by a cloud provider; removing them here removes them everywhere.",
+            how:
+                "In Finder, choose Remove Download to keep the file in the cloud but free the local copy."
+        ),
+        rule(
+            "~/Library/Mobile Documents", .managedByApp, "iCloud Drive",
+            "iCloud Drive files; removing them here removes them from every device.",
+            how:
+                "In Finder, choose Remove Download to keep the file in iCloud but free the local copy."
+        ),
+        rule(
+            "/opt/homebrew/Cellar", .managedByApp, "Homebrew packages",
+            "Installed Homebrew formulae.",
+            how: "brew uninstall <formula>, brew autoremove, brew cleanup."),
+        rule(
+            "/usr/local/Cellar", .managedByApp, "Homebrew packages",
+            "Installed Homebrew formulae.",
+            how: "brew uninstall <formula>, brew autoremove, brew cleanup."),
+        rule(
+            "**/*.vmwarevm", .managedByApp, "Virtual machine", "A VMware virtual machine.",
+            how: "Delete it from VMware Fusion."),
+        rule(
+            "**/*.pvm", .managedByApp, "Virtual machine", "A Parallels virtual machine.",
+            how: "Delete it from Parallels Desktop."),
+        rule(
+            "**/*.utm", .managedByApp, "Virtual machine", "A UTM virtual machine.",
+            how: "Delete it from UTM."),
+        rule(
+            "**/*.vbvm", .managedByApp, "Virtual machine", "A VirtualBuddy virtual machine.",
+            how: "Delete it from VirtualBuddy."),
+        rule(
+            "~/Library/Application Support/Steam/steamapps", .managedByApp, "Steam games",
+            "Installed games.", how: "Uninstall from Steam."),
+        rule(
+            "~/Music/Music/Media.localized", .managedByApp, "Music library",
+            "Your music library's media.", how: "Remove downloads in Music."),
+        rule(
+            "~/Movies/TV", .managedByApp, "TV downloads", "Downloaded TV app content.",
+            how: "Remove downloads in the TV app."),
+        rule(
+            "~/Library/Group Containers", .managedByApp, "App data",
+            "Data shared between an app and its extensions.",
+            how: "Manage storage inside the app, or remove the app."),
+        // Safe to remove.
+        rule(
+            "~/Library/Caches", .safeToRemove, "User caches",
+            "Caches apps rebuild when they need them.",
+            how: "Quit the apps first; they recreate what they need."),
+        rule(
+            "/Library/Caches", .safeToRemove, "System caches",
+            "Caches shared by all users; rebuilt on demand."),
+        rule(
+            "~/Library/Developer/Xcode/DerivedData", .safeToRemove, "Xcode DerivedData",
+            "Build products and indexes; Xcode rebuilds them on the next build.",
+            how: "Xcode > Settings > Locations > Derived Data, or trash it while Xcode is closed."),
+        rule(
+            "~/Library/Developer/Xcode/iOS DeviceSupport", .safeToRemove, "iOS device support",
+            "Symbols for every iOS version you have debugged; re-downloaded when a device connects.",
+            how: "Keep the folders for OS versions you still debug on."),
+        rule(
+            "~/Library/Developer/Xcode/watchOS DeviceSupport", .safeToRemove,
+            "watchOS device support",
+            "Symbols for every watchOS version you have debugged."),
+        rule(
+            "~/Library/Developer/Xcode/tvOS DeviceSupport", .safeToRemove, "tvOS device support",
+            "Symbols for every tvOS version you have debugged."),
+        rule(
+            "~/Library/Developer/Xcode/iOS Device Logs", .safeToRemove, "Device logs",
+            "Crash and console logs copied from devices."),
+        rule(
+            "~/Library/Developer/CoreSimulator/Caches", .safeToRemove, "Simulator caches",
+            "Caches the simulators rebuild."),
+        rule(
+            "~/Library/Developer/Xcode/Archives", .reviewBeforeRemoving, "Xcode archives",
+            "App archives with the dSYMs needed to symbolicate crash reports for shipped builds.",
+            how: "Keep archives of versions still in use; delete the rest in the Organizer."),
+        rule(
+            "~/Library/Logs", .safeToRemove, "Logs",
+            "Diagnostic logs; new ones are written as needed."),
+        rule("/Library/Logs", .safeToRemove, "System logs", "Shared diagnostic logs."),
+        rule(
+            "~/Library/Caches/Homebrew", .safeToRemove, "Homebrew downloads",
+            "Downloaded bottles and sources.", how: "brew cleanup --prune=all."),
+        rule(
+            "~/Library/Caches/pip", .safeToRemove, "pip cache", "Downloaded Python packages.",
+            how: "pip cache purge."),
+        rule(
+            "~/.npm", .safeToRemove, "npm cache", "Downloaded Node packages.",
+            how: "npm cache clean --force."),
+        rule("~/.cache", .safeToRemove, "Tool caches", "Caches kept by command-line tools."),
+        rule(
+            "~/.cargo/registry", .safeToRemove, "Cargo registry", "Downloaded Rust crates.",
+            how: "cargo cache -a (cargo-cache), or trash it; cargo re-downloads."),
+        rule(
+            "~/.gradle/caches", .safeToRemove, "Gradle caches",
+            "Downloaded dependencies and build caches."),
+        rule(
+            "~/Library/pnpm", .safeToRemove, "pnpm store", "Downloaded Node packages.",
+            how: "pnpm store prune."),
+        rule(
+            "~/.pnpm-store", .safeToRemove, "pnpm store", "Downloaded Node packages.",
+            how: "pnpm store prune."),
+        rule(
+            "~/.yarn/berry/cache", .safeToRemove, "Yarn cache", "Downloaded Node packages.",
+            how: "yarn cache clean."),
+        rule(
+            "~/Library/Caches/CocoaPods", .safeToRemove, "CocoaPods cache", "Downloaded pods.",
+            how: "pod cache clean --all."),
+        rule(
+            "~/.cocoapods/repos", .safeToRemove, "CocoaPods specs",
+            "Podspec repositories; re-cloned on demand."),
+        rule(
+            "**/node_modules", .safeToRemove, "Dependencies (node_modules)",
+            "Installed Node packages for a project; the package manager recreates them.",
+            how: "npm install (or yarn, pnpm) in the project restores them."),
+        rule(
+            "**/DerivedData", .safeToRemove, "DerivedData",
+            "Xcode build products; rebuilt on the next build."),
+        rule(
+            "~/.Trash", .safeToRemove, "Trash",
+            "Items you already removed; the space is not free until the Trash is emptied.",
+            how: "Empty the Trash in Finder."),
+        // Review.
+        rule(
+            "~/Downloads", .reviewBeforeRemoving, "Downloads",
+            "Installers, archives and files you downloaded, often no longer needed.",
+            how: "Trash what you have already installed or copied elsewhere."),
+        rule("~/Desktop", .reviewBeforeRemoving, "Desktop", "Files kept on the Desktop."),
+        rule("~/Documents", .reviewBeforeRemoving, "Documents", "Your documents."),
+        rule(
+            "~/Movies", .reviewBeforeRemoving, "Movies",
+            "Your videos, usually the largest files you own."),
+        rule(
+            "~/Pictures", .reviewBeforeRemoving, "Pictures",
+            "Your photos and images outside Photos."),
+        rule("~/Music", .reviewBeforeRemoving, "Music", "Your music files."),
+        rule(
+            "/Applications", .reviewBeforeRemoving, "Applications",
+            "Installed apps.", how: "Drag an app to the Trash, or use its uninstaller."),
+        rule(
+            "**/*.dmg", .reviewBeforeRemoving, "Disk image",
+            "An installer or disk image, usually disposable once its contents are installed.",
+            file: true),
+        rule(
+            "**/*.iso", .reviewBeforeRemoving, "Disc image", "A disc image, often an OS installer.",
+            file: true),
+        rule(
+            "**/*.ipsw", .reviewBeforeRemoving, "iOS restore image",
+            "A firmware image used to restore a device; re-downloadable.", file: true),
+    ]
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapTrash.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapTrash.swift
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+
+import Darwin
+import Foundation
+
+/// Move to Trash, with the checks that make it safe to offer from a scan
+/// that may be minutes or days old: the item must still be the one the user
+/// looked at (same inode), and it must not be one of the places the app
+/// refuses to touch. Trashing is a same-volume rename into `~/.Trash` or the
+/// volume's `.Trashes`, so it frees nothing until Finder empties the Trash;
+/// callers re-home the bytes into an In Trash bucket rather than subtract
+/// them from the volume.
+public enum DiskMapTrash {
+    public enum Precheck: Equatable, Sendable {
+        /// Safe to proceed.
+        case ok
+        /// The path no longer exists: treat as already gone.
+        case vanished
+        /// Something else now sits at that path (a different inode).
+        case replaced
+        /// One of the hard refusals.
+        case refused(String)
+    }
+
+    public enum Outcome: Equatable, Sendable {
+        case trashed(URL?)
+        case alreadyGone
+        case failed(String)
+    }
+
+    /// Confirm the item at `path` is still the scanned one.
+    public static func precheck(
+        path: String, expectedFileID: UInt64, advisor: DiskMapAdvisor, scanRoot: String
+    ) -> Precheck {
+        if advisor.isRefusedForTrash(canonicalPath: path, scanRoot: scanRoot) {
+            return .refused("\(AppInfoName.short) does not remove this location.")
+        }
+        var st = stat()
+        guard lstat(path, &st) == 0 else {
+            return errno == ENOENT ? .vanished : .refused("The item could not be checked.")
+        }
+        if st.st_flags & UInt32(SF_RESTRICTED) != 0 || st.st_flags & UInt32(SF_IMMUTABLE) != 0 {
+            return .refused("macOS protects this item.")
+        }
+        if expectedFileID != 0, st.st_ino != expectedFileID {
+            return .replaced
+        }
+        return .ok
+    }
+
+    /// Move the item to the Trash as the current user (Put Back works).
+    public static func trash(path: String) -> Outcome {
+        var resulting: NSURL?
+        do {
+            try FileManager.default.trashItem(
+                at: URL(fileURLWithPath: path), resultingItemURL: &resulting)
+            return .trashed(resulting as URL?)
+        } catch let error as CocoaError where error.code == .fileNoSuchFile {
+            return .alreadyGone
+        } catch let error as CocoaError
+            where error.code == .fileReadNoPermission
+            || error.code == .fileWriteNoPermission
+        {
+            return .failed(
+                "macOS did not allow it to be moved. It may belong to another user or be in use.")
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+    }
+}
+
+/// The product name for user-facing copy in Core, where `AppInfo` is not
+/// visible.
+enum AppInfoName {
+    static let short = "Mac Performance Monitor"
+}

--- a/Tests/MacPerfMonitorCoreTests/DiskMapAdvisorTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskMapAdvisorTests.swift
@@ -1,0 +1,253 @@
+import Darwin
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class DiskMapAdvisorTests: XCTestCase {
+    private let advisor = DiskMapAdvisor(home: "/Users/test")
+
+    private func advice(
+        _ path: String, directory: Bool = true, flags: FileNodeFlags = []
+    )
+        -> DiskMapAdvice
+    {
+        advisor.advice(forCanonicalPath: path, isDirectory: directory, flags: flags)
+    }
+
+    func testExactRules() {
+        XCTAssertEqual(advice("/Users/test/Library/Caches").tier, .safeToRemove)
+        XCTAssertEqual(advice("/Users/test/Library/Caches").title, "User caches")
+        XCTAssertEqual(
+            advice("/Users/test/Library/Developer/Xcode/DerivedData").tier, .safeToRemove)
+        XCTAssertEqual(advice("/Users/test/Library/Mail").tier, .managedByApp)
+        XCTAssertEqual(advice("/private/var/vm").tier, .systemProtected)
+        XCTAssertEqual(advice("/Users/test/Downloads").tier, .reviewBeforeRemoving)
+        XCTAssertEqual(advice("/Users/test/Downloads").title, "Downloads")
+    }
+
+    func testAncestorsInherit() {
+        let nested = advice(
+            "/Users/test/Library/Caches/com.apple.Safari/Cache.db", directory: false)
+        XCTAssertEqual(nested.tier, .safeToRemove)
+        XCTAssertEqual(nested.title, "User caches")
+        XCTAssertEqual(advice("/System/Library/Frameworks/Foo.framework").tier, .systemProtected)
+        XCTAssertEqual(advice("/Users/test/Projects/thing").tier, .reviewBeforeRemoving)
+        XCTAssertEqual(advice("/Users/test/Projects/thing").title, "Your files")
+    }
+
+    func testAnyDepthAndExtensionRules() {
+        XCTAssertEqual(advice("/Users/test/Projects/app/node_modules").tier, .safeToRemove)
+        XCTAssertEqual(
+            advice("/Users/test/Projects/app/node_modules/left-pad", directory: true).title,
+            "Dependencies (node_modules)")
+        XCTAssertEqual(
+            advice("/Users/test/Pictures/Photos Library.photoslibrary").tier, .managedByApp)
+        XCTAssertEqual(
+            advice("/Volumes/Ext/Old.photoslibrary/database", directory: false).title,
+            "Photos library")
+        XCTAssertEqual(advice("/Users/test/VMs/Win.pvm").tier, .managedByApp)
+        XCTAssertEqual(
+            advice("/Users/test/Downloads/Xcode.dmg", directory: false).title, "Disk image")
+        XCTAssertEqual(
+            advice("/Users/test/Downloads/Xcode.dmg", directory: false).tier, .reviewBeforeRemoving)
+        // A folder named like a file rule is not a file.
+        XCTAssertEqual(
+            advice("/Users/test/Downloads/Xcode.dmg", directory: true).title, "Downloads")
+    }
+
+    func testWildcardFileRules() {
+        let docker = advice(
+            "/Users/test/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw",
+            directory: false)
+        XCTAssertEqual(docker.title, "Docker disk image")
+        XCTAssertEqual(docker.tier, .managedByApp)
+        XCTAssertNotNil(docker.howToReclaim)
+    }
+
+    func testFlagsOverrideRules() {
+        XCTAssertEqual(
+            advice("/Users/test/Library/Caches/x", flags: [.restricted]).tier, .systemProtected)
+        XCTAssertEqual(advice("/Users/test/Downloads/x", flags: [.dataless]).tier, .managedByApp)
+        XCTAssertEqual(
+            advice("/Users/test/Downloads/x", flags: [.separateVolume]).tier, .systemProtected)
+        XCTAssertFalse(advice("/Users/test/Downloads/x", flags: [.immutable]).canTrash)
+        XCTAssertTrue(advice("/Users/test/Downloads/x").canTrash)
+    }
+
+    func testTrashRefusals() {
+        let root = "/System/Volumes/Data"
+        for path in [
+            "/", "/Users", "/Users/test", "/Users/test/Library", "/Applications", "/Library",
+            "/System", "/System/Library", "/usr", "/usr/bin", "/private/var", "/private/var/db/x",
+            "/Users/test/.Trash", "/Users/test/.Trash/old", "/Volumes/Ext/.Trashes/501/x", root,
+        ] {
+            XCTAssertTrue(advisor.isRefusedForTrash(canonicalPath: path, scanRoot: root), path)
+        }
+        for path in [
+            "/Users/test/Downloads/big.zip", "/Users/test/Library/Caches/foo",
+            "/usr/local/bin/tool",
+            "/opt/homebrew/Cellar/node", "/Applications/Old.app", "/Users/test/Movies/clip.mov",
+        ] {
+            XCTAssertFalse(advisor.isRefusedForTrash(canonicalPath: path, scanRoot: root), path)
+        }
+    }
+
+    // MARK: - Whole-tree analysis
+
+    /// root (/Users/test)
+    ///   Library/
+    ///     Caches/ a 100, b 50          -> safe, one reclaim item (Caches)
+    ///     Mail/ m 30                   -> managed
+    ///   Projects/
+    ///     app/
+    ///       node_modules/ x 40         -> safe, reclaim item
+    ///       Thing.app/ (package, application)
+    ///         Contents/ icon.png 7, bin 3
+    ///     clip.mov 60
+    ///   Downloads/ Xcode.dmg 200       -> Downloads folder (review), dmg file (review, own rule)
+    private func sampleSnapshot() -> DiskMapSnapshot {
+        let b = FileTreeBuilder()
+        b.appendRoot(name: "test", fileID: 1, modified: 0, flags: [])
+        func e(
+            _ name: String, _ bytes: UInt64, dir: Bool = false, flags: FileNodeFlags = [],
+            kind: FileKind = .other
+        ) -> FileTreeBuilder.Entry {
+            FileTreeBuilder.Entry(
+                name: ArraySlice(name.utf8), bytes: bytes, count: 1,
+                flags: dir ? flags.union(.directory) : flags,
+                kind: dir && kind == .other ? .folder : kind)
+        }
+        let top = b.appendChildren(
+            of: 0,
+            [e("Library", 0, dir: true), e("Projects", 0, dir: true), e("Downloads", 0, dir: true)])
+        let library = top.lowerBound
+        let projects = top.lowerBound + 1
+        let downloads = top.lowerBound + 2
+        let lib = b.appendChildren(
+            of: library, [e("Caches", 0, dir: true), e("Mail", 0, dir: true)])
+        b.appendChildren(of: lib.lowerBound, [e("a", 100, kind: .cache), e("b", 50, kind: .cache)])
+        b.appendChildren(of: lib.lowerBound + 1, [e("m", 30, kind: .data)])
+        let proj = b.appendChildren(
+            of: projects, [e("app", 0, dir: true), e("clip.mov", 60, kind: .video)])
+        let app = b.appendChildren(
+            of: proj.lowerBound,
+            [
+                e("node_modules", 0, dir: true),
+                e("Thing.app", 0, dir: true, flags: [.package], kind: .application),
+            ])
+        b.appendChildren(of: app.lowerBound, [e("x", 40, kind: .code)])
+        let contents = b.appendChildren(of: app.lowerBound + 1, [e("Contents", 0, dir: true)])
+        b.appendChildren(
+            of: contents.lowerBound, [e("icon.png", 7, kind: .image), e("bin", 3, kind: .other)])
+        b.appendChildren(of: downloads, [e("Xcode.dmg", 200, kind: .archive)])
+        let tree = b.build()
+        return DiskMapSnapshot(
+            scope: .home, rootPath: "/Users/test", tree: tree,
+            reconciliation: DiskMapReconciliation.compute(
+                scope: .home, mountPoint: "/", volume: nil, allVolumes: [], usedBefore: nil,
+                scannedBytes: tree.bytes[0], sharedBytes: 0, scannedItems: UInt64(tree.count[0]),
+                counts: DiskMapScanCounts(), localSnapshotCount: nil),
+            scannedAt: Date(), duration: 0, partial: false, smallFileThreshold: 0, revision: 3)
+    }
+
+    private func node(_ tree: FileTree, _ name: String) -> Int32 {
+        Int32((0..<tree.nodeCount).first { tree.name(of: Int32($0)) == name }!)
+    }
+
+    func testAnalysisTiersReclaimAndKinds() {
+        let snapshot = sampleSnapshot()
+        let tree = snapshot.tree
+        let analysis = advisor.analyze(snapshot, firmlinks: FirmlinkMap(lines: []))
+        XCTAssertEqual(analysis.revision, 3)
+        XCTAssertEqual(analysis.tiers.count, tree.nodeCount)
+
+        XCTAssertEqual(analysis.tier(of: node(tree, "Caches")), .safeToRemove)
+        XCTAssertEqual(
+            analysis.tier(of: node(tree, "a")), .safeToRemove, "files inherit the folder's rule")
+        XCTAssertEqual(analysis.tier(of: node(tree, "Mail")), .managedByApp)
+        XCTAssertEqual(analysis.tier(of: node(tree, "node_modules")), .safeToRemove)
+        XCTAssertEqual(analysis.tier(of: node(tree, "x")), .safeToRemove)
+        XCTAssertEqual(analysis.tier(of: node(tree, "clip.mov")), .reviewBeforeRemoving)
+        XCTAssertEqual(analysis.tier(of: node(tree, "Xcode.dmg")), .reviewBeforeRemoving)
+        XCTAssertEqual(
+            advisor.advice(for: node(tree, "Xcode.dmg"), in: analysis, tree: tree).title,
+            "Disk image",
+            "a file rule beats the inherited folder rule")
+        XCTAssertEqual(
+            advisor.advice(for: node(tree, "clip.mov"), in: analysis, tree: tree).title,
+            "Your files")
+
+        let reclaimTitles = analysis.reclaim.map(\.advice.title)
+        XCTAssertTrue(reclaimTitles.contains("User caches"))
+        XCTAssertTrue(reclaimTitles.contains("Dependencies (node_modules)"))
+        XCTAssertTrue(reclaimTitles.contains("Mail"))
+        XCTAssertTrue(reclaimTitles.contains("Downloads"))
+        XCTAssertTrue(reclaimTitles.contains("Disk image"))
+        XCTAssertFalse(
+            analysis.reclaim.contains { $0.node == node(tree, "a") },
+            "children of a matched folder are not repeated")
+        XCTAssertEqual(analysis.reclaim.first?.bytes, 200, "largest first")
+        XCTAssertEqual(analysis.reclaim.first { $0.advice.title == "User caches" }?.bytes, 150)
+
+        let kinds = Dictionary(uniqueKeysWithValues: analysis.kinds.map { ($0.kind, $0) })
+        XCTAssertEqual(kinds[.cache]?.bytes, 150)
+        XCTAssertEqual(kinds[.cache]?.count, 2)
+        XCTAssertEqual(kinds[.application]?.bytes, 10, "package contents roll up")
+        XCTAssertEqual(kinds[.application]?.count, 1)
+        XCTAssertEqual(kinds[.application]?.topItems, [node(tree, "Thing.app")])
+        XCTAssertNil(kinds[.image], "the icon inside the app is not an image item")
+        XCTAssertEqual(kinds[.video]?.topItems, [node(tree, "clip.mov")])
+        XCTAssertEqual(kinds[.archive]?.bytes, 200)
+        XCTAssertEqual(analysis.kinds.first?.kind, .archive, "kinds sorted by bytes")
+        XCTAssertEqual(analysis.trashedBytes, 0)
+    }
+
+    func testAnalysisCountsTrashedBytesAndSkipsThem() {
+        var snapshot = sampleSnapshot()
+        let tree = snapshot.tree
+        let dmg = node(tree, "Xcode.dmg")
+        snapshot.tree.markTrashed(dmg)
+        snapshot.revision += 1
+        let analysis = advisor.analyze(snapshot, firmlinks: FirmlinkMap(lines: []))
+        XCTAssertEqual(analysis.trashedBytes, 200)
+        XCTAssertFalse(analysis.reclaim.contains { $0.node == dmg })
+        XCTAssertNil(
+            Dictionary(uniqueKeysWithValues: analysis.kinds.map { ($0.kind, $0) })[.archive])
+    }
+
+    // MARK: - Trash prechecks
+
+    func testTrashPrecheck() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiskMapAdvisorTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("victim.txt")
+        try Data("x".utf8).write(to: file)
+        var st = stat()
+        XCTAssertEqual(lstat(file.path, &st), 0)
+
+        let live = DiskMapAdvisor(home: NSHomeDirectory())
+        XCTAssertEqual(
+            DiskMapTrash.precheck(
+                path: file.path, expectedFileID: st.st_ino, advisor: live, scanRoot: "/x"),
+            .ok)
+        XCTAssertEqual(
+            DiskMapTrash.precheck(
+                path: file.path, expectedFileID: st.st_ino &+ 1, advisor: live, scanRoot: "/x"),
+            .replaced)
+        XCTAssertEqual(
+            DiskMapTrash.precheck(
+                path: root.appendingPathComponent("gone").path, expectedFileID: 1, advisor: live,
+                scanRoot: "/x"),
+            .vanished)
+        if case .refused = DiskMapTrash.precheck(
+            path: "/System", expectedFileID: 0, advisor: live, scanRoot: "/x")
+        {
+        } else {
+            XCTFail("the system folder must be refused")
+        }
+        XCTAssertEqual(
+            DiskMapTrash.trash(path: root.appendingPathComponent("nope").path), .alreadyGone)
+    }
+}

--- a/docs/disk-map-design.md
+++ b/docs/disk-map-design.md
@@ -115,6 +115,40 @@ and no volume figure to reconcile against.
   `NSToolTipManager displayToolTip:` when its timer fired. The hover card
   carries the same information.
 
+## Acting on what the map shows
+
+- `DiskMapAdvisor` holds a rule table of known locations (canonical paths,
+  `~` for home, `**/name` at any depth, `*.ext` by extension) with a tier,
+  a one-sentence reason and the proper way to reclaim the space: caches and
+  build products that regenerate (`safeToRemove`), the user's own files
+  (`reviewBeforeRemoving`, the default), places an app owns and has its own
+  controls for, such as Photos, Mail, iOS backups, Docker.raw, simulator
+  runtimes and cloud folders (`managedByApp`), and macOS itself
+  (`systemProtected`). Flags override rules: SIP-restricted, immutable,
+  mount points and data vaults are protected; dataless items are managed.
+- `analyze(_:)` is one forward pass over the arena: each node's rule is its
+  own match or its parent's (tiers inherit), the Reclaim view lists the nodes
+  where a rule first applies (largest first), and Kinds totals leaf bytes
+  with package contents rolled up into the package (an app's PNGs are
+  "Applications"). The pass also supplies the Safety colour mode's tiers.
+- Move to Trash is `FileManager.trashItem`, as the user, so Put Back works,
+  behind a confirmation that states the size, item count and, for
+  app-managed items, the recommended route instead. Before the move the
+  item is `lstat`ed and its inode compared with the scan's file ID: a
+  mismatch means "changed since the scan" and nothing is moved. A fixed
+  refusal list (volume and scan roots, the home folder and its top-level
+  folders, `/Applications`, `/Library`, `/System`, `/usr` outside
+  `/usr/local`, `/private/var`, anything already in a Trash, the app's own
+  bundle) applies regardless of tier.
+- Trashing frees nothing until Finder empties the Trash (it is a same-volume
+  rename), so the tree is patched in place: the node keeps its own figures
+  and gains `trashed`, its ancestors lose the bytes, the analysis re-homes
+  them into an In Trash chip on the reconciliation bar, and the snapshot's
+  revision bumps so every view follows.
+- Small-files folds cannot be trashed as a unit; the rail lists the files
+  behind a fold live (one `getattrlistbulk` of the directory) so the user
+  can see what is there.
+
 ## Errors, by cause
 
 `EPERM` is privacy protection (TCC): Full Disk Access clears it, and only these


### PR DESCRIPTION
## Summary

Phase 4 of the Disk Map (engine → page → treemap → **act** → remember): the part that answers "which of this can I remove safely".

- **`DiskMapAdvisor`** (Core): a rule table of known locations with four tiers (safe to remove, review, managed by an app, protected by macOS), a reason and a how-to each; flags override rules. `analyze(_:)` is one pass over the arena: tier per node (inherited down the tree), Reclaim items (first match per rule, largest first), per-kind totals with package roll-up, and the bytes already trashed.
- **`DiskMapTrash`** (Core): inode precheck against the scan's file ID ("changed since the scan" if it differs), a fixed refusal list (roots, home and its top-level folders, `/Applications`, `/Library`, `/System`, `/usr` outside `/usr/local`, `/private/var`, anything already in a Trash, the app's own bundle), `FileManager.trashItem` as the user so Put Back works.
- **Views**: Map | Largest | Oldest | **Kinds** | **Reclaim**; the rail's verdict card, Move to Trash (⌘⌫) where allowed, Open in Map / Show in Map, and a live listing of the files behind a small-files fold; a **Safety** colour mode; Move to Trash in every context menu.
- **Trash semantics**: confirmation states size, item count and (for app-managed items) the recommended route; on success the tree is patched in place (node flagged, ancestors decremented, bytes re-homed into an **In Trash** chip on the reconciliation bar, revision bumped). Trashing frees nothing until Finder empties the Trash, and the UI says so.

## Test plan

- [x] `swift test`: 555 tests, 0 failures (9 new: exact / inherited / any-depth / extension / wildcard rules, flag overrides, refusal list, whole-tree analysis incl. package roll-up and trashed bytes, precheck outcomes).
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` clean, no warnings.
- [ ] Live: a display change on the test machine interrupted the screenshot pass for Reclaim/Kinds; the page, model and views build and the earlier live checks (map, rail, restore) still hold. Please exercise Reclaim, Kinds and one Move to Trash on a throwaway folder after installing.

Next: phase 5 (changed-since-last-scan, CHANGELOG, glossary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
