### PR TITLE
Set the version to 2.0.0

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -32,9 +32,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>206</string>
+	<string>207</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>


### PR DESCRIPTION
Version bump for the test build: 1.7.1 becomes 2.0.0, build 207.

Major rather than minor because the behaviour changes for every existing
install: the menu bar item becomes optional, the Dock icon follows the window,
a launch now opens the window, and the app quits when neither the item nor
recording is on.

The build is installed at `/Applications/Mac Performance Monitor.app`, Developer
ID signed with the release team identity, signature verified. It is **not
notarized**: the notarytool credentials live in the data-protection keychain,
which stays locked while the Mac is at its lock screen, so `notarytool` cannot
read the profile. Gatekeeper does not block it locally because a `ditto` install
carries no quarantine flag, but the published build will need notarizing.

Notarizing these exact bytes afterwards needs no rebuild:

```sh
ditto -c -k --keepParent "/Applications/Mac Performance Monitor.app" /tmp/mpm-2.0.0.zip
xcrun notarytool submit /tmp/mpm-2.0.0.zip --keychain-profile macperfmon-notary --wait
xcrun stapler staple "/Applications/Mac Performance Monitor.app"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ