### PR TITLE
Build 208: the installed test build carries the table fix

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>207</string>
+	<string>208</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>


### PR DESCRIPTION
Build-number bump only. `install.sh` bumps it on each release build, and 208 is
the build now installed at `/Applications/Mac Performance Monitor.app`, with the
process-table fix from #91 in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ