### PR TITLE
Keep each badge row on one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Downloads](https://img.shields.io/github/downloads/Zesty0wl/mac-performance-monitor/MacPerformanceMonitor.pkg?logo=github&label=downloads)](https://github.com/Zesty0wl/mac-performance-monitor/releases)
 [![Homebrew cask](https://img.shields.io/homebrew/cask/v/mac-performance-monitor?logo=homebrew&logoColor=white&label=homebrew)](https://formulae.brew.sh/cask/mac-performance-monitor)
 [![Stars](https://img.shields.io/github/stars/Zesty0wl/mac-performance-monitor?style=flat&logo=github&label=stars)](https://github.com/Zesty0wl/mac-performance-monitor/stargazers)
-[![License](https://img.shields.io/github/license/Zesty0wl/mac-performance-monitor?label=license)](LICENSE)
 
 [![macOS 15+](https://img.shields.io/badge/macOS-15%2B-000000?logo=apple&logoColor=white)](#install)
 [![Apple silicon](https://img.shields.io/badge/Apple%20silicon-arm64-000000?logo=apple&logoColor=white)](#install)
@@ -13,6 +12,7 @@
 [![Notarized](https://img.shields.io/badge/notarized-by%20Apple-000000?logo=apple&logoColor=white)](#install)
 [![No telemetry](https://img.shields.io/badge/telemetry-none-2ea44f)](#privacy)
 [![Crowdin](https://img.shields.io/badge/Crowdin-translate-2E3340?logo=crowdin&logoColor=white)](https://crowdin.com/project/mac-performance-monitor)
+[![License](https://img.shields.io/github/license/Zesty0wl/mac-performance-monitor?label=license)](LICENSE)
 
 A native macOS **performance analyzer and logger** that lives in your menu bar. It
 continuously records CPU, memory pressure, GPU, network, disk, battery, and per-process


### PR DESCRIPTION
Counting only the installer in #79 made the downloads badge 291 px wide,
because shields appends the asset name to the message. That pushed the first
row past GitHub's readme column, so the licence chip wrapped onto a line by
itself.

Measured every badge and moved licence to the second row:

| Row | Badges | Width with gaps |
| --- | --- | --- |
| 1 | CI, release, downloads, homebrew, stars | 775 px |
| 2 | macOS, Apple silicon, Swift, notarized, telemetry, Crowdin, licence | 791 px |

The column is about 830 px on a desktop, so both rows now sit on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ