### PR TITLE
Point the Homebrew cask at v1.7.0.205

### DIFF
--- a/Casks/mac-performance-monitor.rb
+++ b/Casks/mac-performance-monitor.rb
@@ -1,6 +1,6 @@
 cask "mac-performance-monitor" do
-  version "1.6.0.204"
-  sha256 "9904e2d1bc28c1e4bf66d1d4dde12d71766d425bb482c2458e5fd60caa88f926"
+  version "1.7.0.205"
+  sha256 "da9ad510ed95f4bbced4de02e254c81b2d903bc703ba510e3ef2538aa49d1d01"
 
   url "https://github.com/Zesty0wl/mac-performance-monitor/releases/download/v#{version}/MacPerformanceMonitor.pkg"
   name "Mac Performance Monitor"


### PR DESCRIPTION
Follow-up to the 1.7.0 release. `deploy.sh` derived this checksum from the installer it actually uploaded, and I verified it independently by downloading the published asset: `da9ad510…` matches the cask, the local build, and what GitHub serves.

Homebrew reads the cask from the default branch, so `brew install` and `brew upgrade` fail until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ