### PR TITLE
Format numbers and plurals in the reader's language

### DIFF
--- a/Sources/MacPerfMonitorCore/Util/ByteFormat.swift
+++ b/Sources/MacPerfMonitorCore/Util/ByteFormat.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 /// Human-readable byte formatting shared across the CLI and UI.
+///
+/// Every numeric format passes `locale: .current` deliberately. `String(format:)`
+/// without a locale formats in the POSIX locale, so "1.4 GB" stays "1.4 GB" for
+/// a reader whose language writes "1,4 GB". Simplified Chinese uses the same
+/// decimal separator as English, so this was invisible until the second
+/// language; German, French, Spanish and Russian all show it.
 public enum ByteFormat {
     /// Format a byte count using binary units (KiB/MiB/GiB), e.g. "1.4 GB".
     /// Uses the conventional macOS labels (GB) while computing on 1024 bases,
@@ -16,12 +22,13 @@ public enum ByteFormat {
         if unitIndex == 0 {
             return "\(bytes) bytes"
         }
-        return String(format: "%.\(fractionDigits)f %@", value, units[unitIndex])
+        return String(
+            format: "%.\(fractionDigits)f %@", locale: .current, value, units[unitIndex])
     }
 
     /// Format a fraction (0...1) as a percentage string, e.g. "42%".
     public static func percent(_ fraction: Double, fractionDigits: Int = 0) -> String {
-        String(format: "%.\(fractionDigits)f%%", fraction * 100)
+        String(format: "%.\(fractionDigits)f%%", locale: .current, fraction * 100)
     }
 
     /// Format a throughput (bytes per second) for charts, menus, and tooltips,
@@ -36,7 +43,8 @@ public enum ByteFormat {
             unitIndex += 1
         }
         if unitIndex == 0 { return "\(Int(value.rounded())) B/s" }
-        return String(format: "%.\(fractionDigits)f %@", value, units[unitIndex])
+        return String(
+            format: "%.\(fractionDigits)f %@", locale: .current, value, units[unitIndex])
     }
 
     /// A very compact throughput for the cramped menu bar read-out: number plus a
@@ -52,7 +60,9 @@ public enum ByteFormat {
             unitIndex += 1
         }
         if unitIndex == 0 { return "\(Int(value.rounded()))" }
-        if value < 10 { return String(format: "%.1f%@", value, units[unitIndex]) }
-        return String(format: "%.0f%@", value, units[unitIndex])
+        if value < 10 {
+            return String(format: "%.1f%@", locale: .current, value, units[unitIndex])
+        }
+        return String(format: "%.0f%@", locale: .current, value, units[unitIndex])
     }
 }

--- a/Sources/MacPerfMonitorCore/Util/Localization.swift
+++ b/Sources/MacPerfMonitorCore/Util/Localization.swift
@@ -40,7 +40,7 @@ public func t(_ key: String) -> String {
 /// live inside the key rather than arrive as an argument: splicing an English
 /// fragment (" is" / "es are") into a sentence cannot survive translation.
 public func t(_ key: String, _ arguments: CVarArg...) -> String {
-    String(format: t(key), arguments: arguments)
+    String(format: t(key), locale: LocalizationTable.currentLocale, arguments: arguments)
 }
 
 /// The `.lproj` bundle `t(_:)` reads, cached until the language changes.
@@ -51,9 +51,27 @@ public func t(_ key: String, _ arguments: CVarArg...) -> String {
 /// System": it already honours the Mac's preferred-language list, and after the
 /// launch preflight re-executes with `-AppleLanguages` it resolves to the chosen
 /// language on its own.
-private enum LocalizationTable {
+enum LocalizationTable {
     private static let lock = NSLock()
     private static var cached: (language: String, bundle: Bundle)?
+
+    /// The locale that matches the chosen language.
+    ///
+    /// This has to be passed to every `String(format:)` explicitly. Without it
+    /// the format uses the POSIX locale, which gets two things wrong outside
+    /// English: numbers print with the wrong decimal separator ("1.4 GB" where
+    /// a German reader expects "1,4 GB"), and, more seriously, a `.stringsdict`
+    /// plural is resolved with the WRONG LANGUAGE'S rules. The plural engine
+    /// keys off the locale handed to the format, not the bundle the string came
+    /// out of, so looking a Russian string up in `ru.lproj` while formatting
+    /// with a non-Russian locale selects English categories: 5 renders as
+    /// "5 ядра" (few) instead of "5 ядер" (many). Simplified Chinese cannot
+    /// expose this, because it has a single plural form, so any rule picks the
+    /// same string.
+    static var currentLocale: Locale {
+        let choice = UserDefaults.standard.string(forKey: appLanguageDefaultsKey) ?? "system"
+        return choice == "system" ? .autoupdatingCurrent : Locale(identifier: choice)
+    }
 
     static var current: Bundle {
         let choice = UserDefaults.standard.string(forKey: appLanguageDefaultsKey) ?? "system"


### PR DESCRIPTION
Two locale bugs that Simplified Chinese cannot expose, both of which surface the moment a third language is added. Worth fixing now that the String Catalog makes real per-language plural rules available.

**`t(_:_:)` formatted with the POSIX locale.** That is wrong for decimal separators across most of Europe, and it is worse than cosmetic for plurals: the plural engine keys off the locale handed to `String(format:)`, **not** the bundle the string came from. So a Russian string looked up in `ru.lproj` but formatted without a Russian locale gets English plural categories:

| n | correct | before this change |
|---|---|---|
| 1 | 1 ядро | 1 ядро |
| 5 | 5 ядер (many) | 5 ядра |
| 21 | 21 ядро (one) | 21 ядра |

Chinese has a single plural form, so any rule selects the same string and the bug is invisible in the languages we ship today.

**`ByteFormat` had the same POSIX problem** for every size, rate and percentage. Verified after the change:

    en_GB: 1.4 GB
    de_DE: 1,4 GB
    fr_FR: 1,4 GB

Build, 560 tests, strict lint and the localization check all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ