### PR TITLE
Disk Map phase 5: Changes view, unmount handling, changelog; fix Move to Trash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ## [Unreleased]
 
+### Added
+
+- **Disk Map.** The Disk tab has a second page for the question the rest of
+  the tab could not answer: what is using the space. Scan the startup disk,
+  any mounted volume or any folder and see it as a squarified treemap you
+  can zoom into (double-click, Escape, breadcrumbs), coloured by kind, age,
+  safety or depth, with a hover read-out and a detail rail that follows the
+  selection. The numbers are the professional kind: allocated bytes rather
+  than lengths, hard links counted once, clones flagged and, on selection,
+  "would free now" read from the filesystem so a 21 GB clone shows as
+  freeing nothing. A bar reconciles the scan against the volume's used
+  figure (macOS system volumes, purgeable space, shared blocks, folders
+  macOS would not let it read, data vaults) so the total agrees with Finder
+  and every caveat is a chip. Largest and Oldest tables, a Kinds view with
+  app bundles rolled up, a Reclaim view that groups known locations (caches,
+  Xcode DerivedData, simulator runtimes, iOS backups, Docker images, cloud
+  folders, Photos and Mail libraries and more) by how safe they are to
+  remove with the proper way to reclaim each, and a Changes view comparing
+  the scan with the previous one. Reveal in Finder, Quick Look and Move to
+  Trash on every item, the last behind a confirmation and an inode check so
+  a scan that is days old never removes something that replaced what you
+  saw; the space moves to an In Trash figure until Finder empties the Trash.
+  Full Disk Access is requested in context (with the relaunch it needs) and
+  never as a modal; without it the page says exactly which folders were
+  skipped. Scans use `getattrlistbulk` on a handful of utility-priority
+  threads that never download iCloud files: a 3 M-file startup disk takes
+  about twenty seconds and its total matches `du` to the byte, and the last
+  scan comes back instantly on the next open from a compact snapshot file.
+  Shift-Command-D opens it from anywhere.
+
 ### Changed
 
 - **The Analytics grid is drawn with the app's Canvas charts.** It was the

--- a/Sources/MacPerfMonitor/ViewModels/DiskMapModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/DiskMapModel.swift
@@ -52,6 +52,7 @@ final class DiskMapModel: ObservableObject {
         case oldest = "Oldest"
         case kinds = "Kinds"
         case reclaim = "Reclaim"
+        case changes = "Changes"
         var id: String { rawValue }
     }
 
@@ -132,6 +133,18 @@ final class DiskMapModel: ObservableObject {
     /// A node awaiting the Move to Trash confirmation.
     @Published var pendingTrash: Int32?
     @Published var trashError: String?
+    /// The current scan compared with the previous one of the same scope,
+    /// computed on demand when the Changes view opens.
+    @Published private(set) var diff: DiskMapDiff?
+    @Published private(set) var diffState: DiffState = .idle
+
+    enum DiffState: Equatable {
+        case idle
+        case loading
+        case ready
+        /// No previous scan of this scope is on disk yet.
+        case noPrevious
+    }
 
     let advisor = DiskMapAdvisor()
 
@@ -141,8 +154,10 @@ final class DiskMapModel: ObservableObject {
     private var restoreID = UUID()
     private var rowsGeneration = 0
     private var analysisGeneration = 0
+    private var diffGeneration = 0
     private var cancellables = Set<AnyCancellable>()
     private var windowCancellable: AnyCancellable?
+    private var unmountObserver: NSObjectProtocol?
     private weak var fullDiskAccess: FullDiskAccessManager?
 
     private init() {
@@ -165,6 +180,32 @@ final class DiskMapModel: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] _ in self?.rebuildRows() }
             .store(in: &cancellables)
+        $viewMode
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] mode in
+                if mode == .changes { self?.loadDiffIfNeeded() }
+            }
+            .store(in: &cancellables)
+        // A volume that goes away mid-scan: stop rather than report a
+        // partial tree as if the disk had shrunk.
+        unmountObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didUnmountNotification, object: nil, queue: .main
+        ) { [weak self] notification in
+            guard let url = notification.userInfo?[NSWorkspace.volumeURLUserInfoKey] as? URL
+            else { return }
+            Task { @MainActor in self?.volumeDidUnmount(url.path) }
+        }
+    }
+
+    private func volumeDidUnmount(_ mountPoint: String) {
+        guard isScanning else { return }
+        let root = scope.scanRoot
+        let prefix = mountPoint.hasSuffix("/") ? mountPoint : mountPoint + "/"
+        guard root == mountPoint || root.hasPrefix(prefix) else { return }
+        cancelScan()
+        lastError = "\((mountPoint as NSString).lastPathComponent) was ejected during the scan."
+        AppLog.ui.notice("Disk Map scan stopped: volume unmounted \(mountPoint, privacy: .public)")
     }
 
     // MARK: - Lifecycle
@@ -206,6 +247,8 @@ final class DiskMapModel: ObservableObject {
     private func clearSnapshot() {
         snapshot = nil
         analysis = nil
+        diff = nil
+        diffState = .idle
         rows = []
         rowsRevision += 1
         selection = nil
@@ -354,12 +397,15 @@ final class DiskMapModel: ObservableObject {
     private func install(_ snapshot: DiskMapSnapshot) {
         self.snapshot = snapshot
         analysis = nil
+        diff = nil
+        diffState = .idle
         selection = nil
         zoomRoot = FileTree.root
         hover = nil
         pendingTrash = nil
         rebuildRows()
         analyze()
+        if viewMode == .changes { loadDiffIfNeeded() }
     }
 
     private func persist(_ snapshot: DiskMapSnapshot) {
@@ -442,6 +488,30 @@ final class DiskMapModel: ObservableObject {
     }
 
     var trashedBytes: UInt64 { analysis?.trashedBytes ?? 0 }
+
+    // MARK: - Changes since the previous scan
+
+    /// Load the previous snapshot of this scope from disk and diff it against
+    /// the current one, off the main thread; once per snapshot revision.
+    func loadDiffIfNeeded() {
+        guard let snapshot, diffState == .idle || diff.map({ _ in false }) ?? true else { return }
+        guard diffState != .loading else { return }
+        diffState = .loading
+        diffGeneration += 1
+        let generation = diffGeneration
+        let scope = scope
+        Task.detached(priority: .userInitiated) {
+            let previous = try? DiskMapSnapshotStore.load(for: scope, previous: true)
+            let result = previous.map { DiskMapDiff.compute(current: snapshot, previous: $0) }
+            await MainActor.run {
+                guard self.diffGeneration == generation,
+                    self.snapshot?.revision == snapshot.revision
+                else { return }
+                self.diff = result
+                self.diffState = result == nil ? .noPrevious : .ready
+            }
+        }
+    }
 
     // MARK: - Map navigation
 
@@ -579,7 +649,8 @@ final class DiskMapModel: ObservableObject {
         let scanRoot = snapshot.scope.displayRoot
         Task.detached(priority: .userInitiated) {
             let check = DiskMapTrash.precheck(
-                path: path, expectedFileID: fileID, advisor: advisor, scanRoot: scanRoot)
+                path: path, canonicalPath: displayPath, expectedFileID: fileID, advisor: advisor,
+                scanRoot: scanRoot)
             let outcome: DiskMapTrash.Outcome
             switch check {
             case .ok: outcome = DiskMapTrash.trash(path: path)
@@ -681,7 +752,7 @@ final class DiskMapModel: ObservableObject {
         }
 
         switch mode {
-        case .map, .reclaim:
+        case .map, .reclaim, .changes:
             return []
         case .kinds:
             guard let kindItems else { return [] }
@@ -721,14 +792,14 @@ final class DiskMapModel: ObservableObject {
                 if let cutoff, tree.modified[i] > cutoff { continue }
                 if tree.modified[i] == 0 { continue }
                 candidates.append((key: UInt64(tree.modified[i]), node: Int32(i)))
-            case .map, .kinds, .reclaim:
+            case .map, .kinds, .reclaim, .changes:
                 break
             }
         }
         switch mode {
         case .largest: candidates.sort { $0.key > $1.key }
         case .oldest: candidates.sort { $0.key < $1.key }
-        case .map, .kinds, .reclaim: break
+        case .map, .kinds, .reclaim, .changes: break
         }
         return candidates.prefix(limit).map { row($0.node) }
     }

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapChangesView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapChangesView.swift
@@ -1,0 +1,206 @@
+import MacPerfMonitorCore
+import SwiftUI
+
+/// What changed since the previous scan of this scope: the folders and large
+/// files that grew or shrank, largest movement first, with a signed bar. The
+/// flight-recorder answer to "where did 30 GB go this week".
+struct DiskMapChangesView: View {
+    @ObservedObject var model: DiskMapModel
+
+    var body: some View {
+        Group {
+            switch model.diffState {
+            case .idle, .loading:
+                VStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Comparing with the previous scan\u{2026}")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .noPrevious:
+                ContentUnavailableView(
+                    "No earlier scan to compare with", systemImage: "clock.arrow.circlepath",
+                    description: Text(
+                        "The previous scan of \(model.scopeTitle) is kept when you rescan. Scan again later and this view shows what grew and what shrank in between."
+                    ))
+            case .ready:
+                if let diff = model.diff, let snapshot = model.snapshot {
+                    content(diff, snapshot: snapshot)
+                }
+            }
+        }
+        .onAppear { model.loadDiffIfNeeded() }
+    }
+
+    private func content(_ diff: DiskMapDiff, snapshot: DiskMapSnapshot) -> some View {
+        VStack(spacing: 0) {
+            summary(diff)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+            Divider()
+            if diff.grown.isEmpty && diff.shrunk.isEmpty {
+                ContentUnavailableView(
+                    "Nothing moved by 10 MB or more", systemImage: "equal.circle",
+                    description: Text(
+                        "Between the two scans no folder or large file changed size enough to show."
+                    ))
+            } else {
+                List(selection: selectionBinding) {
+                    if !diff.grown.isEmpty {
+                        Section {
+                            ForEach(diff.grown) { entry in
+                                row(entry, diff: diff, snapshot: snapshot)
+                                    .tag(entry.node ?? -1)
+                            }
+                        } header: {
+                            sectionHeader("Grew", entries: diff.grown, tint: .orange)
+                        }
+                    }
+                    if !diff.shrunk.isEmpty {
+                        Section {
+                            ForEach(diff.shrunk) { entry in
+                                row(entry, diff: diff, snapshot: snapshot)
+                                    .tag(entry.node ?? -1)
+                            }
+                        } header: {
+                            sectionHeader("Shrank or gone", entries: diff.shrunk, tint: .green)
+                        }
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+    }
+
+    private func summary(_ diff: DiskMapDiff) -> some View {
+        let when = diff.previousScannedAt.formatted(date: .abbreviated, time: .shortened)
+        let delta = diff.totalDelta
+        return HStack(alignment: .firstTextBaseline, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Since \(when)")
+                    .font(.subheadline.weight(.semibold))
+                Text(
+                    "\(ByteFormat.string(diff.totalBefore)) then, \(ByteFormat.string(diff.totalAfter)) now"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text(signed(delta))
+                .font(.title3.monospacedDigit().weight(.semibold))
+                .foregroundStyle(delta > 0 ? .orange : (delta < 0 ? .green : .secondary))
+        }
+    }
+
+    private func sectionHeader(
+        _ title: String, entries: [DiskMapDiffEntry], tint: Color
+    ) -> some View {
+        let total = entries.reduce(Int64(0)) { $0 + $1.delta }
+        return HStack(spacing: 8) {
+            Circle().fill(tint).frame(width: 8, height: 8)
+            Text(title)
+                .font(.caption.weight(.semibold))
+            Text(signed(total))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+            Text("\(entries.count) entries")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Spacer()
+        }
+        .textCase(nil)
+    }
+
+    private func row(
+        _ entry: DiskMapDiffEntry, diff: DiskMapDiff, snapshot: DiskMapSnapshot
+    )
+        -> some View
+    {
+        let largest = max(
+            abs(diff.grown.first?.delta ?? 0), abs(diff.shrunk.first?.delta ?? 0), 1)
+        let fraction = Double(abs(entry.delta)) / Double(largest)
+        let tint: Color = entry.delta > 0 ? .orange : .green
+        let name =
+            entry.relativePath.isEmpty
+            ? snapshot.scope.rootName : (entry.relativePath as NSString).lastPathComponent
+        let location =
+            entry.relativePath.isEmpty
+            ? snapshot.scope.displayRoot
+            : FirmlinkMap.system.canonicalPath(
+                snapshot.rootPath == "/"
+                    ? "/" + (entry.relativePath as NSString).deletingLastPathComponent
+                    : snapshot.rootPath + "/"
+                        + (entry.relativePath as NSString).deletingLastPathComponent)
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: entry.isDirectory ? "folder" : "doc")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14)
+                Text(name)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if entry.isNew {
+                    badge("new")
+                } else if entry.isGone {
+                    badge("gone")
+                }
+                Text(location)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 8)
+                Text(
+                    "\(ByteFormat.string(entry.before)) \u{2192} \(ByteFormat.string(entry.after))"
+                )
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+                Text(signed(entry.delta))
+                    .font(.subheadline.monospacedDigit().weight(.semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 90, alignment: .trailing)
+            }
+            GroupProportionBar(fraction: fraction, tint: tint)
+        }
+        .padding(.vertical, 3)
+        .contentShape(Rectangle())
+        .contextMenu {
+            if let node = entry.node {
+                Button {
+                    model.reveal(node)
+                } label: {
+                    Label("Show in Map", systemImage: "rectangle.3.group")
+                }
+                Button {
+                    ProcessActions.revealInFinder(path: snapshot.displayPath(of: node))
+                } label: {
+                    Label("Reveal in Finder", systemImage: "folder")
+                }
+            }
+        }
+    }
+
+    private func badge(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(.quaternary))
+            .foregroundStyle(.secondary)
+    }
+
+    private func signed(_ delta: Int64) -> String {
+        if delta == 0 { return "no change" }
+        let magnitude = ByteFormat.string(UInt64(abs(delta)))
+        return delta > 0 ? "+\(magnitude)" : "\u{2212}\(magnitude)"
+    }
+
+    private var selectionBinding: Binding<Int32?> {
+        Binding(
+            get: { model.selection },
+            set: { model.select(($0 ?? -1) < 0 ? nil : $0) })
+    }
+}

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapTables.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapTables.swift
@@ -39,7 +39,7 @@ struct DiskMapSliceTable: View {
     private var controls: some View {
         HStack(spacing: 12) {
             switch model.viewMode {
-            case .map, .reclaim:
+            case .map, .reclaim, .changes:
                 EmptyView()
             case .kinds:
                 if let kind = model.selectedKind {
@@ -177,7 +177,7 @@ struct DiskMapSliceTable: View {
                 model.selectedKind == nil
                 ? "Pick a kind on the left to list its largest items."
                 : "The scan found nothing of this kind."
-        case .map, .largest, .reclaim:
+        case .map, .largest, .reclaim, .changes:
             title = model.filterText.isEmpty ? "Nothing to show" : "No matches"
             detail =
                 model.filterText.isEmpty

--- a/Sources/MacPerfMonitor/Views/DiskMap/DiskMapView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskMap/DiskMapView.swift
@@ -276,6 +276,8 @@ struct DiskMapView: View {
                         DiskMapKindsView(model: model)
                     case .reclaim:
                         DiskMapReclaimView(model: model)
+                    case .changes:
+                        DiskMapChangesView(model: model)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapDiff.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapDiff.swift
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// One path whose size moved between two scans.
+public struct DiskMapDiffEntry: Sendable, Equatable, Identifiable {
+    public var id: String { relativePath }
+    /// Path relative to the scan root, `""` for the root itself.
+    public var relativePath: String
+    /// The node in the current tree, nil when the item is gone.
+    public var node: Int32?
+    public var before: UInt64
+    public var after: UInt64
+    public var isDirectory: Bool
+
+    public var delta: Int64 { Int64(after) - Int64(before) }
+    public var isNew: Bool { before == 0 }
+    public var isGone: Bool { after == 0 && node == nil }
+}
+
+/// What changed between the last two scans of a scope: the flight-recorder
+/// angle. Directories and large files are compared by path; every entry
+/// whose size moved by at least `minimumDelta` is listed, largest movement
+/// first, so "Library grew 30 GB" sits next to "Library/Caches grew 28 GB"
+/// and the eye can follow the growth down.
+public struct DiskMapDiff: Sendable, Equatable {
+    public var previousScannedAt: Date
+    public var currentScannedAt: Date
+    public var totalBefore: UInt64
+    public var totalAfter: UInt64
+    /// Entries that grew, largest growth first.
+    public var grown: [DiskMapDiffEntry]
+    /// Entries that shrank or disappeared, largest shrink first.
+    public var shrunk: [DiskMapDiffEntry]
+
+    public var totalDelta: Int64 { Int64(totalAfter) - Int64(totalBefore) }
+
+    public static let defaultMinimumDelta: UInt64 = 10 * 1024 * 1024
+
+    /// Compare two snapshots of the same scope. Files below `minimumDelta`
+    /// are never indexed (their movement is invisible at that threshold and
+    /// they are most of the entries), so the index holds directories plus
+    /// the large files only.
+    public static func compute(
+        current: DiskMapSnapshot, previous: DiskMapSnapshot,
+        minimumDelta: UInt64 = defaultMinimumDelta, limit: Int = 200
+    ) -> DiskMapDiff {
+        let before = index(previous.tree, minimumBytes: minimumDelta)
+        let after = index(current.tree, minimumBytes: minimumDelta)
+
+        var grown: [DiskMapDiffEntry] = []
+        var shrunk: [DiskMapDiffEntry] = []
+        for (path, now) in after {
+            let was = before[path]?.bytes ?? 0
+            guard now.bytes != was else { continue }
+            let magnitude = now.bytes > was ? now.bytes - was : was - now.bytes
+            guard magnitude >= minimumDelta else { continue }
+            let entry = DiskMapDiffEntry(
+                relativePath: path, node: now.node, before: was, after: now.bytes,
+                isDirectory: now.isDirectory)
+            if now.bytes > was { grown.append(entry) } else { shrunk.append(entry) }
+        }
+        // Gone: in the previous index, not in the current one. Only the
+        // top-most gone path is listed; its descendants went with it.
+        var gone: [DiskMapDiffEntry] = []
+        for (path, was) in before where after[path] == nil && was.bytes >= minimumDelta {
+            gone.append(
+                DiskMapDiffEntry(
+                    relativePath: path, node: nil, before: was.bytes, after: 0,
+                    isDirectory: was.isDirectory))
+        }
+        if !gone.isEmpty {
+            let gonePaths = Set(gone.map(\.relativePath))
+            gone.removeAll { entry in
+                var parent = entry.relativePath
+                while let slash = parent.lastIndex(of: "/") {
+                    parent = String(parent[..<slash])
+                    if gonePaths.contains(parent) { return true }
+                }
+                return false
+            }
+            shrunk.append(contentsOf: gone)
+        }
+        // Largest movement first; among equal movements the shallower path
+        // (the folder before the child that grew inside it), then by name, so
+        // the order is stable across runs.
+        grown.sort { a, b in
+            a.delta != b.delta ? a.delta > b.delta : shallowerFirst(a, b)
+        }
+        shrunk.sort { a, b in
+            a.delta != b.delta ? a.delta < b.delta : shallowerFirst(a, b)
+        }
+        return DiskMapDiff(
+            previousScannedAt: previous.scannedAt, currentScannedAt: current.scannedAt,
+            totalBefore: previous.tree.bytes.first ?? 0, totalAfter: current.tree.bytes.first ?? 0,
+            grown: Array(grown.prefix(limit)), shrunk: Array(shrunk.prefix(limit)))
+    }
+
+    private static func shallowerFirst(_ a: DiskMapDiffEntry, _ b: DiskMapDiffEntry) -> Bool {
+        let depthA = a.relativePath.isEmpty ? 0 : a.relativePath.filter { $0 == "/" }.count + 1
+        let depthB = b.relativePath.isEmpty ? 0 : b.relativePath.filter { $0 == "/" }.count + 1
+        return depthA != depthB ? depthA < depthB : a.relativePath < b.relativePath
+    }
+
+    struct Indexed {
+        var bytes: UInt64
+        var node: Int32
+        var isDirectory: Bool
+    }
+
+    /// Relative path to size for every directory and every large file. Paths
+    /// are built from the parent's in one forward pass; the root is `""`.
+    static func index(_ tree: FileTree, minimumBytes: UInt64) -> [String: Indexed] {
+        let n = tree.nodeCount
+        var result: [String: Indexed] = [:]
+        guard n > 0 else { return result }
+        result.reserveCapacity(min(n, 1 << 19))
+        var directoryPath = [String?](repeating: nil, count: n)
+        directoryPath[0] = ""
+        result[""] = Indexed(bytes: tree.bytes[0], node: 0, isDirectory: true)
+        for i in 1..<n {
+            let flags = tree.flags[i]
+            if flags.contains(.smallFilesFold) || flags.contains(.trashed) { continue }
+            let isDirectory = flags.contains(.directory)
+            if !isDirectory, tree.bytes[i] < minimumBytes { continue }
+            let parentPath = directoryPath[Int(tree.parent[i])] ?? ""
+            let name = tree.name(of: Int32(i))
+            let path = parentPath.isEmpty ? name : parentPath + "/" + name
+            if isDirectory { directoryPath[i] = path }
+            result[path] = Indexed(bytes: tree.bytes[i], node: Int32(i), isDirectory: isDirectory)
+        }
+        return result
+    }
+}

--- a/Sources/MacPerfMonitorCore/DiskMap/DiskMapTrash.swift
+++ b/Sources/MacPerfMonitorCore/DiskMap/DiskMapTrash.swift
@@ -28,11 +28,16 @@ public enum DiskMapTrash {
         case failed(String)
     }
 
-    /// Confirm the item at `path` is still the scanned one.
+    /// Confirm the item at `path` (the path to open on disk, which on the
+    /// startup disk is under `/System/Volumes/Data`) is still the scanned one.
+    /// The refusal list is judged on `canonicalPath`, the path the user
+    /// knows; judging it on the Data-volume path would refuse everything
+    /// under `/System/`.
     public static func precheck(
-        path: String, expectedFileID: UInt64, advisor: DiskMapAdvisor, scanRoot: String
+        path: String, canonicalPath: String, expectedFileID: UInt64, advisor: DiskMapAdvisor,
+        scanRoot: String
     ) -> Precheck {
-        if advisor.isRefusedForTrash(canonicalPath: path, scanRoot: scanRoot) {
+        if advisor.isRefusedForTrash(canonicalPath: canonicalPath, scanRoot: scanRoot) {
             return .refused("\(AppInfoName.short) does not remove this location.")
         }
         var st = stat()

--- a/Tests/MacPerfMonitorCoreTests/DiskMapAdvisorTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskMapAdvisorTests.swift
@@ -230,24 +230,43 @@ final class DiskMapAdvisorTests: XCTestCase {
         let live = DiskMapAdvisor(home: NSHomeDirectory())
         XCTAssertEqual(
             DiskMapTrash.precheck(
-                path: file.path, expectedFileID: st.st_ino, advisor: live, scanRoot: "/x"),
+                path: file.path, canonicalPath: file.path, expectedFileID: st.st_ino,
+                advisor: live, scanRoot: "/x"),
             .ok)
         XCTAssertEqual(
             DiskMapTrash.precheck(
-                path: file.path, expectedFileID: st.st_ino &+ 1, advisor: live, scanRoot: "/x"),
+                path: file.path, canonicalPath: file.path, expectedFileID: st.st_ino &+ 1,
+                advisor: live, scanRoot: "/x"),
             .replaced)
         XCTAssertEqual(
             DiskMapTrash.precheck(
-                path: root.appendingPathComponent("gone").path, expectedFileID: 1, advisor: live,
-                scanRoot: "/x"),
+                path: root.appendingPathComponent("gone").path,
+                canonicalPath: root.appendingPathComponent("gone").path, expectedFileID: 1,
+                advisor: live, scanRoot: "/x"),
             .vanished)
         if case .refused = DiskMapTrash.precheck(
-            path: "/System", expectedFileID: 0, advisor: live, scanRoot: "/x")
+            path: "/System", canonicalPath: "/System", expectedFileID: 0, advisor: live,
+            scanRoot: "/x")
         {
         } else {
             XCTFail("the system folder must be refused")
         }
         XCTAssertEqual(
             DiskMapTrash.trash(path: root.appendingPathComponent("nope").path), .alreadyGone)
+        // The startup disk is scanned at /System/Volumes/Data, so the path on
+        // disk starts with /System/ while the user's path does not; the
+        // refusal list must be judged on the latter or everything is refused.
+        XCTAssertEqual(
+            DiskMapTrash.precheck(
+                path: file.path, canonicalPath: "/Users/someone/Downloads/victim.txt",
+                expectedFileID: st.st_ino, advisor: live, scanRoot: "/"),
+            .ok)
+        if case .refused = DiskMapTrash.precheck(
+            path: file.path, canonicalPath: "/System/Volumes/Data" + file.path,
+            expectedFileID: st.st_ino, advisor: live, scanRoot: "/")
+        {
+        } else {
+            XCTFail("a /System path is refused, which is why the canonical one must be passed")
+        }
     }
 }

--- a/Tests/MacPerfMonitorCoreTests/DiskMapDiffTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/DiskMapDiffTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+final class DiskMapDiffTests: XCTestCase {
+    private let mb: UInt64 = 1024 * 1024
+
+    /// Builds root/{Docs/{a,b}, Media/{clip}, extras...} with the given sizes.
+    private func snapshot(
+        docsA: UInt64, docsB: UInt64, clip: UInt64, extra: [(String, UInt64)] = [],
+        mediaPresent: Bool = true, at date: Date
+    ) -> DiskMapSnapshot {
+        let b = FileTreeBuilder()
+        b.appendRoot(name: "root", fileID: 1, modified: 0, flags: [])
+        func e(_ name: String, _ bytes: UInt64, dir: Bool = false) -> FileTreeBuilder.Entry {
+            FileTreeBuilder.Entry(
+                name: ArraySlice(name.utf8), bytes: bytes, count: 1,
+                flags: dir ? [.directory] : [], kind: dir ? .folder : .other)
+        }
+        var top = [e("Docs", 0, dir: true)]
+        if mediaPresent { top.append(e("Media", 0, dir: true)) }
+        for (name, bytes) in extra { top.append(e(name, bytes)) }
+        let range = b.appendChildren(of: 0, top)
+        b.appendChildren(of: range.lowerBound, [e("a", docsA), e("b", docsB)])
+        if mediaPresent {
+            let media = range.lowerBound + 1
+            let sub = b.appendChildren(of: media, [e("Raw", 0, dir: true), e("clip", clip)])
+            b.appendChildren(of: sub.lowerBound, [e("r1", 20 * mb), e("r2", 20 * mb)])
+        }
+        let tree = b.build()
+        return DiskMapSnapshot(
+            scope: .folder("/x"), rootPath: "/x", tree: tree,
+            reconciliation: DiskMapReconciliation.compute(
+                scope: .folder("/x"), mountPoint: "/", volume: nil, allVolumes: [], usedBefore: nil,
+                scannedBytes: tree.bytes[0], sharedBytes: 0, scannedItems: 0,
+                counts: DiskMapScanCounts(), localSnapshotCount: nil),
+            scannedAt: date, duration: 0, partial: false, smallFileThreshold: 0, revision: 1)
+    }
+
+    func testGrowthShrinkageNewAndGone() {
+        let earlier = Date(timeIntervalSince1970: 1_000)
+        let later = Date(timeIntervalSince1970: 2_000)
+        let previous = snapshot(docsA: 100 * mb, docsB: 50 * mb, clip: 500 * mb, at: earlier)
+        let current = snapshot(
+            docsA: 400 * mb, docsB: 50 * mb, clip: 300 * mb, extra: [("new.iso", 1_000 * mb)],
+            at: later)
+        let diff = DiskMapDiff.compute(current: current, previous: previous)
+
+        XCTAssertEqual(diff.previousScannedAt, earlier)
+        XCTAssertEqual(diff.currentScannedAt, later)
+        XCTAssertEqual(diff.totalBefore, 690 * mb)
+        XCTAssertEqual(diff.totalAfter, 1_790 * mb)
+        XCTAssertEqual(diff.totalDelta, Int64(1_100 * mb))
+
+        let grownPaths = diff.grown.map(\.relativePath)
+        XCTAssertEqual(grownPaths.first, "", "the root grew the most")
+        XCTAssertTrue(grownPaths.contains("new.iso"))
+        XCTAssertTrue(grownPaths.contains("Docs"))
+        XCTAssertTrue(grownPaths.contains("Docs/a"))
+        XCTAssertFalse(grownPaths.contains("Docs/b"), "unchanged files are not listed")
+        let newISO = diff.grown.first { $0.relativePath == "new.iso" }!
+        XCTAssertTrue(newISO.isNew)
+        XCTAssertEqual(newISO.delta, Int64(1_000 * mb))
+        XCTAssertNotNil(newISO.node)
+        let docs = diff.grown.first { $0.relativePath == "Docs" }!
+        XCTAssertTrue(docs.isDirectory)
+        XCTAssertEqual(docs.before, 150 * mb)
+        XCTAssertEqual(docs.after, 450 * mb)
+
+        let shrunkPaths = diff.shrunk.map(\.relativePath)
+        XCTAssertEqual(
+            shrunkPaths, ["Media", "Media/clip"], "largest shrink first, sub-folder unchanged")
+        XCTAssertEqual(diff.shrunk[1].delta, -Int64(200 * mb))
+    }
+
+    func testGoneItemsListOnlyTheTopMostPath() {
+        let previous = snapshot(docsA: 100 * mb, docsB: 50 * mb, clip: 500 * mb, at: Date())
+        let current = snapshot(
+            docsA: 100 * mb, docsB: 50 * mb, clip: 0, mediaPresent: false, at: Date())
+        let diff = DiskMapDiff.compute(current: current, previous: previous)
+        let gone = diff.shrunk.filter(\.isGone)
+        XCTAssertEqual(gone.map(\.relativePath), ["Media"], "Media/Raw and Media/clip went with it")
+        XCTAssertEqual(gone.first?.before, 540 * mb)
+        XCTAssertNil(gone.first?.node)
+        XCTAssertTrue(diff.grown.isEmpty)
+    }
+
+    func testThresholdAndLimit() {
+        let previous = snapshot(docsA: 100 * mb, docsB: 50 * mb, clip: 500 * mb, at: Date())
+        let current = snapshot(docsA: 100 * mb + 5 * mb, docsB: 50 * mb, clip: 500 * mb, at: Date())
+        let quiet = DiskMapDiff.compute(current: current, previous: previous)
+        XCTAssertTrue(quiet.grown.isEmpty, "a 5 MB move is below the 10 MB default")
+        let sensitive = DiskMapDiff.compute(current: current, previous: previous, minimumDelta: mb)
+        XCTAssertEqual(sensitive.grown.map(\.relativePath), ["", "Docs", "Docs/a"])
+        let capped = DiskMapDiff.compute(
+            current: current, previous: previous, minimumDelta: mb, limit: 1)
+        XCTAssertEqual(capped.grown.count, 1)
+    }
+
+    func testIdenticalScansHaveNoEntries() {
+        let a = snapshot(docsA: 100 * mb, docsB: 50 * mb, clip: 500 * mb, at: Date())
+        let diff = DiskMapDiff.compute(current: a, previous: a)
+        XCTAssertTrue(diff.grown.isEmpty)
+        XCTAssertTrue(diff.shrunk.isEmpty)
+        XCTAssertEqual(diff.totalDelta, 0)
+    }
+
+    func testIndexSkipsSmallFilesFoldsAndTrashedItems() {
+        var current = snapshot(docsA: 100 * mb, docsB: 50 * mb, clip: 500 * mb, at: Date())
+        let clip = Int32(
+            (0..<current.tree.nodeCount).first { current.tree.name(of: Int32($0)) == "clip" }!)
+        current.tree.markTrashed(clip)
+        let index = DiskMapDiff.index(current.tree, minimumBytes: 30 * mb)
+        XCTAssertNil(index["Media/clip"], "trashed items are not compared")
+        XCTAssertNil(index["Media/Raw/r1"], "below the threshold")
+        XCTAssertNotNil(index["Media/Raw"])
+        XCTAssertEqual(index["Media"]?.bytes, 40 * mb, "the trashed clip left the folder total")
+    }
+}

--- a/docs/disk-map-design.md
+++ b/docs/disk-map-design.md
@@ -149,6 +149,24 @@ and no volume figure to reconcile against.
   behind a fold live (one `getattrlistbulk` of the directory) so the user
   can see what is there.
 
+## Remembering
+
+- Every completed scan is written to
+  `~/Library/Application Support/MacPerformanceMonitor/diskmap/<scope>.mpmdisk`
+  (`DiskMapSnapshotCodec`: raw arrays plus JSON under LZFSE, caps and
+  structural validation on load, mode 0600) and the previous file is kept as
+  `.prev`. The page restores the last scan instantly on open and drops it
+  when the window closes.
+- The Changes view (`DiskMapDiff`) indexes directories and files of at
+  least 10 MB in both snapshots by path relative to the scan root, lists
+  every entry whose size moved by at least that much (largest movement
+  first, so a folder and the child that grew inside it appear together),
+  and lists a disappeared subtree once, at its top-most path. Trashed nodes
+  and folds are left out. The comparison runs on demand when the view opens,
+  off the main thread, once per snapshot revision.
+- A volume unmounted while its scan runs stops the scan with a message
+  rather than finishing a partial tree that would read as a shrunken disk.
+
 ## Errors, by cause
 
 `EPERM` is privacy protection (TCC): Full Disk Access clears it, and only these


### PR DESCRIPTION
## Summary

Phase 5 of the Disk Map (engine → page → treemap → act → **remember**), plus a fix for a phase 4 bug found in use.

- **`DiskMapDiff`** (Core): compares the current scan with the previous one of the same scope (`.prev`), directories and files ≥ 10 MB by relative path, largest movement first with a deterministic tie-break, a disappeared subtree listed once at its top-most path. 5 tests.
- **Changes view**: summary (then, now, delta), Grew / Shrank or gone sections with signed bars and new/gone badges, Show in Map and Reveal in Finder, computed on demand off the main thread, once per revision.
- **Unmount**: a volume ejected mid-scan stops the scan with a message.
- **Fix, Move to Trash refused everything on the startup disk**: the button and the confirmation judged the canonical path, but the final precheck received the on-disk path under `/System/Volumes/Data`, which the refusal list rejects as `/System/`. The precheck now takes both and judges on the canonical path; regression test added.
- CHANGELOG entry for the Disk Map; design notes gain the remembering section.

## Test plan

- [x] `swift test`: 560 tests, 0 failures (5 new diff tests, 1 new regression).
- [x] `swift format lint --strict --recursive Sources Tests Package.swift` clean.
- [ ] Live: Move to Trash on a throwaway item (dev build relaunched with the fix), then Changes after a rescan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
