### PR TITLE
Make CI run on Crowdin pull requests

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -14,6 +14,18 @@
 project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN
 
+# Crowdin's default commit message ends in "[ci skip]", which GitHub Actions
+# honours, so the localization check and the catalog compile would never run
+# on a Crowdin pull request. Replacing the message (append_commit_message:
+# false) drops that tag. These PRs are the one place a broken plural or a
+# mismatched format specifier can arrive from outside the repository, so CI
+# must run on them.
+commit_message: "Update translations from Crowdin"
+append_commit_message: false
+pull_request_title: "Translations from Crowdin"
+pull_request_labels:
+  - "translations"
+
 preserve_hierarchy: true
 
 files:


### PR DESCRIPTION
Crowdin's first sync (#63) opened a pull request whose commit message ends in Crowdin's default skip tag (the words "ci skip" in square brackets). GitHub Actions honours that tag, so the localization check and the catalog compile never ran on the one kind of PR most likely to carry a broken plural variation or a mismatched format specifier.

The integration panel says the message is controlled by `commit_message` in the configuration file, and Crowdin's docs confirm that `append_commit_message: false` replaces the default message and drops the tag. This sets both, names the PR "Translations from Crowdin", and labels it `translations` (label created).

No code changes. Crowdin reads `crowdin.yml` from the branch on each sync, so this takes effect on the next one.

Note to self, learned the hard way: the first commit on this branch quoted the tag literally in its message, so GitHub skipped CI on this PR as well. Never write the tag verbatim in a commit message or PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ