### PR TITLE
Show the per-core bars as measured, not as a five second mean

### DIFF
--- a/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
@@ -1509,6 +1509,16 @@ final class SamplerModel: ObservableObject {
     /// popovers that want a 1 Hz read-out (memory used, pressure) read this. O(1).
     var liveSystem: SystemSample? { systemHistory.last }
 
+    /// The newest CPU sample, exactly as measured, with no smoothing.
+    ///
+    /// `smoothedCPU` is a five second rolling mean, which is what a menu bar
+    /// read-out needs: an unsmoothed percentage jitters too much to read at a
+    /// glance. It is the wrong thing for the per-core bars, where a core that
+    /// pins for half a second and drops back is the movement you are looking
+    /// for, and the mean flattens it to nearly nothing. So the core grids read
+    /// this instead.
+    var liveCPU: CPUSample? { recentCPUSamples.last }
+
     /// The most recent battery sample, refreshed every fast tick (~1 Hz) — the
     /// battery analogue of `liveSystem`/`latestNetwork`, so the battery menubar
     /// read-outs stay live at 1 Hz instead of the slower heavy `latest` cadence.

--- a/Sources/MacPerfMonitor/Views/DashboardView.swift
+++ b/Sources/MacPerfMonitor/Views/DashboardView.swift
@@ -85,7 +85,7 @@ struct DashboardView: View {
         .onReceive(liveTicks) { _ in
             guard appState.mainWindowVisible, let model else { return }
             timeline.append(
-                model.liveSystem, cpu: model.smoothedCPU,
+                model.liveSystem, cpu: model.smoothedCPU, liveCPU: model.liveCPU,
                 networkRates: model.smoothedNetworkRates, diskRates: model.smoothedDiskRates,
                 disk: model.latestDisk)
             appendThermalPoint(model)
@@ -395,6 +395,7 @@ struct DashboardView: View {
             guard self.range == requested else { return }
             self.timeline.replace(
                 pts, span: requested.seconds, live: model.liveSystem, cpu: model.smoothedCPU,
+                liveCPU: model.liveCPU,
                 totalRAM: model.liveSystem?.totalRAM ?? model.latest?.system.totalRAM ?? 0)
             self.thermalPoints = pts
             self.loadedRange = requested
@@ -488,7 +489,7 @@ private final class DashboardTimelineStore: ObservableObject {
 
     func replace(
         _ loaded: [SystemHistoryPoint], span: TimeInterval, live: SystemSample?, cpu: CPUSample?,
-        totalRAM: UInt64
+        liveCPU: CPUSample?, totalRAM: UInt64
     ) {
         window.replace(loaded, span: span)
         if let live {
@@ -508,13 +509,14 @@ private final class DashboardTimelineStore: ObservableObject {
                 return template
             }
         publishCharts()
-        publishReadouts(cpu: cpu, networkRates: nil, diskRates: nil, disk: nil)
+        publishReadouts(
+            cpu: cpu, liveCPU: liveCPU, networkRates: nil, diskRates: nil, disk: nil)
         if window.count >= 2, !hasEnoughHistory { hasEnoughHistory = true }
         rangeVersion &+= 1
     }
 
     func append(
-        _ system: SystemSample?, cpu: CPUSample?,
+        _ system: SystemSample?, cpu: CPUSample?, liveCPU: CPUSample?,
         networkRates: (inBytesPerSec: Double, outBytesPerSec: Double)?,
         diskRates: (readBytesPerSec: Double, writeBytesPerSec: Double)?, disk: DiskSample?
     ) {
@@ -525,7 +527,9 @@ private final class DashboardTimelineStore: ObservableObject {
         if totalRAM == 0, system.totalRAM > 0 { totalRAM = system.totalRAM }
         refreshAutoDomains()
         publishCharts()
-        publishReadouts(cpu: cpu, networkRates: networkRates, diskRates: diskRates, disk: disk)
+        publishReadouts(
+            cpu: cpu, liveCPU: liveCPU, networkRates: networkRates, diskRates: diskRates,
+            disk: disk)
         if window.count >= 2, !hasEnoughHistory { hasEnoughHistory = true }
     }
 
@@ -564,7 +568,8 @@ private final class DashboardTimelineStore: ObservableObject {
     /// The figures around the charts: processor, network and disk read-outs,
     /// the core grid, and the memory composition.
     private func publishReadouts(
-        cpu: CPUSample?, networkRates: (inBytesPerSec: Double, outBytesPerSec: Double)?,
+        cpu: CPUSample?, liveCPU: CPUSample?,
+        networkRates: (inBytesPerSec: Double, outBytesPerSec: Double)?,
         diskRates: (readBytesPerSec: Double, writeBytesPerSec: Double)?, disk: DiskSample?
     ) {
         cpuTotalFeed.publish(
@@ -572,7 +577,10 @@ private final class DashboardTimelineStore: ObservableObject {
         cpuPerformanceFeed.publish(cpu.map { percent($0.performanceUsage) } ?? "—")
         cpuEfficiencyFeed.publish(cpu.map { percent($0.efficiencyUsage) } ?? "—")
         loadAverageFeed.publish(cpu.map { String(format: "%.2f", $0.loadAverage1) } ?? "—")
-        coreFeed.publish(cpu?.cores ?? [])
+        // The bars show the sample as measured; the percentages around them
+        // stay smoothed, because a jittering number is unreadable and a still
+        // core grid is uninformative.
+        coreFeed.publish((liveCPU ?? cpu)?.cores ?? [])
         if let networkRates {
             downloadFeed.publish(ByteFormat.rate(networkRates.inBytesPerSec))
             uploadFeed.publish(ByteFormat.rate(networkRates.outBytesPerSec))

--- a/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
+++ b/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
@@ -64,13 +64,15 @@ struct SystemHeaderView: View {
         // for it (the feeds repaint their AppKit surfaces).
         .onReceive(model.liveTick) {
             guard appState.mainWindowVisible else { return }
-            live.append(model.liveSystem, cpu: model.smoothedCPU)
+            live.append(model.liveSystem, cpu: model.smoothedCPU, liveCPU: model.liveCPU)
         }
     }
 
     private func reload() {
         model.loadRecentSystemHistory(seconds: 2 * 3600) { points in
-            live.replace(points, live: model.liveSystem, cpu: model.smoothedCPU)
+            live.replace(
+                points, live: model.liveSystem, cpu: model.smoothedCPU,
+                liveCPU: model.liveCPU)
         }
     }
 
@@ -199,18 +201,21 @@ final class ProcessHeaderStore: ObservableObject {
     /// grows the fourth card on machines that actually report one.
     @Published private(set) var hasTemperature = false
 
-    func replace(_ points: [SystemHistoryPoint], live: SystemSample?, cpu: CPUSample?) {
+    func replace(
+        _ points: [SystemHistoryPoint], live: SystemSample?, cpu: CPUSample?,
+        liveCPU: CPUSample?
+    ) {
         window.replace(points)
         if let live { window.append(Self.point(from: live)) }
-        publish(cpu, system: live)
+        publish(cpu, system: live, liveCPU: liveCPU)
     }
 
-    func append(_ system: SystemSample?, cpu: CPUSample?) {
+    func append(_ system: SystemSample?, cpu: CPUSample?, liveCPU: CPUSample?) {
         if let system { window.append(Self.point(from: system)) }
-        publish(cpu, system: system)
+        publish(cpu, system: system, liveCPU: liveCPU)
     }
 
-    private func publish(_ cpu: CPUSample?, system: SystemSample?) {
+    private func publish(_ cpu: CPUSample?, system: SystemSample?, liveCPU: CPUSample?) {
         let level = CPULevel(fraction: cpu?.totalUsage ?? 0)
         usageFeed.publish(
             value: cpu.map { "\(Int(($0.totalUsage * 100).rounded()))%" },
@@ -219,7 +224,10 @@ final class ProcessHeaderStore: ObservableObject {
         loadFeed.publish(
             value: cpu.map { String(format: "%.2f", $0.loadAverage1) }, tint: .labelColor,
             column: nil, xDomain: nil, yDomain: nil)
-        coreFeed.publish(cpu?.cores ?? [])
+        // The bars show the sample as measured. The cards above them stay
+        // smoothed: a jittering percentage is unreadable, a still core grid is
+        // uninformative.
+        coreFeed.publish((liveCPU ?? cpu)?.cores ?? [])
         // The temperature card: hottest die sensor, tinted by macOS's own
         // thermal pressure verdict (green means "hot but working as designed").
         let die = system?.cpuDieC ?? window.peakLatestCPUDie


### PR DESCRIPTION
Reported from the test build: the per-core CPU chart looks too static.

**Why.** Both core grids read `smoothedCPU`, which is a five second rolling mean
of the CPU sample. That value exists for the menu bar read-out, where an
unsmoothed percentage jitters too much to read at a glance. For per-core bars it
removes the very thing you are watching for.

**Measured** over twenty consecutive ticks, busiest core:

| Source | Range | Spread | Standard deviation |
| --- | --- | --- | --- |
| live | 41 to 70 percent | 29 | 7.2 |
| smoothed | 47 to 51 percent | 4 | 1.5 |

**The change.** `SamplerModel` exposes `liveCPU` next to `liveSystem`, and the
dashboard's Processor grid and the grid above the process table both take it.
The percentages around them stay smoothed: a jittering number is unreadable, a
still grid is uninformative.

The CPU panel inside the menu bar popover has a third, smaller copy of the same
grid. It keeps the smoothed sample, since it was not part of the request; say
the word and it can follow.

567 tests, lint, and both localization checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ