### PR TITLE
Fix two localization bugs the compiler found, and add the check that finds them

### DIFF
--- a/Localizations/Localizable.xcstrings
+++ b/Localizations/Localizable.xcstrings
@@ -2341,6 +2341,24 @@
         }
       }
     },
+    "%lld cores": {
+      "comment": "Identity entries: English renders the key verbatim. Present so the two tables mirror each other and English copy stays auditable in one place; check-localization.py enforces the parity.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld cores"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 个核心"
+          }
+        }
+      }
+    },
     "%lld entries": {
       "comment": "Disk Map (1.6.0)",
       "extractionState": "manual",
@@ -2481,6 +2499,24 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 个受 macOS 保护"
+          }
+        }
+      }
+    },
+    "%lld supported": {
+      "comment": "Identity entries: English renders the key verbatim. Present so the two tables mirror each other and English copy stays auditable in one place; check-localization.py enforces the parity.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld supported"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持 %lld 项"
           }
         }
       }

--- a/Scripts/check-string-coverage.py
+++ b/Scripts/check-string-coverage.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Report UI strings the app looks up but the String Catalog does not carry.
+
+check-localization.py scans source text for lookups, which finds the strings
+passed to t(). It cannot see what SwiftUI does to an interpolated literal: the
+compiler decides the key, and it is not always what a human would write.
+`Text("\\(count) cores")` looks up `%lld cores`, not `%@ cores`, so a
+translation filed under the second form is never found and the string silently
+renders in English forever.
+
+This asks the compiler instead. It builds with -emit-localized-strings, which
+is the same extraction Xcode uses, and compares the keys the compiler actually
+emits against the catalog.
+
+    Scripts/check-string-coverage.py
+    Scripts/check-string-coverage.py --all   # include punctuation-only keys
+
+Keys with no letters in them (" / ", "%@ · %@") are composition rather than
+copy and are hidden by default.
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CATALOG = os.path.join(ROOT, "Localizations/Localizable.xcstrings")
+
+
+def compiler_keys(destination):
+    """Every localization key the Swift compiler emits, key -> source file."""
+    print("building with -emit-localized-strings ...", file=sys.stderr)
+    result = subprocess.run(
+        ["swift", "build",
+         "-Xswiftc", "-emit-localized-strings",
+         "-Xswiftc", "-emit-localized-strings-path",
+         "-Xswiftc", destination],
+        cwd=ROOT, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stderr[-2000:], file=sys.stderr)
+        raise SystemExit("build failed")
+    found = {}
+    for path in glob.glob(os.path.join(destination, "*.stringsdata")):
+        raw = subprocess.run(["plutil", "-convert", "json", "-o", "-", path],
+                             capture_output=True).stdout
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        origin = os.path.basename(path).replace(".stringsdata", "")
+        for table in data.get("tables", {}).values():
+            for entry in table:
+                if isinstance(entry, dict) and "key" in entry:
+                    found.setdefault(entry["key"], origin)
+    return found
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--all", action="store_true",
+                        help="include keys with no letters in them")
+    args = parser.parse_args()
+
+    with open(CATALOG, encoding="utf-8") as handle:
+        catalog = set(json.load(handle)["strings"])
+
+    with tempfile.TemporaryDirectory() as destination:
+        emitted = compiler_keys(destination)
+
+    missing = {k: v for k, v in emitted.items() if k not in catalog}
+    if not args.all:
+        missing = {k: v for k, v in missing.items() if re.search(r"[A-Za-z]{3}", k)}
+
+    print(f"keys the compiler emits: {len(emitted)}")
+    print(f"keys in the catalog:     {len(catalog)}")
+    print(f"not carried:             {len(missing)}")
+    if missing:
+        print("\nThese render in English in every language:")
+        for key in sorted(missing, key=lambda k: (missing[k], k)):
+            print(f"  [{missing[key]}] {key!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Sources/MacPerfMonitor/Views/HardwareView.swift
+++ b/Sources/MacPerfMonitor/Views/HardwareView.swift
@@ -475,8 +475,14 @@ private struct HardwareFeatureCloud: View {
     let query: String
 
     var body: some View {
-        let supported = properties.filter { $0.value == "Supported" }
-        let missing = properties.filter { $0.value != "Supported" }
+        // Compare against the same translated word the reader sees, not the
+        // English literal. HardwareNativeReaders sets this value with
+        // t("Supported"), so on a Chinese system it is "支持" and an English
+        // comparison matches nothing: every ISA feature would be reported as
+        // unsupported.
+        let supportedValue = t("Supported")
+        let supported = properties.filter { $0.value == supportedValue }
+        let missing = properties.filter { $0.value != supportedValue }
         VStack(alignment: .leading, spacing: 12) {
             Text("\(supported.count) supported")
                 .font(.caption)


### PR DESCRIPTION
Prompted by @Maybe404's comment on #51. Both claims checked out, and chasing them turned up a user-visible bug.

## 1. `%lld` vs `%@` (confirmed)

SwiftUI generates `%lld` for an interpolated `Int`, so `Text("\(count) cores")` looks up **`%lld cores`**. The catalog only carried `%@ cores`, so those sites rendered English in every language and nothing flagged it.

Both keys are genuine and both now exist: Core's `t("%@ cores", "\(cores)")` passes a **String** and correctly needs `%@`; the SwiftUI site needs `%lld`. My first attempt renamed one into the other, which would have broken Core; the checker caught the resulting specifier mismatch, which is a decent sign the guard works.

## 2. A comparison against a translated string (worse, and shipped in 1.7.0)

`HardwareFeatureCloud` filtered on the English literal:

```swift
let supported = properties.filter { /bin/zsh.value == "Supported" }
```

but `HardwareNativeReaders` sets that value with `t("Supported")`, which is `支持` on a Chinese system. The comparison matched nothing, so **every ISA feature was listed as unsupported and the supported count read zero**.

This is exactly the failure class I went looking for when reviewing #51 and reported as absent. It was present, one file away from where I looked. A sweep of `.value ==` / `.label ==` style comparisons found no other instance.

## 3. The check that found them

`Scripts/check-string-coverage.py` builds with `-emit-localized-strings`, the same extraction Xcode performs, and compares the keys the compiler **actually emits** against the catalog. Scanning source text cannot find these, because the compiler decides the key.

It currently reports **123 keys** the app looks up but the catalog does not carry: `Start`, `End`, `Value`, `Signal`, `Gateway`, `Running`, `Timeline`, `Dropped` and similar. Those render in English for every language today. I have not added them here, because they need real translations rather than invented ones; filing them as contributor work instead.

Build, 560 tests, strict lint and the localization check all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ