### PR TITLE
Write the catalog in Xcode's layout from the rename tool

### DIFF
--- a/Scripts/rename-localization-key.py
+++ b/Scripts/rename-localization-key.py
@@ -99,9 +99,18 @@ def main():
         return 0
 
     strings[args.new] = strings.pop(args.old)
+    # Xcode and Crowdin both write the catalog with a space on either side of
+    # the colon and no trailing newline. Matching that byte for byte keeps a
+    # rename from showing up as a whole-file rewrite in the diff.
     with open(CATALOG, "w", encoding="utf-8") as handle:
-        json.dump(catalog, handle, ensure_ascii=False, indent=2, sort_keys=True)
-        handle.write("\n")
+        json.dump(
+            catalog,
+            handle,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            separators=(",", " : "),
+        )
     for path, _, updated in edits:
         with open(path, "w", encoding="utf-8") as handle:
             handle.write(updated)


### PR DESCRIPTION
Crowdin's first pull request (#63) rewrote every line of `Localizations/Localizable.xcstrings` while changing nothing semantic. The cause is on our side: the catalog was written by Python with `": "` separators, while Xcode and Crowdin both write `" : "` and no trailing newline. Once #63 lands the file is in Xcode's layout, and the rename tool would have flipped it back on its next use.

This makes `Scripts/rename-localization-key.py` write Xcode's layout. `json.dumps(..., separators=(",", " : "))` reproduces Crowdin's file byte for byte, verified against the #63 head. A rename-and-rename-back round trip leaves the catalog semantically identical and in Xcode's layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ