### PR TITLE
Build 211: the installed test build has the card changes

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>210</string>
+	<string>211</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>


### PR DESCRIPTION
Build-number bump only. 211 is installed at
`/Applications/Mac Performance Monitor.app`, carrying #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ