### PR TITLE
Chart rules 1 to 4: a mean line inside a band, not a forest of spikes

### DIFF
--- a/Sources/MacPerfMonitor/Charts/SparklineSurface.swift
+++ b/Sources/MacPerfMonitor/Charts/SparklineSurface.swift
@@ -27,7 +27,8 @@ final class MetricCardFeed {
 
     func publish(
         value: String?, tint: NSColor, column: LiveColumn?, scale: Double = 1,
-        xDomain: ClosedRange<Date>?, yDomain: ClosedRange<Double>?, peak: String? = nil
+        xDomain: ClosedRange<Date>?, yDomain: ClosedRange<Double>?, peak: String? = nil,
+        reduction: TrendSurfaceSeries.Reduction = .mean
     ) {
         self.value = value
         self.peak = peak
@@ -41,7 +42,8 @@ final class MetricCardFeed {
         if let column {
             model.series = [
                 TrendSurfaceSeries(
-                    column: column, scale: scale, color: Color(nsColor: tint), lineWidth: 1.5)
+                    column: column, scale: scale, color: Color(nsColor: tint), lineWidth: 1.5,
+                    reduction: reduction)
             ]
         }
         model.xDomain = xDomain

--- a/Sources/MacPerfMonitor/Charts/TrendSurface.swift
+++ b/Sources/MacPerfMonitor/Charts/TrendSurface.swift
@@ -8,11 +8,22 @@ import SwiftUI
 /// (see `TrendSurfaceView`). `scale` multiplies every value (CPU load 0...1
 /// is shown as a percentage).
 struct TrendSurfaceSeries {
+    /// What the line through a bucket of samples should be. See rule 2 in
+    /// docs/chart-rules.md: the reduction belongs to the metric, not the chart.
+    enum Reduction {
+        /// "How loaded was it": the mean, with the extremes drawn as a band.
+        case mean
+        /// "Did it spike": the maximum. Temperatures and fan speeds, where an
+        /// average erases the event worth seeing.
+        case maximum
+    }
+
     var column: LiveColumn
     var scale: Double = 1
     var color: Color
     var filled = false
     var lineWidth: CGFloat = 2
+    var reduction: Reduction = .mean
 }
 
 /// What a live chart surface draws: the same inputs as `TrendChart`, as a
@@ -789,6 +800,50 @@ enum TrendRenderer {
     /// points, y is the plot height flipped. The caller has clipped the
     /// context to the columns being repainted; the path is built from a couple
     /// of buckets either side so joins at the clip edges match a full repaint.
+    /// The middle of a bucket in absolute time, so an aggregated line sits at
+    /// the centre of the column it summarises rather than at whichever sample
+    /// happened to be the extreme.
+    fileprivate static func bucketMidTime(
+        _ bucket: LiveStripBuckets.Bucket, width: Double
+    )
+        -> Double
+    {
+        (Double(bucket.index) + 0.5) * width
+    }
+
+    /// The minimum-to-maximum spread of each bucket, as one translucent shape
+    /// behind the line. Runs break at gaps, exactly like the line does.
+    fileprivate static func drawBand(
+        _ buckets: [LiveStripBuckets.Bucket], width: Double, color: NSColor,
+        x: (Double) -> CGFloat, y: (Double) -> CGFloat, context ctx: CGContext
+    ) {
+        var run: [LiveStripBuckets.Bucket] = []
+        func flush() {
+            defer { run = [] }
+            guard run.count > 1 else { return }
+            var top: [CGPoint] = []
+            var bottom: [CGPoint] = []
+            top.reserveCapacity(run.count)
+            bottom.reserveCapacity(run.count)
+            for bucket in run {
+                let px = x(bucketMidTime(bucket, width: width))
+                top.append(CGPoint(x: px, y: y(bucket.maxValue)))
+                bottom.append(CGPoint(x: px, y: y(bucket.minValue)))
+            }
+            let path = CGMutablePath()
+            path.addLines(between: top + bottom.reversed())
+            path.closeSubpath()
+            ctx.addPath(path)
+            ctx.setFillColor(color.withAlphaComponent(0.22).cgColor)
+            ctx.fillPath()
+        }
+        for bucket in buckets {
+            if bucket.gapBefore { flush() }
+            run.append(bucket)
+        }
+        flush()
+    }
+
     fileprivate static func drawColumns(
         _ model: TrendModel, tick: TickFrame, bucketWidth: Double, home: Int,
         buckets: ClosedRange<Int>, height: CGFloat, context ctx: CGContext,
@@ -821,6 +876,16 @@ enum TrendRenderer {
             guard !extremes.isEmpty else { continue }
             let color = NSColor(s.color)
 
+            // More than one sample per column means the samples cannot all be
+            // drawn honestly. Rule 3: the line becomes the bucket's reduction
+            // and the spread goes behind it as a band, instead of a spike per
+            // column that turns a busy metric into a solid block.
+            let aggregated = extremes.contains(where: \.isAggregate)
+            if aggregated {
+                drawBand(
+                    extremes, width: bucketWidth, color: color, x: x, y: y, context: ctx)
+            }
+
             // Gap-free runs of points in time order.
             var runs: [[CGPoint]] = []
             var current: [CGPoint] = []
@@ -829,8 +894,14 @@ enum TrendRenderer {
                     runs.append(current)
                     current = []
                 }
-                for point in bucket.orderedPoints {
-                    current.append(CGPoint(x: x(point.time), y: y(point.value)))
+                if aggregated {
+                    let value = s.reduction == .maximum ? bucket.maxValue : bucket.mean
+                    current.append(
+                        CGPoint(x: x(bucketMidTime(bucket, width: bucketWidth)), y: y(value)))
+                } else {
+                    for point in bucket.orderedPoints {
+                        current.append(CGPoint(x: x(point.time), y: y(point.value)))
+                    }
                 }
             }
             if !current.isEmpty { runs.append(current) }

--- a/Sources/MacPerfMonitor/Views/DashboardView.swift
+++ b/Sources/MacPerfMonitor/Views/DashboardView.swift
@@ -633,7 +633,7 @@ private final class DashboardTimelineStore: ObservableObject {
         let column = LiveColumn(window, .cpuLoad)
         var model = TrendModel()
         model.series = [
-            TrendSurfaceSeries(column: column, scale: 100, color: level.color, filled: true)
+            TrendSurfaceSeries(column: column, scale: 100, color: level.color)
         ]
         model.xDomain = domain
         model.yDomain = 0...100
@@ -663,7 +663,7 @@ private final class DashboardTimelineStore: ObservableObject {
         let upload = LiveColumn(window, .networkOutBytesPerSec)
         var model = TrendModel()
         model.series = [
-            TrendSurfaceSeries(column: download, color: NetworkStyle.download, filled: true),
+            TrendSurfaceSeries(column: download, color: NetworkStyle.download),
             TrendSurfaceSeries(
                 column: upload, color: NetworkStyle.upload, filled: false, lineWidth: 1.8),
         ]
@@ -694,7 +694,7 @@ private final class DashboardTimelineStore: ObservableObject {
         let write = LiveColumn(window, .diskWriteBytesPerSec)
         var model = TrendModel()
         model.series = [
-            TrendSurfaceSeries(column: read, color: DiskStyle.read, filled: true),
+            TrendSurfaceSeries(column: read, color: DiskStyle.read),
             TrendSurfaceSeries(
                 column: write, color: DiskStyle.write, filled: false, lineWidth: 1.8),
         ]

--- a/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
+++ b/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
@@ -282,7 +282,10 @@ final class ProcessHeaderStore: ObservableObject {
             xDomain: window.xDomain, yDomain: dieDomain,
             peak: window.peak(.cpuDieC).flatMap {
                 $0 > 0 ? t("peak %@°C", String(Int($0.rounded()))) : nil
-            })
+            },
+            // Rule 2: a thermal spike is the event, so the line follows the
+            // bucket maximum rather than its mean.
+            reduction: .maximum)
     }
 
     private static func point(from s: SystemSample) -> SystemHistoryPoint {

--- a/Sources/MacPerfMonitorCore/Util/LiveStripBuckets.swift
+++ b/Sources/MacPerfMonitorCore/Util/LiveStripBuckets.swift
@@ -20,6 +20,12 @@ public enum LiveStripBuckets {
         public var minValue: Double
         public var maxTime: Double
         public var maxValue: Double
+        /// Running total and count of the samples in this bucket, so the mean
+        /// can be drawn as the line with the extremes as a band behind it. A
+        /// chart that draws only the extremes reads as a forest of spikes once
+        /// more than one sample lands in a column: see docs/chart-rules.md.
+        public var sum: Double
+        public var count: Int
         /// True when the first sample in this bucket follows a pause longer
         /// than the gap threshold, so a line must not connect it to the
         /// previous bucket.
@@ -27,7 +33,7 @@ public enum LiveStripBuckets {
 
         public init(
             index: Int, minTime: Double, minValue: Double, maxTime: Double, maxValue: Double,
-            gapBefore: Bool
+            gapBefore: Bool, sum: Double? = nil, count: Int = 1
         ) {
             self.index = index
             self.minTime = minTime
@@ -35,7 +41,17 @@ public enum LiveStripBuckets {
             self.maxTime = maxTime
             self.maxValue = maxValue
             self.gapBefore = gapBefore
+            self.sum = sum ?? minValue
+            self.count = count
         }
+
+        /// The bucket's mean, which is what a line through the buckets should
+        /// follow. Falls back to the single value when there is only one.
+        public var mean: Double { count > 0 ? sum / Double(count) : minValue }
+
+        /// Whether this bucket holds more than the one sample a column can show
+        /// directly, and so has a band worth drawing.
+        public var isAggregate: Bool { count > 1 && maxValue > minValue }
 
         /// The bucket's one or two points in chronological order: a single
         /// point when both extremes are the same sample, else the earlier
@@ -101,6 +117,8 @@ public enum LiveStripBuckets {
                     bucket.maxValue = v
                     bucket.maxTime = t
                 }
+                bucket.sum += v
+                bucket.count += 1
                 current = bucket
             } else {
                 if let bucket = current { out.append(bucket) }

--- a/Sources/MacPerfMonitorCore/Util/SystemHistoryWindow.swift
+++ b/Sources/MacPerfMonitorCore/Util/SystemHistoryWindow.swift
@@ -44,40 +44,14 @@ public struct SystemHistoryWindow {
     private var columns: [[Double]] = Array(repeating: [], count: Column.allCases.count)
     private var head = 0
     public private(set) var span: TimeInterval
-    /// Width of the buckets appended samples are folded into, or zero to keep
-    /// every sample as it arrives.
-    ///
-    /// A one hour window at a one second cadence holds 3,600 samples and is
-    /// drawn perhaps 1,500 pixels wide, so more than two samples land in every
-    /// column and the line is painted at the highest of them: the chart reads as
-    /// a band of noise whose height is worst case rather than typical. Folding
-    /// appends into buckets keeps the window at the resolution the chart can
-    /// actually show, however long the app runs. Short ranges leave this at zero
-    /// and keep every sample, because at five minutes the detail is the point.
-    public private(set) var bucketSeconds: TimeInterval = 0
-    /// How many samples the open bucket has absorbed, for the running mean.
-    private var openBucketCount = 0
     /// The newest sample in full, for the live read-outs.
     public private(set) var latest: SystemHistoryPoint?
 
     private static var compactionThreshold: Int { 1024 }
 
-    public init(span: TimeInterval, bucketSeconds: TimeInterval = 0) {
+    public init(span: TimeInterval) {
         precondition(span > 0, "SystemHistoryWindow span must be positive")
         self.span = span
-        self.bucketSeconds = max(0, bucketSeconds)
-    }
-
-    /// Change the bucket width. Samples already held keep whatever resolution
-    /// they were stored at; the caller reloads when it wants them re-bucketed.
-    public mutating func setBucketSeconds(_ seconds: TimeInterval) {
-        bucketSeconds = max(0, seconds)
-        openBucketCount = 0
-    }
-
-    /// Which bucket a timestamp belongs to, as a bucket index.
-    private func bucket(_ time: Double) -> Double {
-        (time / bucketSeconds).rounded(.down)
     }
 
     public var count: Int { times.count - head }
@@ -121,58 +95,20 @@ public struct SystemHistoryWindow {
 
     /// Append a sample newer than the latest one. Returns false, leaving the
     /// window untouched, when it is not.
+    /// Samples are kept as they arrive, at full resolution.
+    ///
+    /// It is tempting to fold them into buckets here, since an hour at a one
+    /// second cadence is 3,600 samples for a plot a fraction that wide. Do not:
+    /// the charts draw a mean line inside a band of the real minimum and
+    /// maximum, and averaging on the way in would throw away the extremes that
+    /// band is made of. The reduction belongs at draw time, where both are
+    /// still available. See docs/chart-rules.md.
     @discardableResult
     public mutating func append(_ point: SystemHistoryPoint) -> Bool {
         if let latest, point.date <= latest.date { return false }
-        let time = point.date.timeIntervalSinceReferenceDate
-        if bucketSeconds > 0, let lastTime = times.last, count > 0,
-            bucket(lastTime) == bucket(time)
-        {
-            merge(point)
-        } else {
-            openBucketCount = 1
-            push(point)
-        }
+        push(point)
         trim()
         return true
-    }
-
-    /// Fold a sample into the open bucket rather than starting a new one.
-    ///
-    /// Most metrics take a running mean, which is what makes a long window
-    /// readable. The temperature column takes the maximum instead, matching the
-    /// stored-history downsampler: averaging thermal readings erases the spikes,
-    /// which are the reason to look at them at all. The timestamp stays at the
-    /// bucket's first sample so the x axis does not creep.
-    private mutating func merge(_ point: SystemHistoryPoint) {
-        let n = Double(openBucketCount)
-        let next = n + 1
-        func mean(_ column: Column, _ value: Double) {
-            let i = columns[column.rawValue].count - 1
-            columns[column.rawValue][i] = (columns[column.rawValue][i] * n + value) / next
-        }
-        func peak(_ column: Column, _ value: Double) {
-            let i = columns[column.rawValue].count - 1
-            columns[column.rawValue][i] = Swift.max(columns[column.rawValue][i], value)
-        }
-        mean(.pressurePercent, point.pressurePercent)
-        mean(.cpuLoad, point.cpuLoad)
-        mean(.appMemory, Double(point.appMemory))
-        mean(.wired, Double(point.wired))
-        mean(.compressed, Double(point.compressed))
-        mean(.cachedFiles, Double(point.cachedFiles))
-        mean(.swapUsed, Double(point.swapUsed))
-        mean(.networkInBytesPerSec, point.networkInBytesPerSec)
-        mean(.networkOutBytesPerSec, point.networkOutBytesPerSec)
-        mean(.diskReadBytesPerSec, point.diskReadBytesPerSec)
-        mean(.diskWriteBytesPerSec, point.diskWriteBytesPerSec)
-        mean(.gpuUtilization, point.gpuUtilization ?? 0)
-        mean(.gpuPowerWatts, point.gpuPowerWatts ?? 0)
-        mean(.anePowerWatts, point.anePowerWatts ?? 0)
-        peak(.cpuDieC, point.cpuDieC ?? 0)
-        openBucketCount += 1
-        // The read-outs want the sample as it arrived, not the bucket's mean.
-        latest = point
     }
 
     /// The window as points, oldest first. Allocates; for occasional use only

--- a/Tests/MacPerfMonitorCoreTests/LiveStripBucketsTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/LiveStripBucketsTests.swift
@@ -119,4 +119,55 @@ final class LiveStripBucketsTests: XCTestCase {
                 times: t[...], values: v[...], width: 0, from: 0, through: 10, gapThreshold: 30
             ).isEmpty)
     }
+    // MARK: Rule 2 and 3: a bucket carries its mean as well as its extremes
+
+    func testBucketCarriesMeanAndCount() {
+        let times: [Double] = [0, 1, 2, 3]
+        let values: [Double] = [10, 20, 30, 40]
+        let buckets = LiveStripBuckets.buckets(
+            times: times[...], values: values[...], width: 10,
+            from: 0, through: 0, gapThreshold: 100)
+        XCTAssertEqual(buckets.count, 1)
+        let bucket = try! XCTUnwrap(buckets.first)
+        XCTAssertEqual(bucket.count, 4)
+        XCTAssertEqual(bucket.mean, 25, accuracy: 0.0001)
+        XCTAssertEqual(bucket.minValue, 10)
+        XCTAssertEqual(bucket.maxValue, 40)
+        XCTAssertTrue(bucket.isAggregate)
+    }
+
+    func testSingleSampleBucketIsNotAggregate() {
+        let times: [Double] = [0]
+        let values: [Double] = [42]
+        let buckets = LiveStripBuckets.buckets(
+            times: times[...], values: values[...], width: 10,
+            from: 0, through: 0, gapThreshold: 100)
+        let bucket = try! XCTUnwrap(buckets.first)
+        XCTAssertEqual(bucket.mean, 42)
+        XCTAssertEqual(bucket.count, 1)
+        XCTAssertFalse(bucket.isAggregate, "one sample has no spread to band")
+    }
+
+    func testMeanIgnoresBucketBoundariesCorrectly() {
+        // Two buckets of two samples each: means 15 and 35, not one mean of 25.
+        let times: [Double] = [0, 1, 10, 11]
+        let values: [Double] = [10, 20, 30, 40]
+        let buckets = LiveStripBuckets.buckets(
+            times: times[...], values: values[...], width: 10,
+            from: 0, through: 1, gapThreshold: 100)
+        XCTAssertEqual(buckets.count, 2)
+        XCTAssertEqual(buckets[0].mean, 15, accuracy: 0.0001)
+        XCTAssertEqual(buckets[1].mean, 35, accuracy: 0.0001)
+    }
+
+    func testScaleAppliesToTheMeanToo() {
+        let times: [Double] = [0, 1]
+        let values: [Double] = [0.1, 0.3]
+        let buckets = LiveStripBuckets.buckets(
+            times: times[...], values: values[...], width: 10,
+            from: 0, through: 0, gapThreshold: 100, scale: 100)
+        let bucket = try! XCTUnwrap(buckets.first)
+        XCTAssertEqual(bucket.mean, 20, accuracy: 0.0001)
+    }
+
 }

--- a/docs/chart-rules.md
+++ b/docs/chart-rules.md
@@ -49,11 +49,13 @@ than per chart.
 
 ## The rules
 
-**1. Never draw more points than there are pixels.** The budget comes from the
-plot width, not from the range. Aim for one bucket per two pixels and never
-exceed one per pixel. This applies equally to history loaded from the database
-and to samples appended live, because a window that starts correct drifts back
-to raw resolution after an hour of running otherwise.
+**1. Never draw more points than there are pixels, and reduce as late as
+possible.** The budget comes from the plot width, not from the range: one bucket
+per column of the plot. Do the reduction at draw time, not on the way into the
+window or out of the database, because rule 3 needs the real minimum and maximum
+of each bucket and an average taken earlier has already thrown them away. Keeping
+full resolution in memory is the cheap part; an hour at one second is 3,600
+doubles per metric.
 
 **2. How a bucket is reduced belongs to the metric, and is decided once.**
 
@@ -70,9 +72,13 @@ of the same hue behind it. That keeps the worst case visible without letting it
 own the plot. The live decimator already computes both ends of the range, so
 this is a drawing change rather than a data change.
 
-**4. No range is special.** A range is raw only while its raw sample count fits
-the point budget. Five minutes at one second is 300 points and fits; one hour
-does not, so it is bucketed. Nothing is special-cased by name.
+**4. No range is special.** Every range goes through the same reduction, and it
+is the plot width that decides how much reduction happens. Five minutes at one
+second is 300 samples and most of them survive; an hour is 3,600 and most do
+not. Nothing is special-cased by name. Ranges long enough to be served by the
+stored minute and hour tiers arrive pre-averaged, so their bands are flat: giving
+those tiers a stored minimum and maximum is the one piece of this that is not
+done.
 
 **5. The y axis fits the data, with a floor on the span.** A fixed wide axis
 wastes the plot: a die sensor pinned to 0 to 110 draws a flat ribbon through the
@@ -106,7 +112,7 @@ be raw data is a lie the user cannot see.
 
 | Rule | Where it lives |
 | --- | --- |
-| 1, 4 | `SystemHistoryWindow.bucketSeconds` for live appends, `chartDownsampled` for loaded history, `LiveSeriesDecimator` at draw time |
+| 1, 4 | `LiveStripBuckets` at draw time, one bucket per plot column. The window keeps every sample on purpose |
 | 2 | one table in Core, keyed by `SystemHistoryWindow.Column` |
 | 3 | `TrendSurface` band drawing, fed by the decimator's existing min and max |
 | 5, 6 | `ChartDomain.fitted`, called by each chart with its own minimum span |
@@ -121,10 +127,10 @@ met today; everything else is work.
 
 | Surface | Rules met | Work needed |
 | --- | --- | --- |
-| Dashboard: pressure, processor, network, disk, swap | 7 | 1, 3, 4: raw at 5 min to 1 hr, min/max forest above 30 min |
-| Dashboard: thermals | 2, 5, 7 | 1, 3: still raw below six hours |
-| Dashboard: metric cards | 5, 7, 9 | 8: no peak label, unlike the Processes header |
-| Processes header: CPU, load, die | 5, 8, 9 | 3: ten minute window is close to the budget but not derived from it |
+| Dashboard: pressure, processor, network, disk, swap | 1, 2, 3, 4, 7, 9 | none |
+| Dashboard: thermals | 2, 5, 7 | 3: drawn by `TemperatureChart`, which has no band yet |
+| Dashboard: metric cards | 1, 2, 3, 4, 5, 7, 9 | 8: no peak label, unlike the Processes header |
+| Processes header: CPU, load, die | 1, 2, 3, 4, 5, 8, 9 | none |
 | GPU tab | 7 | 1, 3, 5: fixed 0 to 100 and 0 to peak domains |
 | Energy and battery | 7, 9 | 1, 3, 5 |
 | Disk tab | 7 | 1, 3, 5 |
@@ -138,14 +144,20 @@ One pull request per rule group, applied across every surface at once rather
 than per tab, because the point of writing this down is to stop fixing charts
 one at a time.
 
-1. **Resolution** (rules 1 and 4): the point budget comes from the plot width;
-   the live window buckets its appends; loaded history uses the same budget. One
-   change in Core plus the call sites.
-2. **Reduction** (rules 2 and 3): the per-metric table, and the band behind the
-   mean line in `TrendSurface`.
-3. **Axes** (rules 5 and 6): `ChartDomain.fitted` everywhere, with a stated
-   minimum span per metric, and hysteresis on live recomputation.
-4. **Annotation** (rules 8 and 10): peak labels on every card strip, captions
-   that name the reduction.
+1. **Resolution and reduction** (rules 1 to 4, 9): done for every live surface.
+   `LiveStripBuckets` carries each bucket's mean alongside its extremes, and
+   `TrendSurface` draws the mean as the line inside a translucent band of the
+   spread. Series declare their reduction, so temperature follows the maximum
+   while everything else follows the mean, and the area fills are gone from the
+   volatile series.
+2. **Axes** (rules 5 and 6): `ChartDomain.fitted` everywhere, with a stated
+   minimum span per metric, and hysteresis on live recomputation. Done for the
+   two temperature surfaces; the GPU, Energy, Disk and Network tabs still carry
+   fixed domains.
+3. **Annotation** (rules 8 and 10): peak labels on every card strip, captions
+   that name the reduction. Done for the Processes header only.
+4. **Stored tiers** (rule 4's exception): keep a minimum and maximum alongside
+   the mean in the minute and hour tiers, so ranges of six hours and longer get
+   a band too.
 
-Rules 7 and 9 are already met almost everywhere; the audit lists the exceptions.
+Rules 7 and 9 are met everywhere the audit does not list an exception.


### PR DESCRIPTION
First stage of the rollout in `docs/chart-rules.md`, applied to every live chart
at once rather than tab by tab.

**The mechanism, now that I have read it properly.** The reduction was never
missing: the surface already buckets to one column per pixel. What it drew was
the minimum *and* maximum of each bucket, which hides no spike and is unreadable
once more than one sample lands in a column, because almost every column then
has a spike. That is the wall of green behind a 7 percent read-out.

**The change.** Each bucket now carries its mean and count alongside its
extremes. The surface draws the mean as the line and the spread behind it as a
translucent band. A column holding a single sample draws exactly as before, so
short ranges are untouched.

**Reduction belongs to the metric** (rule 2), so series declare theirs:
temperature follows the bucket maximum, since a thermal spike is the event an
average erases, everything else follows the mean.

**Fills** are gone from the volatile series (rule 9). A gradient under a noisy
line is a solid block, and with a band it was doing the same job twice. Pressure
and swap keep theirs.

**One correction to my own work.** The window bucketing that shipped with the
rules document is removed. Folding samples into means on the way in would have
destroyed the extremes the band is made of. The reduction belongs at draw time,
where both are still available, and `SystemHistoryWindow` now says so where the
temptation lives. The rules document is corrected to match, including the piece
that is not done: the stored minute and hour tiers arrive pre-averaged, so six
hours and longer have flat bands until those tiers keep a minimum and maximum.

Four new tests cover the bucket mean, the single sample case, bucket boundaries
and scaling. 571 tests, lint, and both localization checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ