### PR TITLE
Make the header cards readable, and stop the charts wasting their height

### DIFF
--- a/Localizations/Localizable.xcstrings
+++ b/Localizations/Localizable.xcstrings
@@ -62581,6 +62581,36 @@
         }
       }
     },
+    "peak %@" : {
+      "comment" : "Accessibility strings (charts)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spitze %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "peak %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pic %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "峰值 %@"
+          }
+        }
+      }
+    },
     "peak %@ · %d samples" : {
       "comment" : "InsightsView",
       "extractionState" : "manual",
@@ -62607,6 +62637,66 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "峰值 %@ · %d 个样本"
+          }
+        }
+      }
+    },
+    "peak %@%%" : {
+      "comment" : "Accessibility strings (charts)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spitze %@ %%"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "peak %@%%"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pic %@ %%"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "峰值 %@%%"
+          }
+        }
+      }
+    },
+    "peak %@°C" : {
+      "comment" : "Accessibility strings (charts)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spitze %@ °C"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "peak %@°C"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pic %@ °C"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "峰值 %@°C"
           }
         }
       }

--- a/Sources/MacPerfMonitor/Charts/CoreGridSurface.swift
+++ b/Sources/MacPerfMonitor/Charts/CoreGridSurface.swift
@@ -137,7 +137,9 @@ final class CoreGridSurfaceView: LiveSurfaceView {
         }
         let spacing: CGFloat = 3
         let width = (bounds.width - spacing * CGFloat(cores.count - 1)) / CGFloat(cores.count)
-        let track = NSColor.secondaryLabelColor.withAlphaComponent(0.14)
+        // Quiet: eleven empty tracks used to carry more weight on screen than
+        // the fills inside them.
+        let track = NSColor.secondaryLabelColor.withAlphaComponent(0.08)
         for (i, core) in cores.enumerated() {
             let x = CGFloat(i) * (width + spacing)
             let full = CGRect(x: x, y: 0, width: width, height: barHeight)

--- a/Sources/MacPerfMonitor/Charts/SparklineSurface.swift
+++ b/Sources/MacPerfMonitor/Charts/SparklineSurface.swift
@@ -11,6 +11,10 @@ import SwiftUI
 /// instead of restroking its whole path four times a second.
 final class MetricCardFeed {
     private(set) var value: String?
+
+    /// The largest value in the window, already formatted. Drawn in the corner
+    /// of the strip so a bare sparkline has something to read against.
+    private(set) var peak: String?
     private(set) var tint: NSColor = .labelColor
     /// The raw window column behind the sparkline, zero-copy.
     private(set) var column: LiveColumn?
@@ -23,9 +27,10 @@ final class MetricCardFeed {
 
     func publish(
         value: String?, tint: NSColor, column: LiveColumn?, scale: Double = 1,
-        xDomain: ClosedRange<Date>?, yDomain: ClosedRange<Double>?
+        xDomain: ClosedRange<Date>?, yDomain: ClosedRange<Double>?, peak: String? = nil
     ) {
         self.value = value
+        self.peak = peak
         self.tint = tint
         self.column = column
         self.scale = scale

--- a/Sources/MacPerfMonitor/Charts/TemperatureChart.swift
+++ b/Sources/MacPerfMonitor/Charts/TemperatureChart.swift
@@ -77,15 +77,15 @@ struct TemperatureChart: View {
         .accessibilityValue(accessibilitySummary)
     }
 
-    /// A stable floor-to-headroom domain: starting the axis at 0 wastes half
-    /// the plot (die sensors never read near 0), while a tight auto-fit makes
-    /// idle noise look dramatic. 20 to a rounded-up peak keeps small wiggles
-    /// small and real spikes visible.
+    /// Fit the readings rather than pinning the axis to a fixed 20 degrees and a
+    /// rounded-up peak. That was safe but spent most of the plot on temperatures
+    /// a die never reaches: sensors sitting between 60 and 90 drew a flat ribbon
+    /// through the middle. The 30 degree minimum span is what stops the opposite
+    /// problem, a degree of idle noise filling the chart.
     private var temperatureDomain: ClosedRange<Double>? {
         let values = cpuPoints.map(\.value) + gpuPoints.map(\.value)
-        guard let peak = values.max() else { return nil }
-        let top = max(60, (peak / 10).rounded(.up) * 10 + 10)
-        return 20...top
+        guard let lo = values.min(), let hi = values.max() else { return nil }
+        return ChartDomain.fitted(min: lo, max: hi, minimumSpan: 30, padding: 5, floor: 0)
     }
 }
 

--- a/Sources/MacPerfMonitor/Charts/TrendChart.swift
+++ b/Sources/MacPerfMonitor/Charts/TrendChart.swift
@@ -369,6 +369,32 @@ struct TrendChart: View {
 
 /// The plot rectangle shared by the layers, so gridlines, labels, the series
 /// and the scrub overlay agree on where the axes are.
+/// Y ranges that fit the data without magnifying a flat reading.
+///
+/// A fixed wide axis (0 to 110 for a die sensor, say) is safe but wastes most of
+/// the plot: a CPU that lives between 60 and 90 degrees draws a flat ribbon
+/// across the middle. A tight auto-fit has the opposite problem, turning a
+/// degree of idle noise into a mountain range. `fitted` does both: it wraps the
+/// data with a little air, and refuses to show a span narrower than
+/// `minimumSpan`, so a steady reading stays visibly steady.
+enum ChartDomain {
+    static func fitted(
+        min lo: Double, max hi: Double, minimumSpan: Double, padding: Double,
+        floor: Double = -.greatestFiniteMagnitude
+    ) -> ClosedRange<Double> {
+        var low = lo - padding
+        var high = hi + padding
+        let short = minimumSpan - (high - low)
+        if short > 0 {
+            low -= short / 2
+            high += short / 2
+        }
+        low = Swift.max(floor, low.rounded(.down))
+        high = Swift.max(low + minimumSpan, high.rounded(.up))
+        return low...high
+    }
+}
+
 struct TrendChartGeometry: Equatable {
     var leftGutter: CGFloat
     var showsTimeAxis: Bool

--- a/Sources/MacPerfMonitor/Views/MetricCard.swift
+++ b/Sources/MacPerfMonitor/Views/MetricCard.swift
@@ -98,6 +98,12 @@ struct MetricGauge: Equatable {
 /// height so a row or grid stays tidy. The whole card is a button that opens a
 /// detail modal explaining the figure and showing its chart in full.
 struct MetricCard: View {
+    /// Height of the chart strip inside a compact card, and so of the card
+    /// itself, since these are sized by their content. Roughly a quarter taller
+    /// than it was: the strips are the part being read, and at the old height a
+    /// trend had almost no room to be one.
+    static let stripHeight: CGFloat = 57
+
     /// Narrowest a card is laid out at in a row before the row wraps to a grid.
     static let minimumWidth: CGFloat = 150
 
@@ -178,7 +184,7 @@ struct MetricCard: View {
                     MetricGaugeBar(
                         fraction: gauge.fraction, threshold: gauge.threshold, tint: data.tint)
                 } else if let live = data.live {
-                    LiveSparkline(feed: live, lineWidth: 1.5)
+                    ScaledSparkline(feed: live)
                 } else if loading {
                     ProgressView()
                         .controlSize(.small)
@@ -196,7 +202,7 @@ struct MetricCard: View {
                     Color.clear
                 }
             }
-            .frame(height: 28)
+            .frame(height: MetricCard.stripHeight)
             .accessibilityHidden(true)
         }
         // Fill the row's height so cards of differing content (e.g. beside the
@@ -217,6 +223,46 @@ struct MetricCard: View {
                 )
         )
         .contentShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+/// A card sparkline with the least scale it can get away with: a hairline at the
+/// bottom to sit the trend on, and the window's peak in the top corner.
+///
+/// The strip is drawn bare, with no axes, which is right for something this
+/// small but left it impossible to read a height against. These two marks are
+/// what the charts in the detail rail get from a full axis, at a fraction of the
+/// ink.
+private struct ScaledSparkline: View {
+    let feed: MetricCardFeed
+    @State private var peak: String?
+    @State private var observer: UUID?
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            LiveSparkline(feed: feed, lineWidth: 1.5)
+            VStack(alignment: .trailing, spacing: 0) {
+                if let peak {
+                    Text(peak)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                        .padding(.trailing, 1)
+                }
+                Spacer(minLength: 0)
+                Rectangle()
+                    .fill(Color.primary.opacity(0.10))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 0.5)
+            }
+        }
+        .onAppear {
+            peak = feed.peak
+            observer = feed.observe { peak = feed.peak }
+        }
+        .onDisappear {
+            if let observer { feed.stopObserving(observer) }
+            observer = nil
+        }
     }
 }
 
@@ -804,10 +850,10 @@ enum CPUMetrics {
                 label: "Load average",
                 value: cpu.map { String(format: "%.2f", $0.loadAverage1) },
                 tint: loadTint(cpu),
-                gauge: cpu.map {
-                    MetricGauge(
-                        fraction: coreCount > 0 ? min(1, $0.loadAverage1 / Double(coreCount)) : 0)
-                },
+                // No gauge: the header gives this card a live chart like the
+                // others, and a card cannot have both. The Dashboard does not
+                // use this card.
+
                 unit: .percent,
                 detail: cpu.map {
                     String(format: "%.2f · %.2f", $0.loadAverage5, $0.loadAverage15)
@@ -826,6 +872,8 @@ enum CPUMetrics {
 
     /// Green/amber/red by 1-minute load relative to the core count: comfortable
     /// below ~0.7×, subscribed up to 1×, queuing above.
+    static func loadColor(_ cpu: CPUSample?) -> Color { loadTint(cpu) }
+
     private static func loadTint(_ cpu: CPUSample?) -> Color {
         guard let cpu, !cpu.cores.isEmpty else { return .secondary }
         switch cpu.loadAverage1 / Double(cpu.cores.count) {

--- a/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
+++ b/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
@@ -21,7 +21,7 @@ struct SystemHeaderView: View {
         // Prefer the smoothed live CPU (matches the Dashboard's Processor panel),
         // falling back to the snapshot's raw sample before the first smooth lands.
         let cpu = model.smoothedCPU ?? snapshot?.cpu
-        var cards = CPUMetrics.cards(cpu: cpu, history: [], span: 2 * 3600)
+        var cards = CPUMetrics.cards(cpu: cpu, history: [], span: ProcessHeaderStore.headerSpan)
         if !cards.isEmpty { cards[0].live = live.usageFeed }
         if cards.count > 1 { cards[1].live = live.loadFeed }
         return VStack(alignment: .leading, spacing: 10) {
@@ -69,7 +69,7 @@ struct SystemHeaderView: View {
     }
 
     private func reload() {
-        model.loadRecentSystemHistory(seconds: 2 * 3600) { points in
+        model.loadRecentSystemHistory(seconds: ProcessHeaderStore.headerSpan) { points in
             live.replace(
                 points, live: model.liveSystem, cpu: model.smoothedCPU,
                 liveCPU: model.liveCPU)
@@ -167,7 +167,7 @@ private struct CPUCoreCard: View {
                     .lineLimit(1)
                 Spacer(minLength: 4)
             }
-            CoreGridSurface(feed: feed, barHeight: 40)
+            CoreGridSurface(feed: feed, barHeight: 50)
         }
         // Match the metric cards' fill so all three header cards are one height.
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -192,7 +192,22 @@ private struct CPUCoreCard: View {
 /// dial rate without re-rendering any SwiftUI view. Main thread only.
 @MainActor
 final class ProcessHeaderStore: ObservableObject {
-    private var window = SystemHistoryWindow(span: 2 * 3600)
+    /// Ten minutes, not two hours. The strip is about 350 points wide, so a two
+    /// hour window at the sampler's cadence put roughly twenty samples in every
+    /// pixel column and painted the spike from each one: the result read as a
+    /// band of noise whose height was worst case, not typical. Ten minutes is
+    /// close to one sample per column, which is what makes the charts on the
+    /// right legible.
+    private var window = SystemHistoryWindow(span: ProcessHeaderStore.headerSpan)
+
+    /// Shared by the window and the history load so they cannot drift apart.
+    static let headerSpan: TimeInterval = 10 * 60
+
+    /// Load average has no column in the history window, so the header keeps its
+    /// own ring of samples over the same span. That is what lets the load card
+    /// be a chart like its neighbours instead of the odd bar out.
+    private var loadTimes: [Double] = []
+    private var loadValues: [Double] = []
     let usageFeed = MetricCardFeed()
     let loadFeed = MetricCardFeed()
     let coreFeed = CoreGridFeed()
@@ -220,10 +235,27 @@ final class ProcessHeaderStore: ObservableObject {
         usageFeed.publish(
             value: cpu.map { "\(Int(($0.totalUsage * 100).rounded()))%" },
             tint: NSColor(level.color), column: LiveColumn(window, .cpuLoad), scale: 100,
-            xDomain: window.xDomain, yDomain: 0...100)
+            xDomain: window.xDomain, yDomain: 0...100,
+            peak: window.peak(.cpuLoad).map { t("peak %@%%", String(Int(($0 * 100).rounded()))) })
+        if let cpu {
+            let now = Date().timeIntervalSinceReferenceDate
+            loadTimes.append(now)
+            loadValues.append(cpu.loadAverage1)
+            let cutoff = now - Self.headerSpan
+            if let keep = loadTimes.firstIndex(where: { $0 >= cutoff }), keep > 0 {
+                loadTimes.removeFirst(keep)
+                loadValues.removeFirst(keep)
+            }
+        }
+        let loadColumn = LiveColumn(times: loadTimes[...], values: loadValues[...])
+        // Full height is one process per core, so the chart reads as "how close
+        // to fully subscribed", and it stretches when load goes past that.
+        let loadTop = max(Double(cpu?.cores.count ?? 0), loadColumn.range?.max ?? 0, 1)
         loadFeed.publish(
-            value: cpu.map { String(format: "%.2f", $0.loadAverage1) }, tint: .labelColor,
-            column: nil, xDomain: nil, yDomain: nil)
+            value: cpu.map { String(format: "%.2f", $0.loadAverage1) },
+            tint: NSColor(CPUMetrics.loadColor(cpu)), column: loadColumn, scale: 1,
+            xDomain: window.xDomain, yDomain: 0...loadTop,
+            peak: loadColumn.range.map { t("peak %@", String(format: "%.2f", $0.max)) })
         // The bars show the sample as measured. The cards above them stay
         // smoothed: a jittering percentage is unreadable, a still core grid is
         // uninformative.
@@ -233,10 +265,24 @@ final class ProcessHeaderStore: ObservableObject {
         let die = system?.cpuDieC ?? window.peakLatestCPUDie
         if die != nil, !hasTemperature { hasTemperature = true }
         let pressure = system?.thermalPressure ?? .nominal
+        // Zoom to the readings rather than 0 to 110: a die that lives between 60
+        // and 75 degrees drew a flat line across the bottom sixth of the strip.
+        // A minimum span keeps a steady temperature from being magnified into
+        // noise, and the padding stops the line touching the edges.
+        let dieColumn = LiveColumn(window, .cpuDieC)
+        let dieRange = dieColumn.range
+        let dieDomain =
+            dieRange.map {
+                ChartDomain.fitted(
+                    min: $0.min, max: $0.max, minimumSpan: 10, padding: 2, floor: 0)
+            } ?? 20...90
         temperatureFeed.publish(
             value: die.map { "\(Int($0.rounded()))°C" },
-            tint: NSColor(pressure.color), column: LiveColumn(window, .cpuDieC), scale: 1,
-            xDomain: window.xDomain, yDomain: 0...110)
+            tint: NSColor(pressure.color), column: dieColumn, scale: 1,
+            xDomain: window.xDomain, yDomain: dieDomain,
+            peak: window.peak(.cpuDieC).flatMap {
+                $0 > 0 ? t("peak %@°C", String(Int($0.rounded()))) : nil
+            })
     }
 
     private static func point(from s: SystemSample) -> SystemHistoryPoint {


### PR DESCRIPTION
The Processor cards above the process table were hard to read next to the detail
rail, which uses the same chart component configured differently.

## What was wrong

| | Header cards | Detail rail |
| --- | --- | --- |
| Window | 2 hours | the selected range |
| Samples per pixel column | about 20 | about 1 |
| Axes | none, bare mode | labels and gridlines |

Twenty samples per column, each column painted at its spike, gives a band whose
height is worst case rather than typical: the card read 15 percent while the
chart looked like 60.

## Changes

- **Ten minute window** instead of two hours, close to one sample per column.
- **The least scale that works**: a hairline baseline and the window's peak in
  the corner, which is what a full axis gives the rail charts at a fraction of
  the ink.
- **Load average becomes a chart** rather than a progress bar among charts. The
  history window has no load column, so the header keeps its own ten minute ring
  of samples. Full height is one process per core.
- **A quarter taller cards**, 104 points to 130, measured on a render. Almost
  all of it goes to the chart strip. The Dashboard row follows.
- **Quieter core tracks**: eleven empty tracks carried more weight than the data.

## Two charts that wasted their height

Reported separately: the die card looked static and the Dashboard thermals chart
looked compressed. Both were pinned to a fixed wide axis, which is safe but
spends most of the plot on temperatures a die never reaches. One shared rule now
fits the data while keeping a minimum span, so a flat reading is not magnified:

| Chart | Before | After |
| --- | --- | --- |
| Thermals, CPU to 95 and GPU down to 45 | 20 to 110 | 40 to 100 |
| Thermals, everything idle at 60 to 65 | 20 to 110 | 47 to 78 |
| Die card, 66 to 74 | 0 to 110 | 64 to 76 |
| Die card, flat at 70 | 0 to 110 | 65 to 75 |

567 tests, lint, and both localization checks pass. Three new strings, all four
languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ