### PR TITLE
Point translators at the Crowdin project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,10 +120,24 @@ source-language value, which is what stops the key itself leaking to the screen.
 
 ### Crowdin
 
-`crowdin.yml` configures the project's Crowdin integration. Crowdin reads and
-writes the catalog directly and opens a pull request on an `l10n_` branch; it
-never commits to the default branch. `multilingual: true` is load-bearing:
-without it Crowdin splits the catalog into one file per language.
+Translators can work at https://crowdin.com/project/mac-performance-monitor instead of
+editing the catalog. `crowdin.yml` configures the integration: Crowdin reads
+and writes the catalog directly and opens a pull request titled "Translations
+from Crowdin" on the `l10n_main` branch, about once an hour when something has
+changed. It never commits to the default branch. Two lines there are
+load-bearing. `multilingual: true` stops Crowdin splitting the catalog into one
+file per language, and `append_commit_message: false` removes the CI-skip tag
+Crowdin adds to commits by default, so CI runs on its pull requests.
+
+Maintainer notes for the Crowdin project settings: the GitHub integration has
+"Always import new translations from the repository" and "Allow target
+translation to match source" switched on. The second matters because Crowdin
+otherwise skips translations identical to the English (CPU, USB, Wi-Fi and the
+like) and reports the language as incomplete. When someone asks for a new
+language, add it as a target language in the Crowdin project, add its `case` to
+`AppLanguage` in `Sources/MacPerfMonitor/Settings/AppLanguageManager.swift`,
+and once it is complete add it to `COMPLETE_LANGUAGES` in
+`Scripts/check-localization.py`.
 
 ## Submitting changes
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) and the
 [SECURITY.md](SECURITY.md).
 
 Translations are community-contributed: the app ships in English and Simplified
-Chinese, and adding your language means editing one file. See
-[TRANSLATING.md](TRANSLATING.md).
+Chinese. Translate in your browser on
+[Crowdin](https://crowdin.com/project/mac-performance-monitor), or edit one file and open a
+pull request. See [TRANSLATING.md](TRANSLATING.md).
 
 ## License
 

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -8,12 +8,36 @@ Localizations/Localizable.xcstrings
 
 That is an Apple **String Catalog**: a JSON document holding every key, the
 English source text, and one entry per language. There are no per-language
-folders to keep in sync, and adding a language does not touch any Swift code.
+folders to keep in sync, and adding a language touches one line of Swift, for
+the Settings picker, which we are happy to do for you.
 
 You do not need Xcode to translate. You do need it to build the app, because
 the catalog is compiled by `xcstringstool`, which ships inside Xcode.
 
-## Adding a language
+## The easy way: Crowdin
+
+You can translate in a web editor with no git, no JSON and no Xcode:
+
+**https://crowdin.com/project/mac-performance-monitor**
+
+Sign in (a GitHub account works), pick your language, and start. The editor
+shows the English, a note on where the string appears in the app, protected
+placeholders for the format specifiers, and one box per plural form your
+language needs. About once an hour Crowdin opens a pull request here with
+whatever changed; we review it like any other, and your strings ship in the
+next release.
+
+If your language is not listed, open an issue asking for it. Only the
+maintainers can add a target language, and we will do it the same day. We also
+add the Settings picker entry when the first strings for a new language land,
+so on Crowdin you never touch code.
+
+Pick one route per language. If a language is being translated on Crowdin,
+send corrections there rather than as catalog pull requests, so the two do not
+overwrite each other. Everything below describes the GitHub route, and the
+rules further down apply either way.
+
+## Adding a language on GitHub
 
 1. Open `Localizations/Localizable.xcstrings`. If you have Xcode, double-click
    it for a table view with a language picker and a progress bar. If not, it is


### PR DESCRIPTION
The Crowdin project is live at https://crowdin.com/project/mac-performance-monitor, so the docs should lead with it.

- TRANSLATING.md opens with "The easy way: Crowdin": sign in, pick a language, translate in the browser; Crowdin opens the PR. Explains that only maintainers can add a target language and that we add the Settings picker entry, so a Crowdin translator never touches code. Adds a one-route-per-language rule so Crowdin and direct PRs do not overwrite each other. The GitHub route is retitled and kept intact.
- README links the project beside the existing TRANSLATING.md pointer.
- CONTRIBUTING's Crowdin section records the two integration settings that matter (always import from the repository, allow translations to match source), why `append_commit_message: false` is load-bearing, and the three-step maintainer checklist when a language is requested.
- Corrects TRANSLATING.md's claim that a new language touches no Swift. It needs one `AppLanguage` case, which we do for the translator.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ