### PR TITLE
Build 209: the installed test build has the live core grid

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>208</string>
+	<string>209</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>


### PR DESCRIPTION
Build-number bump only. 209 is the build now installed at
`/Applications/Mac Performance Monitor.app`, carrying #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ