### PR TITLE
Write down how this app draws data over time

### DIFF
--- a/Sources/MacPerfMonitorCore/Util/SystemHistoryWindow.swift
+++ b/Sources/MacPerfMonitorCore/Util/SystemHistoryWindow.swift
@@ -44,14 +44,40 @@ public struct SystemHistoryWindow {
     private var columns: [[Double]] = Array(repeating: [], count: Column.allCases.count)
     private var head = 0
     public private(set) var span: TimeInterval
+    /// Width of the buckets appended samples are folded into, or zero to keep
+    /// every sample as it arrives.
+    ///
+    /// A one hour window at a one second cadence holds 3,600 samples and is
+    /// drawn perhaps 1,500 pixels wide, so more than two samples land in every
+    /// column and the line is painted at the highest of them: the chart reads as
+    /// a band of noise whose height is worst case rather than typical. Folding
+    /// appends into buckets keeps the window at the resolution the chart can
+    /// actually show, however long the app runs. Short ranges leave this at zero
+    /// and keep every sample, because at five minutes the detail is the point.
+    public private(set) var bucketSeconds: TimeInterval = 0
+    /// How many samples the open bucket has absorbed, for the running mean.
+    private var openBucketCount = 0
     /// The newest sample in full, for the live read-outs.
     public private(set) var latest: SystemHistoryPoint?
 
     private static var compactionThreshold: Int { 1024 }
 
-    public init(span: TimeInterval) {
+    public init(span: TimeInterval, bucketSeconds: TimeInterval = 0) {
         precondition(span > 0, "SystemHistoryWindow span must be positive")
         self.span = span
+        self.bucketSeconds = max(0, bucketSeconds)
+    }
+
+    /// Change the bucket width. Samples already held keep whatever resolution
+    /// they were stored at; the caller reloads when it wants them re-bucketed.
+    public mutating func setBucketSeconds(_ seconds: TimeInterval) {
+        bucketSeconds = max(0, seconds)
+        openBucketCount = 0
+    }
+
+    /// Which bucket a timestamp belongs to, as a bucket index.
+    private func bucket(_ time: Double) -> Double {
+        (time / bucketSeconds).rounded(.down)
     }
 
     public var count: Int { times.count - head }
@@ -98,9 +124,55 @@ public struct SystemHistoryWindow {
     @discardableResult
     public mutating func append(_ point: SystemHistoryPoint) -> Bool {
         if let latest, point.date <= latest.date { return false }
-        push(point)
+        let time = point.date.timeIntervalSinceReferenceDate
+        if bucketSeconds > 0, let lastTime = times.last, count > 0,
+            bucket(lastTime) == bucket(time)
+        {
+            merge(point)
+        } else {
+            openBucketCount = 1
+            push(point)
+        }
         trim()
         return true
+    }
+
+    /// Fold a sample into the open bucket rather than starting a new one.
+    ///
+    /// Most metrics take a running mean, which is what makes a long window
+    /// readable. The temperature column takes the maximum instead, matching the
+    /// stored-history downsampler: averaging thermal readings erases the spikes,
+    /// which are the reason to look at them at all. The timestamp stays at the
+    /// bucket's first sample so the x axis does not creep.
+    private mutating func merge(_ point: SystemHistoryPoint) {
+        let n = Double(openBucketCount)
+        let next = n + 1
+        func mean(_ column: Column, _ value: Double) {
+            let i = columns[column.rawValue].count - 1
+            columns[column.rawValue][i] = (columns[column.rawValue][i] * n + value) / next
+        }
+        func peak(_ column: Column, _ value: Double) {
+            let i = columns[column.rawValue].count - 1
+            columns[column.rawValue][i] = Swift.max(columns[column.rawValue][i], value)
+        }
+        mean(.pressurePercent, point.pressurePercent)
+        mean(.cpuLoad, point.cpuLoad)
+        mean(.appMemory, Double(point.appMemory))
+        mean(.wired, Double(point.wired))
+        mean(.compressed, Double(point.compressed))
+        mean(.cachedFiles, Double(point.cachedFiles))
+        mean(.swapUsed, Double(point.swapUsed))
+        mean(.networkInBytesPerSec, point.networkInBytesPerSec)
+        mean(.networkOutBytesPerSec, point.networkOutBytesPerSec)
+        mean(.diskReadBytesPerSec, point.diskReadBytesPerSec)
+        mean(.diskWriteBytesPerSec, point.diskWriteBytesPerSec)
+        mean(.gpuUtilization, point.gpuUtilization ?? 0)
+        mean(.gpuPowerWatts, point.gpuPowerWatts ?? 0)
+        mean(.anePowerWatts, point.anePowerWatts ?? 0)
+        peak(.cpuDieC, point.cpuDieC ?? 0)
+        openBucketCount += 1
+        // The read-outs want the sample as it arrived, not the bucket's mean.
+        latest = point
     }
 
     /// The window as points, oldest first. Allocates; for occasional use only

--- a/docs/chart-rules.md
+++ b/docs/chart-rules.md
@@ -1,0 +1,151 @@
+# Chart rules
+
+How this app draws data over time. One set of rules for every chart, so the
+next fix is a policy change rather than another local patch.
+
+Status: agreed for 2.0.0. The audit at the end says which surfaces already
+follow the rules and which do not.
+
+## The problem these rules exist to solve
+
+A performance monitor samples faster than a screen can show. At a one second
+cadence an hour is 3,600 samples, and the Dashboard's Processor chart is around
+1,500 pixels wide. Something has to decide what happens to the other 2,100
+samples, and today different charts decide differently.
+
+Measured on this app before the rules, points actually drawn:
+
+| Range | Samples in range | Points drawn | Result |
+| --- | --- | --- | --- |
+| 5 min | 300 | 300 | fine |
+| 30 min | 1,800 | 1,800 | crowded |
+| 1 hr | 3,600 | 3,600 | unreadable |
+| 6 hr | 21,600 | 360 | fine |
+| 24 hr | 86,400 | 360 | fine |
+
+The live path decimates to 720 buckets and emits the minimum *and* maximum of
+each, which is honest: no spike is ever hidden. For a volatile metric it is also
+unreadable, because almost every bucket contains a spike, so the chart becomes a
+solid band whose height is worst case rather than typical. The Processor chart
+reading 7 percent while the plot is a wall of green is exactly this.
+
+For contrast, [beszel](https://github.com/henrygd/beszel), which Neil rates,
+never draws more than about ninety points at any range. It rolls records up in
+the backend, 1m into 10m into 20m into 120m into 480m, storing an average for
+metrics like CPU and memory and a peak for throughput, and the front end picks
+the tier that matches the range:
+
+| Range | Record tier | Points on screen |
+| --- | --- | --- |
+| 1 hr | 1m | about 60 |
+| 12 hr | 10m | about 72 |
+| 24 hr | 20m | about 72 |
+| 1 week | 120m | about 84 |
+| 30 days | 480m | about 90 |
+
+The lesson is not the exact numbers. It is that the point count is roughly
+constant whatever the range, and that the reduction is chosen per metric rather
+than per chart.
+
+## The rules
+
+**1. Never draw more points than there are pixels.** The budget comes from the
+plot width, not from the range. Aim for one bucket per two pixels and never
+exceed one per pixel. This applies equally to history loaded from the database
+and to samples appended live, because a window that starts correct drifts back
+to raw resolution after an hour of running otherwise.
+
+**2. How a bucket is reduced belongs to the metric, and is decided once.**
+
+| Kind of metric | Reduction | Why |
+| --- | --- | --- |
+| Utilisation and rates: CPU, memory, network, disk, GPU | mean, with a min and max band | the question is "how loaded", and the band keeps the spikes visible |
+| Temperature, fan speed | maximum | a thermal spike is the event; an average erases it |
+| Levels and states: pressure band, thermal pressure | last in bucket | a state is not an average |
+| Counters shown as totals | last in bucket | a mean of a monotonic series is meaningless |
+
+**3. A volatile series is a line plus a band, never a forest.** Draw the mean of
+each bucket as the line, and the minimum to maximum range as a translucent band
+of the same hue behind it. That keeps the worst case visible without letting it
+own the plot. The live decimator already computes both ends of the range, so
+this is a drawing change rather than a data change.
+
+**4. No range is special.** A range is raw only while its raw sample count fits
+the point budget. Five minutes at one second is 300 points and fits; one hour
+does not, so it is bucketed. Nothing is special-cased by name.
+
+**5. The y axis fits the data, with a floor on the span.** A fixed wide axis
+wastes the plot: a die sensor pinned to 0 to 110 draws a flat ribbon through the
+middle. A tight auto-fit does the opposite and turns a degree of idle noise into
+a mountain range. `ChartDomain.fitted` does both, and every chart states its
+minimum span. Percentages that genuinely use their range, like total CPU, keep
+0 to 100 so that half the chart always means the same thing.
+
+**6. The domain is stable while the chart is live.** Recompute it on a range
+change, or when the data leaves it, not on every tick. A y axis that rescales
+each second makes a steady signal look alive.
+
+**7. Gaps are gaps.** A missing sample breaks the line. Never interpolate across
+a hole, because on a monitoring chart a straight line means "we measured this"
+and a gap means "we were not looking".
+
+**8. Every chart says what it is showing against.** Where there is room, a
+labelled y axis, a time axis, and a caption. On a card strip there is not room,
+so it gets the two marks that matter: a baseline to sit on, and the window's
+peak in the corner. A sparkline with no anchor at all is decoration, not data.
+
+**9. Fill is for calm series only.** An area fill under a volatile line becomes
+a solid block. Swap and free space may be filled; CPU, temperature, network and
+disk may not.
+
+**10. Say what the reduction is.** When a chart is showing means of ten second
+buckets rather than samples, the caption says so. A smoothed line that claims to
+be raw data is a lie the user cannot see.
+
+## What enforces each rule
+
+| Rule | Where it lives |
+| --- | --- |
+| 1, 4 | `SystemHistoryWindow.bucketSeconds` for live appends, `chartDownsampled` for loaded history, `LiveSeriesDecimator` at draw time |
+| 2 | one table in Core, keyed by `SystemHistoryWindow.Column` |
+| 3 | `TrendSurface` band drawing, fed by the decimator's existing min and max |
+| 5, 6 | `ChartDomain.fitted`, called by each chart with its own minimum span |
+| 7 | `TrendModel.gapThreshold` |
+| 8 | `TrendChartGeometry` for full charts, `ScaledSparkline` for strips |
+| 9, 10 | review, and the captions each panel already carries |
+
+## Audit
+
+Verified by reading the code on 5 September 2026. "Follows" means the rule is
+met today; everything else is work.
+
+| Surface | Rules met | Work needed |
+| --- | --- | --- |
+| Dashboard: pressure, processor, network, disk, swap | 7 | 1, 3, 4: raw at 5 min to 1 hr, min/max forest above 30 min |
+| Dashboard: thermals | 2, 5, 7 | 1, 3: still raw below six hours |
+| Dashboard: metric cards | 5, 7, 9 | 8: no peak label, unlike the Processes header |
+| Processes header: CPU, load, die | 5, 8, 9 | 3: ten minute window is close to the budget but not derived from it |
+| GPU tab | 7 | 1, 3, 5: fixed 0 to 100 and 0 to peak domains |
+| Energy and battery | 7, 9 | 1, 3, 5 |
+| Disk tab | 7 | 1, 3, 5 |
+| Network tab | 7 | 1, 3, 5 |
+| Menu bar panels | 8, 9 | 3, 5 |
+| Insights and Analytics | to audit | to audit |
+
+## Rollout
+
+One pull request per rule group, applied across every surface at once rather
+than per tab, because the point of writing this down is to stop fixing charts
+one at a time.
+
+1. **Resolution** (rules 1 and 4): the point budget comes from the plot width;
+   the live window buckets its appends; loaded history uses the same budget. One
+   change in Core plus the call sites.
+2. **Reduction** (rules 2 and 3): the per-metric table, and the band behind the
+   mean line in `TrendSurface`.
+3. **Axes** (rules 5 and 6): `ChartDomain.fitted` everywhere, with a stated
+   minimum span per metric, and hysteresis on live recomputation.
+4. **Annotation** (rules 8 and 10): peak labels on every card strip, captions
+   that name the reduction.
+
+Rules 7 and 9 are already met almost everywhere; the audit lists the exceptions.


### PR DESCRIPTION
Neil's point, and a fair one: today's chart work has been piecemeal. Six fixes
that were all the same fix in different places. This writes the rules down and
audits every surface against them, so the next change is a policy change.

`docs/chart-rules.md` has ten rules. The first four do most of the work:

1. **Never draw more points than pixels.** The budget comes from the plot width,
   not the range, and it applies to live appends as well as loaded history.
2. **The reduction belongs to the metric**, not the chart: mean for utilisation
   and rates, maximum for temperature, last for states.
3. **A volatile series is a mean line inside a min and max band**, never a
   forest of spikes.
4. **No range is special.** Raw only while the raw count fits the budget.

The numbers are measured. At a one second cadence, one hour draws 3,600 points
into about 1,500 pixels while six hours draws 360. The live decimator emits the
minimum and maximum of each of 720 buckets, which hides no spike and is
unreadable for a volatile metric, because almost every bucket has one. That is
why the Processor chart reads 7 percent while the plot is a wall of green.

Beszel is in there as the contrast, since it was the reference: it never draws
more than about ninety points at any range, rolling records up 1m to 10m to 20m
to 120m to 480m, storing an average for CPU and memory and a peak for
throughput, with the front end picking the tier per range. The lesson taken is
the shape rather than the numbers.

The document ends with an audit of every chart surface and a four-stage rollout,
one pull request per rule group applied across all surfaces at once.

This also carries the first piece of rule 1: `SystemHistoryWindow` can fold
appended samples into buckets, so a live window keeps the resolution the chart
can show however long the app runs. Not yet switched on by any caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ