### PR TITLE
Phase 5: changelog, readme, and what actually got built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- **The app comes first now, and the menu bar item is optional.** Requested in
+  #21 and #67. Until now the menu bar read-out was the app: it could not be
+  turned off, it was the only thing that could open a window, and it held the
+  only Quit command. Three things change together.
+  - **Show in the menu bar** is a switch in Settings. Turn it off and
+    monitoring, recording and alerts carry on exactly as before. Open the window
+    again from the Dock, Spotlight or Launchpad.
+  - **Record history** is now its own switch rather than half of a Mode picker,
+    so recording and the menu bar item are independent. The old Mode setting
+    carries over: menu-bar-only becomes recording off, and everything else
+    becomes recording on, with the item left on either way.
+  - **The Dock icon follows the window.** Mac Performance Monitor appears in the
+    Dock whenever one of its windows is open, which is also what gives it the
+    standard menus and Command-Q, and drops out of the Dock when the last window
+    closes. A preference keeps it there permanently, replacing the old "show
+    icon in the Dock" toggle, which it inherits.
+- Launching the app now opens its window, rather than appearing to do nothing.
+  Opening at login stays quiet, with no window and no Dock icon.
+- Closing the last window quits the app when neither the menu bar item nor
+  recording is switched on. With either on, it keeps running as before.
+
 ### Security
 
 - Sparkle, the updater framework, moved from 2.9.3 to 2.9.6. That picks up two
@@ -29,6 +52,17 @@ Notable changes to Mac Performance Monitor. This project follows
 
 ### Fixed
 
+- **Alerts could be silent.** Alert evaluation runs inside the per-process scan,
+  and that scan only ran while recording was on, a window was open, or a menu
+  bar panel was up. With recording paused and nothing on screen, no alert was
+  ever evaluated, critical memory pressure included: a kernel pressure event
+  forced a tick, but the tick returned before evaluating anything. Alerts are
+  now a reason to sample in their own right. The pressure, swap, thermal, CPU
+  and GPU alerts are evaluated from the cheap system tick, and the two that need
+  the process list, the per-process ceiling and the runaway-process alert, run a
+  scan once a minute when nothing else calls for one.
+- With no menu bar item, no window and no panel open, the sampler no longer
+  publishes to the main thread every second for nobody to read.
 - 99 interface strings were never in the catalog, so they stayed English in
   every language whatever you chose. They are SwiftUI literals that the
   source-scanning check cannot see, from the battery detail panels, the network

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@
 [![Crowdin](https://img.shields.io/badge/Crowdin-translate-2E3340?logo=crowdin&logoColor=white)](https://crowdin.com/project/mac-performance-monitor)
 [![License](https://img.shields.io/github/license/Zesty0wl/mac-performance-monitor?label=license)](LICENSE)
 
-A native macOS **performance analyzer and logger** that lives in your menu bar. It
-continuously records CPU, memory pressure, GPU, network, disk, battery, and per-process
-usage to a local database, then helps you make sense of it: trends, leaks, pressure
-events, and on-device diagnostics.
+A native macOS **performance analyzer and logger**. It continuously records CPU, memory
+pressure, GPU, network, disk, battery, and per-process usage to a local database, then
+helps you make sense of it: trends, leaks, pressure events, and on-device diagnostics.
+
+Run it however suits you. The menu bar read-out and the background recorder are separate
+switches, so it can be a live read-out near the clock, a quiet recorder with no menu bar
+item at all, or a plain window you open when you need it.
 
 Free and open source. No telemetry. Every sample stays on your Mac.
 

--- a/docs/app-presence-design.md
+++ b/docs/app-presence-design.md
@@ -1,6 +1,8 @@
 # App presence: window, menu bar item, and logger as independent components
 
-Design note for issue #21. Status: agreed, not yet implemented.
+Design note for issue #21. Status: built for 2.0.0 on the `2.0.0` branch. See
+"What was actually built" at the end for the two places the work departed from
+the plan.
 
 ## What this is about
 
@@ -269,3 +271,34 @@ Four things follow from working on a branch:
   (`Sources/MacPerfMonitor/Views/MenuBarContentView.swift:136-145`). Being
   regular while a window is open should remove that class of problem rather than
   add to it.
+
+## What was actually built
+
+Phases 1 to 5 landed as pull requests #85, #86, #87, #88 and this one. Two
+departures from the plan above, both deliberate:
+
+- **The read-out selection keeps its "at least one" rule.** The plan said to
+  allow zero read-outs as the way to hide the item. Once the item has its own
+  switch that is a worse way to say the same thing, and it leaves several code
+  paths reading the first selected metric. So the switch hides the item and the
+  selection still needs one read-out. The index reads were hardened anyway.
+- **Alerts do not simply become another scan consumer.** Doing only that would
+  have run the expensive per-process scan at the usual cadence for an app with
+  nothing on screen, which is the cost the menu-bar-only mode existed to avoid.
+  The alerts that need the process list run a scan once a minute when nothing
+  else calls for one; the rest are evaluated from the cheap system tick.
+
+Two things were found while building rather than while planning, both fixed in
+the phase that hit them:
+
+- Asking for the main window once at launch does not work. The scene tree does
+  not exist while the delegate is finishing launch, and the request is dropped
+  rather than queued, so the ask repeats until a window exists.
+- A window can be created without ever becoming key, so the window
+  notifications alone never notice it. With the Dock pin off, the app opened its
+  window and stayed an accessory with no menus. Every window-opening path now
+  runs through `WindowOpenBridge`, which tells the presence controller.
+
+Not verified before release, because the Mac was at its lock screen throughout
+the build: anything that needs to be seen on screen. The interactive checks in
+"Verification" above are for the first person to run the build.


### PR DESCRIPTION
Last phase of `docs/app-presence-design.md`. Documentation only.

- **CHANGELOG** gains the 2.0.0 entry, leading with the three visible changes,
  since they arrive through Sparkle on machines whose owners chose a menu bar
  app. It also records the alerts bug, which is a 1.x bug rather than a
  regression.
- **README** no longer opens by calling this a menu bar app, and says the
  read-out and the recorder are separate switches.
- **The design note** now records what was actually built: the two deliberate
  departures from the plan, the two problems found while building, and an honest
  note that nothing needing a screen was verified, because the Mac was locked
  throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ