### PR TITLE
Release 1.6.0: the Disk Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-31
+
 ### Added
 
 - **Disk Map.** The Disk tab has a second page for the question the rest of
@@ -626,6 +628,7 @@ processes behind them.
   builds, tests, and lints on every push and pull request.
 
 [Unreleased]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.5.0.198...HEAD
+[1.6.0]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.5.0.198...v1.6.0.204
 [1.5.0]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.4.0.197...v1.5.0.198
 [1.4.0]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.3.8.189...v1.4.0.197
 [1.3.8]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.3.7.186...v1.3.8.189

--- a/Casks/mac-performance-monitor.rb
+++ b/Casks/mac-performance-monitor.rb
@@ -1,6 +1,6 @@
 cask "mac-performance-monitor" do
-  version "1.5.0.198"
-  sha256 "362db29f38a34a1970fcdb9b81b7f62dfd6fd1f3ac8c9cc2b32effb196d86a60"
+  version "1.6.0.204"
+  sha256 "71c9eb07bd8043f6de6536027669dbdae836f867be29538e08df4ba7500b267e"
 
   url "https://github.com/Zesty0wl/mac-performance-monitor/releases/download/v#{version}/MacPerformanceMonitor.pkg"
   name "Mac Performance Monitor"

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -30,9 +30,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>203</string>
+	<string>204</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>
@@ -60,26 +60,26 @@
 		<string>_homekit._tcp</string>
 		<string>_hap._tcp</string>
 	</array>
-	<key>NSHighResolutionCapable</key>
-	<true/>
-	<key>NSHumanReadableCopyright</key>
-	<string>Mac Performance Monitor. No telemetry. All data stays on your Mac.</string>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>Scan your selected local subnet to identify devices and available services.</string>
 	<key>NSDesktopFolderUsageDescription</key>
 	<string>The Disk Map measures what is using space on your Desktop so it can show the largest items there.</string>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>The Disk Map measures what is using space in Documents so it can show the largest items there.</string>
 	<key>NSDownloadsFolderUsageDescription</key>
 	<string>The Disk Map measures what is using space in Downloads so it can show the largest items there.</string>
-	<key>NSRemovableVolumesUsageDescription</key>
-	<string>The Disk Map can measure what is using space on external drives you choose to scan.</string>
-	<key>NSNetworkVolumesUsageDescription</key>
-	<string>The Disk Map can measure what is using space on network volumes you choose to scan.</string>
 	<key>NSFileProviderDomainUsageDescription</key>
 	<string>The Disk Map lists cloud-synced folders by name and size without downloading anything.</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Mac Performance Monitor. No telemetry. All data stays on your Mac.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Scan your selected local subnet to identify devices and available services.</string>
+	<key>NSNetworkVolumesUsageDescription</key>
+	<string>The Disk Map can measure what is using space on network volumes you choose to scan.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSRemovableVolumesUsageDescription</key>
+	<string>The Disk Map can measure what is using space on external drives you choose to scan.</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>


### PR DESCRIPTION
## Summary

Cut 1.6.0 (build 204): version bump, the CHANGELOG's Unreleased section dated as 1.6.0 with its compare link, and the Homebrew cask pinned to `v1.6.0.204` with the notarized pkg's sha256.

The app and pkg are already built, Developer ID signed, notarized and stapled locally (`deploy.sh --minor --skip-upload`); after this merges, `deploy.sh --resume` publishes the GitHub release from this commit so the tag lands on the release source.

## Test plan

- [x] Full suite green on main before branching (560 tests); this PR touches only CHANGELOG, Info.plist and the cask.
- [x] Notarization: app and pkg both Accepted and stapled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
