### PR TITLE
Fix the stars badge style and make the downloads badge honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/Zesty0wl/mac-performance-monitor/ci.yml?branch=main&label=CI&logo=githubactions&logoColor=white)](https://github.com/Zesty0wl/mac-performance-monitor/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/Zesty0wl/mac-performance-monitor?logo=github&label=release)](https://github.com/Zesty0wl/mac-performance-monitor/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/Zesty0wl/mac-performance-monitor/total?logo=github&label=downloads)](https://github.com/Zesty0wl/mac-performance-monitor/releases)
+[![Downloads](https://img.shields.io/github/downloads/Zesty0wl/mac-performance-monitor/MacPerformanceMonitor.pkg?logo=github&label=downloads)](https://github.com/Zesty0wl/mac-performance-monitor/releases)
 [![Homebrew cask](https://img.shields.io/homebrew/cask/v/mac-performance-monitor?logo=homebrew&logoColor=white&label=homebrew)](https://formulae.brew.sh/cask/mac-performance-monitor)
 [![Stars](https://img.shields.io/github/stars/Zesty0wl/mac-performance-monitor?style=flat&logo=github&label=stars)](https://github.com/Zesty0wl/mac-performance-monitor/stargazers)
 [![License](https://img.shields.io/github/license/Zesty0wl/mac-performance-monitor?label=license)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest release](https://img.shields.io/github/v/release/Zesty0wl/mac-performance-monitor?logo=github&label=release)](https://github.com/Zesty0wl/mac-performance-monitor/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/Zesty0wl/mac-performance-monitor/total?logo=github&label=downloads)](https://github.com/Zesty0wl/mac-performance-monitor/releases)
 [![Homebrew cask](https://img.shields.io/homebrew/cask/v/mac-performance-monitor?logo=homebrew&logoColor=white&label=homebrew)](https://formulae.brew.sh/cask/mac-performance-monitor)
-[![Stars](https://img.shields.io/github/stars/Zesty0wl/mac-performance-monitor?logo=github&label=stars)](https://github.com/Zesty0wl/mac-performance-monitor/stargazers)
+[![Stars](https://img.shields.io/github/stars/Zesty0wl/mac-performance-monitor?style=flat&logo=github&label=stars)](https://github.com/Zesty0wl/mac-performance-monitor/stargazers)
 [![License](https://img.shields.io/github/license/Zesty0wl/mac-performance-monitor?label=license)](LICENSE)
 
 [![macOS 15+](https://img.shields.io/badge/macOS-15%2B-000000?logo=apple&logoColor=white)](#install)


### PR DESCRIPTION
Two corrections to the badge row from #78.

**Stars.** The badge defaults to shields' social style, so it rendered with a
capital "Stars" label and a white chip next to five flat badges. `style=flat`
gives it the same lowercase label and blue chip as the others.

**Downloads.** The total-downloads badge read 44k, which is true but not what a
reader will think it means. The breakdown across all 17 releases:

| Asset | Downloads | Share |
| --- | --- | --- |
| appcast.xml | 38,889 | 87.7% |
| .zip | 2,768 | 6.2% |
| .pkg | 2,698 | 6.1% |
| Total | 44,355 | |

`appcast.xml` is a release asset, so every running copy checking for an update
increments the total. The zip is what Sparkle downloads to update a copy that
is already installed. Only the pkg is someone installing the app, and that
includes Homebrew, because the cask fetches the same asset.

So the badge now counts `MacPerformanceMonitor.pkg` across all releases and
reads 2.7k. Smaller, and it means what it says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ