### PR TITLE
Point the Homebrew cask at v1.7.1.206

### DIFF
--- a/Casks/mac-performance-monitor.rb
+++ b/Casks/mac-performance-monitor.rb
@@ -1,6 +1,6 @@
 cask "mac-performance-monitor" do
-  version "1.7.0.205"
-  sha256 "da9ad510ed95f4bbced4de02e254c81b2d903bc703ba510e3ef2538aa49d1d01"
+  version "1.7.1.206"
+  sha256 "93633aeba99004a142fc5868ad5774eb4b6ec69b2e24dda43ec44d67f5abd871"
 
   url "https://github.com/Zesty0wl/mac-performance-monitor/releases/download/v#{version}/MacPerformanceMonitor.pkg"
   name "Mac Performance Monitor"


### PR DESCRIPTION
Cask follow-up for the 1.7.1 release. Version and sha256 were written by deploy.sh from the pkg it uploaded, so the checksum is the post-stapling one users download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ