### PR TITLE
Give the README a badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Mac Performance Monitor
 
-[![CI](https://github.com/Zesty0wl/mac-performance-monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/Zesty0wl/mac-performance-monitor/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/Zesty0wl/mac-performance-monitor/ci.yml?branch=main&label=CI&logo=githubactions&logoColor=white)](https://github.com/Zesty0wl/mac-performance-monitor/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/Zesty0wl/mac-performance-monitor?logo=github&label=release)](https://github.com/Zesty0wl/mac-performance-monitor/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/Zesty0wl/mac-performance-monitor/total?logo=github&label=downloads)](https://github.com/Zesty0wl/mac-performance-monitor/releases)
+[![Homebrew cask](https://img.shields.io/homebrew/cask/v/mac-performance-monitor?logo=homebrew&logoColor=white&label=homebrew)](https://formulae.brew.sh/cask/mac-performance-monitor)
+[![Stars](https://img.shields.io/github/stars/Zesty0wl/mac-performance-monitor?logo=github&label=stars)](https://github.com/Zesty0wl/mac-performance-monitor/stargazers)
+[![License](https://img.shields.io/github/license/Zesty0wl/mac-performance-monitor?label=license)](LICENSE)
+
+[![macOS 15+](https://img.shields.io/badge/macOS-15%2B-000000?logo=apple&logoColor=white)](#install)
+[![Apple silicon](https://img.shields.io/badge/Apple%20silicon-arm64-000000?logo=apple&logoColor=white)](#install)
+[![Swift 6](https://img.shields.io/badge/Swift-6.0-F05138?logo=swift&logoColor=white)](Package.swift)
+[![Notarized](https://img.shields.io/badge/notarized-by%20Apple-000000?logo=apple&logoColor=white)](#install)
+[![No telemetry](https://img.shields.io/badge/telemetry-none-2ea44f)](#privacy)
+[![Crowdin](https://img.shields.io/badge/Crowdin-translate-2E3340?logo=crowdin&logoColor=white)](https://crowdin.com/project/mac-performance-monitor)
 
 A native macOS **performance analyzer and logger** that lives in your menu bar. It
 continuously records CPU, memory pressure, GPU, network, disk, battery, and per-process


### PR DESCRIPTION
The CI badge was the only one we had. This adds ten more, arranged in two rows.

**Row 1, the state of the project:** CI, latest release, total downloads,
Homebrew cask version, stars, licence.

**Row 2, what it is:** macOS 15+, Apple silicon, Swift 6, notarized by Apple,
no telemetry, and a Crowdin link for translators.

Every badge asserts something true and was checked before it went in:

| Badge | Shows now |
| --- | --- |
| CI | passing |
| Latest release | v1.7.1.206 |
| Downloads | 44k |
| Homebrew cask | v1.7.1.206 |
| Stars | 402 |
| Licence | MIT |

The static ones match the repository: `LSMinimumSystemVersion` is 15.0,
`Package.swift` is swift-tools 6.0, the pkg is Developer ID signed and
notarized, and the README's own privacy section backs the telemetry claim.
Every link target resolves, and the two in-page anchors point at headings that
exist.

The CI badge moved from GitHub's own `badge.svg` to the shields.io endpoint, so
it matches the others instead of sitting in a different style beside them. It
still links to the workflow.

One badge is not here yet. Crowdin publishes a live "localized 96%" badge at
`badges.crowdin.net`, but it returns 403 until the badge is generated from the
project's own settings page. The Crowdin badge in row 2 is a static link for
now, and can be swapped for the live one once that is switched on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ