### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,35 @@ Notable changes to Mac Performance Monitor. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.7.0] - 2026-09-01
 
 ### Added
 
-- Simplified Chinese localization, contributed by @zbsdsb, with a language picker
-  in Settings (Follow System, English, or 简体中文). The Disk Map, its Full Disk
-  Access flow, and the advisor's guidance are fully translated, and the app
-  relaunches into the chosen language reliably.
-- A translations guide in CONTRIBUTING.md: adding a language is one pull request.
+- Simplified Chinese localization, and a language picker in Settings (Follow
+  System, English, or 简体中文). Contributed by @zbsdsb, who wrote the original
+  translation, and extended by @Maybe404 to cover the interface text that
+  reaches the screen as String values rather than as literals SwiftUI can
+  resolve on its own. The Disk Map, its Full Disk Access flow and the advisor's
+  guidance are all translated.
+- A translations guide in CONTRIBUTING.md. New languages are on hold for a
+  short while during a move to String Catalogs; existing translations carry
+  across unchanged.
+
+### Fixed
+
+- The setup wizard had no visible way to finish. The final step had outgrown
+  its window, so the step icon was clipped and the footer, including the
+  primary button, sat below the bottom edge. Step content now scrolls with the
+  footer pinned, and the flow ends on a closing card offering Close and Open
+  Dashboard.
+- Installing or updating through Homebrew failed with a checksum mismatch. The
+  cask recorded the checksum of a build made before notarization, and
+  stapling changes the file. deploy.sh now derives the checksum from the
+  installer it actually published.
+- Building without an Apple Developer certificate produced an app that was
+  killed at launch, because ad-hoc signing with Hardened Runtime cannot load
+  the bundled Sparkle framework. Contributed by @Maybe404. This affected
+  contributors, not released builds.
 
 ## [1.6.0] - 2026-08-31
 
@@ -636,6 +656,7 @@ processes behind them.
   builds, tests, and lints on every push and pull request.
 
 [Unreleased]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.5.0.198...HEAD
+[1.7.0]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.6.0.204...v1.7.0.205
 [1.6.0]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.5.0.198...v1.6.0.204
 [1.5.0]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.4.0.197...v1.5.0.198
 [1.4.0]: https://github.com/Zesty0wl/mac-performance-monitor/compare/v1.3.8.189...v1.4.0.197

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -37,9 +37,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>204</string>
+	<string>205</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>


### PR DESCRIPTION
Version 1.7.0 (build 205).

- Simplified Chinese localization and a language picker, from @zbsdsb (#37) and @Maybe404 (#51)
- The setup wizard now has a visible ending (#53)
- Homebrew checksum fix so `brew install` works (#49)
- Ad-hoc build launch fix for contributors without a certificate (#50)

The app is already built, signed, notarized and stapled locally. Once this merges, `deploy.sh --resume` publishes the release from this commit, then writes the corrected cask checksum as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ