### PR TITLE
Point the README at the homebrew-cask install now the cask is accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ launches without security warnings, and keeps itself up to date via Sparkle.
 ### Homebrew
 
 ```sh
-brew tap zesty0wl/mac-performance-monitor https://github.com/Zesty0wl/mac-performance-monitor
-brew install --cask zesty0wl/mac-performance-monitor/mac-performance-monitor
+brew install --cask mac-performance-monitor
 ```
 
-This installs the same signed, notarized pkg. A submission to the main
-[homebrew-cask](https://github.com/Homebrew/homebrew-cask) repository is in
-progress (see `docs/homebrew-submission.md`); once accepted, the tap step won't
-be needed and `brew install --cask mac-performance-monitor` will just work.
+This installs the same signed, notarized pkg from the main
+[homebrew-cask](https://github.com/Homebrew/homebrew-cask) repository. Homebrew's
+bump bot picks up each new release within a few hours, and the app keeps itself
+current through Sparkle in between, so `brew upgrade` leaves it alone unless you
+pass `--greedy`.
 
 ### Build from source
 

--- a/docs/homebrew-submission.md
+++ b/docs/homebrew-submission.md
@@ -1,10 +1,12 @@
 # Homebrew submission
 
-How Mac Performance Monitor gets into Homebrew, and how the cask stays current
-afterwards. The canonical cask lives in this repository at
-`Casks/mac-performance-monitor.rb`; the copy submitted to
-[Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask) is
-identical.
+How Mac Performance Monitor got into Homebrew, and how the cask stays current
+afterwards. The cask was accepted into
+[Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask) on
+2026-09-03 ([PR #283646](https://github.com/Homebrew/homebrew-cask/pull/283646)),
+so `brew install --cask mac-performance-monitor` works without a tap. The
+canonical cask still lives in this repository at
+`Casks/mac-performance-monitor.rb`; the homebrew-cask copy is identical.
 
 ## Why a cask (not a formula)
 
@@ -85,20 +87,29 @@ brew untap local/test
 ## After acceptance
 
 - Users install with `brew install --cask mac-performance-monitor`.
-- Homebrew's autobump bot uses the `livecheck` block to open version-bump
-  PRs automatically when a new GitHub release appears, so a normal
-  `Scripts/deploy.sh` release needs no manual Homebrew work. If a bump is
-  ever needed by hand:
+- Homebrew's bump bot (BrewTestBot) follows the GitHub release URL and opens
+  version-bump PRs on its own when a new release appears. No `livecheck`
+  block is needed: the bot bumped 1.5.0.198 to 1.7.0.205 about five hours
+  after the new cask merged. A normal `Scripts/deploy.sh` release therefore
+  needs no manual Homebrew work. If a bump is ever needed by hand:
   `brew bump-cask-pr mac-performance-monitor --version <X.Y.Z.B>`.
 - Keep `Casks/mac-performance-monitor.rb` in this repo in sync when the
   stanzas change (new uninstall paths, changed minimum macOS), and mirror
   such changes into homebrew-cask with a PR.
 
-## Until the PR is merged
+## The tap in this repository
 
-The cask in this repository is directly installable today:
+The cask here is still installable through the tap, and `Scripts/deploy.sh`
+rewrites its version and checksum on every release, so it is always the
+first place a new build appears:
 
 ```sh
 brew tap zesty0wl/mac-performance-monitor https://github.com/Zesty0wl/mac-performance-monitor
 brew install --cask zesty0wl/mac-performance-monitor/mac-performance-monitor
 ```
+
+People who installed from the tap before the homebrew-cask merge need do
+nothing. Homebrew resolves a bare cask name to homebrew-cask first and never
+treats it as ambiguous with a third-party tap (`Cask::CaskLoader::FromNameLoader`),
+and `auto_updates true` means Sparkle keeps existing installs current
+regardless of which tap they came from.


### PR DESCRIPTION
The cask was accepted into Homebrew/homebrew-cask on 2026-09-03 (Homebrew/homebrew-cask#283646) and BrewTestBot bumped it to 1.7.0.205 the same morning (Homebrew/homebrew-cask#284936), so `brew install --cask mac-performance-monitor` now works with no tap.

- README: the Homebrew section is the one-line install, with a note that the bot follows releases and Sparkle handles updates in between.
- docs/homebrew-submission.md: records the acceptance, corrects the claim that autobump needs a `livecheck` block (the bot bumped without one), and replaces "Until the PR is merged" with a section on the tap, including why existing tap installs need no action (Homebrew resolves a bare name to homebrew-cask first and never treats it as ambiguous with a third-party tap).

No code or cask changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ