### PR TITLE
Phase 4: alerts stop being silent, and an idle app stops publishing

### DIFF
--- a/Localizations/Localizable.xcstrings
+++ b/Localizations/Localizable.xcstrings
@@ -1831,6 +1831,66 @@
         }
       }
     },
+    "%@ is ready. It is not recording and has no menu bar read-out, so it will close when you close its window." : {
+      "comment" : "OnboardingView",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ist bereit. Es zeichnet nicht auf und hat keine Menüleisten-Anzeige, also wird es beendet, wenn du sein Fenster schließt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is ready. It is not recording and has no menu bar read-out, so it will close when you close its window."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ est prêt. Il n’enregistre pas et n’a pas de relevé dans la barre des menus, il se fermera donc quand vous fermerez sa fenêtre."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已就绪。它当前不记录数据，也没有菜单栏读数，因此关闭窗口时它会退出。"
+          }
+        }
+      }
+    },
+    "%@ is recording now, quietly in the background. Open it again whenever you want to look." : {
+      "comment" : "OnboardingView",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ zeichnet jetzt auf, unauffällig im Hintergrund. Öffne es einfach wieder, wenn du nachsehen möchtest."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is recording now, quietly in the background. Open it again whenever you want to look."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ enregistre désormais, discrètement en arrière-plan. Rouvrez-le quand vous voulez y jeter un œil."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 正在后台安静地记录。想查看时随时重新打开它即可。"
+          }
+        }
+      }
+    },
     "%@ is recording now. Its read-out lives in the menu bar, near the clock." : {
       "comment" : "Onboarding: the closing card (1.7.0)",
       "extractionState" : "manual",
@@ -1977,6 +2037,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 正在大量占用网络"
+          }
+        }
+      }
+    },
+    "%@ is watching now. Its read-out lives in the menu bar, near the clock." : {
+      "comment" : "OnboardingView",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ beobachtet jetzt. Die Anzeige sitzt in der Menüleiste, in der Nähe der Uhr."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is watching now. Its read-out lives in the menu bar, near the clock."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ surveille désormais. Son relevé se trouve dans la barre des menus, près de l’horloge."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已开始监测。它的读数显示在菜单栏中，就在时钟附近。"
           }
         }
       }
@@ -54177,6 +54267,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主线程正在处理它的 run loop，响应正常。"
+          }
+        }
+      }
+    },
+    "The menu bar read-out is off, so there is nothing to arrange here." : {
+      "comment" : "OnboardingView",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Menüleisten-Anzeige ist aus, hier gibt es also nichts einzurichten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The menu bar read-out is off, so there is nothing to arrange here."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le relevé de la barre des menus est désactivé, il n’y a donc rien à régler ici."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "菜单栏读数已关闭，因此这里没有可设置的内容。"
           }
         }
       }

--- a/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
+++ b/Sources/MacPerfMonitor/App/MacPerfMonitorApp.swift
@@ -509,8 +509,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
         // launch (a no-op), and later changes — from Settings, the menu-bar
         // toggle, or the startup wizard — open or close it live.
         model.setPersistenceEnabled(components.historyLogging)
+        model.setMenuBarItemVisible(components.menuBarItem)
         components.$state
-            .sink { [weak model] state in model?.setPersistenceEnabled(state.historyLogging) }
+            .sink { [weak model] state in
+                model?.setPersistenceEnabled(state.historyLogging)
+                model?.setMenuBarItemVisible(state.menuBarItem)
+            }
             .store(in: &cancellables)
         // Switching everything off while no window is open is a way of asking
         // the app to stop, so honour it rather than sitting there invisible.

--- a/Sources/MacPerfMonitor/Onboarding/OnboardingView.swift
+++ b/Sources/MacPerfMonitor/Onboarding/OnboardingView.swift
@@ -273,19 +273,46 @@ private struct OnboardingStepScaffold<Content: View>: View {
 ///
 /// The flow used to end on the menu bar settings, which reads as one more pane
 /// of switches rather than a finish line. This gives the wizard a visible end
-/// and makes handing the user the dashboard the primary action.
+/// and makes handing the user the dashboard the primary action. What it claims
+/// follows the switches the user just set: with no menu bar item there is no
+/// read-out to look for, and with recording off nothing is being recorded.
 private struct OnboardingDoneStep: View {
+    @EnvironmentObject private var components: AppComponentsManager
+
+    /// Only claim what is actually switched on.
+    private var subtitle: String {
+        switch (components.menuBarItem, components.historyLogging) {
+        case (true, true):
+            return t(
+                "%@ is recording now. Its read-out lives in the menu bar, near the clock.",
+                AppInfo.displayName)
+        case (true, false):
+            return t(
+                "%@ is watching now. Its read-out lives in the menu bar, near the clock.",
+                AppInfo.displayName)
+        case (false, true):
+            return t(
+                "%@ is recording now, quietly in the background. Open it again whenever you want to look.",
+                AppInfo.displayName)
+        case (false, false):
+            return t(
+                "%@ is ready. It is not recording and has no menu bar read-out, so it will close when you close its window.",
+                AppInfo.displayName)
+        }
+    }
+
     var body: some View {
         OnboardingStepScaffold(
             symbol: "checkmark.circle.fill", tint: .green,
             title: "You are all set",
-            subtitle:
-                "\(AppInfo.displayName) is recording now. Its read-out lives in the menu bar, near the clock."
+            subtitle: LocalizedStringKey(subtitle)
         ) {
             VStack(alignment: .leading, spacing: 12) {
-                OnboardingDoneRow(
-                    symbol: "menubar.rectangle",
-                    text: "Click the menu bar read-out for a quick look at any metric.")
+                if components.menuBarItem {
+                    OnboardingDoneRow(
+                        symbol: "menubar.rectangle",
+                        text: "Click the menu bar read-out for a quick look at any metric.")
+                }
                 OnboardingDoneRow(
                     symbol: "square.grid.2x2",
                     text: "Open the dashboard for history, charts and per-process detail.")
@@ -483,6 +510,7 @@ private struct OnboardingPermissionsStep: View {
 /// refresh interval.
 private struct OnboardingMenuBarStep: View {
     @EnvironmentObject private var menuBar: CombinedMenuBarConfiguration
+    @EnvironmentObject private var components: AppComponentsManager
     @AppStorage(PresenceController.pinDefaultsKey) private var pinDockIcon = false
     @AppStorage(SamplerModel.tableIntervalKey) private var tableInterval =
         SamplerModel.defaultTableInterval
@@ -491,7 +519,9 @@ private struct OnboardingMenuBarStep: View {
         OnboardingStepScaffold(
             symbol: "menubar.rectangle", tint: .orange,
             title: "Menu bar & refresh",
-            subtitle: "Choose what the single compact menu bar item shows."
+            subtitle: components.menuBarItem
+                ? "Choose what the single compact menu bar item shows."
+                : "The menu bar read-out is off, so there is nothing to arrange here."
         ) {
             VStack(spacing: 12) {
                 Picker("Presentation", selection: presentationBinding) {
@@ -506,7 +536,6 @@ private struct OnboardingMenuBarStep: View {
                         symbol: metric.symbolName, title: LocalizedStringKey(metric.title),
                         subtitle: metricSubtitle(metric), isOn: selectionBinding(metric)
                     )
-                    .disabled(menuBar.isSelected(metric) && menuBar.selectedMetrics.count == 1)
                 }
 
                 OnboardingToggleRow(

--- a/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
@@ -133,6 +133,19 @@ final class SamplerModel: ObservableObject {
     /// 2–4 Hz. This prevents a popover from bypassing the process-scan floor.
     private var popoverEveryTicks = 1
     private var popoverTickCounter = 0
+    /// The scan cadence to use when a per-process alert is the only thing that
+    /// wants one: with nothing recording and nothing on screen, a leak or
+    /// ceiling alert within the minute is soon enough, and the scan is the
+    /// expensive part of a tick.
+    static let alertOnlyScanInterval: TimeInterval = 60
+    private var alertScanEveryTicks = 60
+    private var alertScanTickCounter = 0
+    /// Whether a menu bar item is currently installed. Set by the app delegate
+    /// from the components switch. Together with the window and popover
+    /// consumers it answers "is anything reading what we publish", which is
+    /// what lets an app with no surfaces skip the per-tick hop to the main
+    /// thread entirely.
+    private var menuBarItemVisible = true
     /// The visible-surface cadence: `liveTick` (charts, the menu-bar image)
     /// and the on-screen row re-reads follow the refresh dial, while the 1 Hz
     /// system heartbeat keeps running underneath for logging and smoothing.
@@ -504,6 +517,8 @@ final class SamplerModel: ObservableObject {
         // heavy ticks, so they key off this same scan cadence.
         let processInterval = LiveRefreshCadence.processInterval(for: tableInterval)
         let scan = persistenceEnabled ? min(processInterval, highRes) : processInterval
+        self.alertScanEveryTicks = LiveRefreshCadence.tickCount(
+            for: Self.alertOnlyScanInterval, baseInterval: baseInterval)
         self.heavyEveryTicks = LiveRefreshCadence.tickCount(
             for: scan, baseInterval: baseInterval)
         self.tableEveryTicks = LiveRefreshCadence.tickCount(
@@ -621,6 +636,12 @@ final class SamplerModel: ObservableObject {
     /// engine reads them. Called from settings whenever the config changes.
     func setAlertConfig(_ config: AlertConfig) {
         queue.async { self.alertConfig = config }
+    }
+
+    /// Tell the sampler whether a menu bar item is on screen reading its
+    /// published values. See `menuBarItemVisible`.
+    func setMenuBarItemVisible(_ visible: Bool) {
+        queue.async { self.menuBarItemVisible = visible }
     }
 
     /// Install (or clear) the privileged helper-backed reader on the sampler.
@@ -795,6 +816,8 @@ final class SamplerModel: ObservableObject {
             persistenceEnabled
             ? min(processInterval, highResIntervalSeconds) : processInterval
         heavyEveryTicks = LiveRefreshCadence.tickCount(for: scan, baseInterval: interval)
+        alertScanEveryTicks = LiveRefreshCadence.tickCount(
+            for: Self.alertOnlyScanInterval, baseInterval: interval)
         // Broad process UI publication (the re-sort, `latest`, alerts) follows
         // the dial with a 5 s floor; the rows on screen are re-read at the dial
         // rate in between (`refreshProcesses`), and the system-only heartbeat
@@ -1022,7 +1045,21 @@ final class SamplerModel: ObservableObject {
         } else {
             popoverTickCounter = 0
         }
-        let needProcesses = persistenceEnabled || processConsumers > 0 || popoverOpen
+        // Alerts are a consumer of the scan in their own right. Without this,
+        // with logging off and nothing on screen, no alert is ever evaluated:
+        // evaluation lives inside the scan, and the scan had no reason to run.
+        // Only the per-process alerts need the scan; the rest are evaluated
+        // below from the cheap tick.
+        let processAlerts = alertConfig.processCeilingEnabled || alertConfig.leakEnabled
+        let interactive = processConsumers > 0 || popoverOpen
+        let needProcesses = persistenceEnabled || interactive || processAlerts
+        // When alerts are the *only* reason to scan, do it on a slow cadence:
+        // the scan is the expensive part of a tick, and a leak or ceiling alert
+        // that arrives within the minute is soon enough. Recording or anything
+        // on screen goes back to the usual cadences.
+        alertScanTickCounter += 1
+        let alertsAreTheOnlyReason = !persistenceEnabled && !interactive && processAlerts
+        let alertScanDue = alertScanTickCounter >= alertScanEveryTicks
         // Two cadences: the fine SCAN (feeds persistence + trails + popover) runs at
         // `heavyEveryTicks`; the main-window UI publish/alerts run at the coarser
         // `tableEveryTicks` (the global Refresh dial), so 1 s logging never forces
@@ -1040,7 +1077,10 @@ final class SamplerModel: ObservableObject {
         let popoverDue =
             popoverOpen
             && (force || !hasProcessSnapshot || popoverTickCounter >= popoverEveryTicks)
-        let runScan = needProcesses && (popoverDue || scanDue || tableDue)
+        let runScan =
+            needProcesses && (popoverDue || scanDue || tableDue)
+            && (!alertsAreTheOnlyReason || alertScanDue)
+        if runScan { alertScanTickCounter = 0 }
         // The dial gate for everything visible. An open popover pins it to
         // every tick (its live strips are the point of opening one), and an
         // immediate-tick request publishes once without waiting out the dial.
@@ -1053,38 +1093,53 @@ final class SamplerModel: ObservableObject {
         }
 
         // Publish the fresh system sample every tick, independent of any scan:
-        // the full-rate heartbeat the menu bar and the live charts read.
+        // the full-rate heartbeat the menu bar and the live charts read. With
+        // no menu bar item, no window and no popover, nothing reads it, so the
+        // hop to the main thread is pure cost: skip it. The rings it fills are
+        // live-chart state, and a chart that is not on screen has no history to
+        // lose; recorded history comes from the database.
         let diagnostics = self.diagnostics
-        DispatchQueue.main.async {
-            let publishStart = TickDiagnostics.now()
-            self.systemHistory.append(system)
-            self.appendRecentCPU(cpu)
-            self.appendRecentNetwork(network)
-            self.appendRecentDisk(disk)
-            self.recentBattery = battery
-            // GPU is sampled only while the menubar GPU item is on; smooth it like
-            // CPU so the icon figure settles, and drop the history when it goes off.
-            if let gpu {
-                self.recentGPUSamples.append(gpu)
-                if self.recentGPUSamples.count > self.cpuSmoothingTicks {
-                    self.recentGPUSamples.removeFirst(
-                        self.recentGPUSamples.count - self.cpuSmoothingTicks)
+        let anythingWatching = menuBarItemVisible || interactive
+        if anythingWatching {
+            DispatchQueue.main.async {
+                let publishStart = TickDiagnostics.now()
+                self.systemHistory.append(system)
+                self.appendRecentCPU(cpu)
+                self.appendRecentNetwork(network)
+                self.appendRecentDisk(disk)
+                self.recentBattery = battery
+                // GPU is sampled only while the menubar GPU item is on; smooth it like
+                // CPU so the icon figure settles, and drop the history when it goes off.
+                if let gpu {
+                    self.recentGPUSamples.append(gpu)
+                    if self.recentGPUSamples.count > self.cpuSmoothingTicks {
+                        self.recentGPUSamples.removeFirst(
+                            self.recentGPUSamples.count - self.cpuSmoothingTicks)
+                    }
+                    self.gpuHistoryRing.append(gpu.utilization)
+                    if self.gpuHistoryRing.count > Self.gpuHistoryCapacity {
+                        self.gpuHistoryRing.removeFirst(
+                            self.gpuHistoryRing.count - Self.gpuHistoryCapacity)
+                    }
+                } else if !self.recentGPUSamples.isEmpty {
+                    self.recentGPUSamples = []
+                    self.gpuHistoryRing = []
                 }
-                self.gpuHistoryRing.append(gpu.utilization)
-                if self.gpuHistoryRing.count > Self.gpuHistoryCapacity {
-                    self.gpuHistoryRing.removeFirst(
-                        self.gpuHistoryRing.count - Self.gpuHistoryCapacity)
-                }
-            } else if !self.recentGPUSamples.isEmpty {
-                self.recentGPUSamples = []
-                self.gpuHistoryRing = []
+                // The visible heartbeat. The rings above append on every tick so
+                // charts keep full 1 s resolution, but the redraw signal honours
+                // the refresh dial: at 10 s the menu-bar image and every live
+                // chart advance ten seconds of data at a time.
+                if uiDue { self.liveTick.send() }
+                diagnostics.recordPublish(duration: TickDiagnostics.now() - publishStart)
             }
-            // The visible heartbeat. The rings above append on every tick so
-            // charts keep full 1 s resolution, but the redraw signal honours
-            // the refresh dial: at 10 s the menu-bar image and every live
-            // chart advance ten seconds of data at a time.
-            if uiDue { self.liveTick.send() }
-            diagnostics.recordPublish(duration: TickDiagnostics.now() - publishStart)
+        }
+
+        // System-level alerts (pressure, swap, thermal, CPU, GPU) have all they
+        // need from the cheap tick. Evaluate them here when no scan ran, so a
+        // pressure alert still fires with the app recording nothing and showing
+        // nothing. The per-process list is whatever the last scan left.
+        if alertsDue, !runScan, alertConfig.anyEnabled {
+            evaluateAlerts(system: system, processes: carriedProcesses, cpu: cpu)
         }
 
         // Between table publishes, re-read just the rows on screen so their
@@ -1212,7 +1267,10 @@ final class SamplerModel: ObservableObject {
         // retention cadences count scan-due ticks here. Alert evaluation
         // follows the table cadence.
         if job.scanDue { runPersistenceMaintenance(snapshot) }
-        if job.alertsDue { evaluateAlerts(snapshot) }
+        if job.alertsDue {
+            evaluateAlerts(
+                system: snapshot.system, processes: snapshot.processes, cpu: snapshot.cpu)
+        }
         guard job.uiWantsProcesses else { return }
 
         // Trails freeze while nothing consumes the scan (full-mode recording
@@ -1615,13 +1673,13 @@ final class SamplerModel: ObservableObject {
     /// Run the alert engine over the full snapshot (all processes, so the
     /// per-process ceiling sees everything) and forward any newly-fired alerts
     /// to the main-thread sink. Runs on `queue`.
-    private func evaluateAlerts(_ snapshot: Sampler.Snapshot) {
+    private func evaluateAlerts(system: SystemSample, processes: [ProcessSample], cpu: CPUSample) {
         let alerts = alertEngine.evaluate(
-            system: snapshot.system,
-            processes: snapshot.processes,
+            system: system,
+            processes: processes,
             leakingProcesses: leakingIDs,
             config: alertConfig,
-            cpu: snapshot.cpu,
+            cpu: cpu,
             gpu: lastSystemTick?.gpu)
         let activeKinds = alertEngine.activeKinds
         let sink = onAlertsFired

--- a/Sources/MacPerfMonitorCore/Analysis/AlertEngine.swift
+++ b/Sources/MacPerfMonitorCore/Analysis/AlertEngine.swift
@@ -26,6 +26,14 @@ public struct AlertConfig: Sendable, Equatable, Codable {
     /// Off by default: fanless Macs throttle routinely under real work.
     public var thermalEnabled: Bool
 
+    /// Whether any alert at all is switched on. When nothing is, there is no
+    /// reason to evaluate, which is what lets the sampler skip the work on a
+    /// tick that has nothing else to do.
+    public var anyEnabled: Bool {
+        criticalPressureEnabled || swapEnabled || processCeilingEnabled || leakEnabled
+            || highCPUEnabled || highGPUEnabled || thermalEnabled
+    }
+
     public init(
         criticalPressureEnabled: Bool = true,
         swapEnabled: Bool = false,


### PR DESCRIPTION
Fourth phase of `docs/app-presence-design.md`: the correctness work this
rearchitecture exposed.

**The alerts bug.** Evaluation lived inside the per-process scan, and the scan
only ran when logging was on, a window was open, or a popover was up. With
logging paused and nothing on screen, no alert was ever evaluated, including
critical memory pressure. A kernel pressure event forced a tick, but the tick
returned before evaluating anything. This is true in 1.x today, and the menu bar
item becoming optional makes it far easier to reach.

The fix has two halves, because not every alert needs the same data:

- **Ceiling and leak** need the process list, so they make the scan run. When
  they are the only reason for it, the scan drops to once a minute rather than
  the usual cadence, since the scan is the expensive part of a tick.
- **Pressure, swap, thermal, CPU and GPU** have everything they need from the
  cheap system tick, so they are evaluated there whenever no scan ran.

**The idle cost.** With no menu bar item, no window and no popover, nothing
reads the values the tick publishes, so the per-tick hop to the main thread is
skipped. The rings it fills are live-chart state, and recorded history comes
from the database.

**The wizard** no longer claims things that may not be true. The closing card
says what is actually switched on, in four variants; the menu bar step says
there is nothing to arrange when the read-out is off; and the last-read-out
guard is gone now the item has its own switch. Four new strings, all four
languages.

567 tests, lint, and both localization checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ