### PR TITLE
Draw charts as monotone curves, carry the stored peaks, and start runs from real samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ Notable changes to Mac Performance Monitor. This project follows
   Opening at login stays quiet, with no window and no Dock icon.
 - Closing the last window quits the app when neither the menu bar item nor
   recording is switched on. With either on, it keeps running as before.
+- **Every chart follows one set of rules**, written down in
+  `docs/chart-rules.md` and modelled on beszel. A line carries about 120 points
+  whatever the range, so a five minute view and a seven day view are equally
+  readable, and the reduction to those points happens at draw time so nothing
+  is thrown away on the way in. A volatile metric is drawn as the mean of each
+  point's samples inside a translucent band from their minimum to their
+  maximum, so the plot shows the typical level and the spikes at once instead of
+  a solid block of spikes. Temperatures follow the maximum, because the spike is
+  the event. The line is a monotone curve, the kind beszel draws, which is
+  smooth but cannot overshoot, so every bump on it was measured. On the six
+  hour, day and week ranges the stored rows carry their bucket's peak, so the
+  band still reaches the real spikes there, and those ranges now run right up
+  to the present rather than stopping at the last complete minute or hour.
+  Temperature axes fit the data with a floor on their span, the area fills are
+  gone from the volatile series, the Processes header cards state their peak,
+  and the load average is a chart.
 
 ### Security
 
@@ -63,6 +79,24 @@ Notable changes to Mac Performance Monitor. This project follows
   scan once a minute when nothing else calls for one.
 - With no menu bar item, no window and no panel open, the sampler no longer
   publishes to the main thread every second for nobody to read.
+- A chart resuming after a gap no longer climbs vertically from zero. The
+  sampler's first tick after launch has nothing to difference against, so its
+  CPU, network and disk figures were zero by construction, and that tick was
+  both recorded and drawn: every restart left a zero at the start of the run.
+  The first tick still seeds the sampler and drives the first process scan, but
+  it is neither recorded nor charted.
+- The six hour, day and week ranges drew dots instead of a line. The gap
+  threshold was sized to the logging interval, but those ranges are served by
+  rows a minute or an hour apart, so every row counted as an island. The
+  threshold now follows the spacing of whichever tier the range loaded from.
+- Gaps in the recently drawn line, and straight lines across periods when the
+  app was not running: samples kept arriving while the window was covered but
+  were dropped, and the gap threshold grew with the range (two and a half
+  minutes at an hour) so real holes were bridged. Samples are now kept while the
+  window is covered, and a gap is anything beyond three times the cadence.
+- The thermals chart changed shape as it scrolled: its buckets were sized from
+  the data's extent rather than the axis, so every new sample moved every
+  boundary. Buckets are anchored to absolute time now.
 - 99 interface strings were never in the catalog, so they stayed English in
   every language whatever you chose. They are SwiftUI literals that the
   source-scanning check cannot see, from the battery detail panels, the network

--- a/Sources/MacPerfMonitor/Charts/LiveTrend.swift
+++ b/Sources/MacPerfMonitor/Charts/LiveTrend.swift
@@ -10,15 +10,24 @@ struct LiveColumn {
     /// `timeIntervalSinceReferenceDate` seconds, oldest first.
     var times: ArraySlice<Double>
     var values: ArraySlice<Double>
+    /// Each sample's own peak, where the samples are stored means with the
+    /// bucket maximum beside them (`SystemHistoryWindow.Column` peak columns).
+    /// The band rises to these; the line ignores them.
+    var highs: ArraySlice<Double>?
 
-    init(times: ArraySlice<Double>, values: ArraySlice<Double>) {
+    init(times: ArraySlice<Double>, values: ArraySlice<Double>, highs: ArraySlice<Double>? = nil) {
         self.times = times
         self.values = values
+        self.highs = highs
     }
 
-    init(_ window: SystemHistoryWindow, _ column: SystemHistoryWindow.Column) {
+    init(
+        _ window: SystemHistoryWindow, _ column: SystemHistoryWindow.Column,
+        peak: SystemHistoryWindow.Column? = nil
+    ) {
         times = window.timestamps
         values = window.values(column)
+        highs = peak.map { window.values($0) }
     }
 
     init(_ points: [SystemHistoryPoint], value: (SystemHistoryPoint) -> Double) {

--- a/Sources/MacPerfMonitor/Charts/MonotoneCurve.swift
+++ b/Sources/MacPerfMonitor/Charts/MonotoneCurve.swift
@@ -1,0 +1,65 @@
+import CoreGraphics
+import MacPerfMonitorCore
+
+/// Builds the smooth curve every chart line and band edge is drawn with.
+///
+/// The shape is `MonotoneCubic`'s: it passes through every point and never
+/// overshoots between two of them, so what looks like a peak is a point that
+/// was measured. Fewer than three points fall back to straight segments.
+enum MonotoneCurve {
+    /// Append the curve through `points` (x increasing) to `path`. With
+    /// `reversed` the same curve is traced from the last point back to the
+    /// first, which is how a band closes along its lower edge. `move` starts
+    /// a subpath at the first point; otherwise a straight line joins it to the
+    /// path's current point.
+    static func add(
+        _ points: [CGPoint], to path: CGMutablePath, reversed: Bool = false, move: Bool = true
+    ) {
+        guard !points.isEmpty else { return }
+        func begin(_ p: CGPoint) {
+            if move { path.move(to: p) } else { path.addLine(to: p) }
+        }
+        if points.count < 3 {
+            let sequence = reversed ? Array(points.reversed()) : points
+            begin(sequence[0])
+            for p in sequence.dropFirst() { path.addLine(to: p) }
+            return
+        }
+        let m = MonotoneCubic.tangents(
+            xs: points.map { Double($0.x) }, ys: points.map { Double($0.y) })
+        if reversed {
+            begin(points[points.count - 1])
+            var i = points.count - 1
+            while i > 0 {
+                let p0 = points[i - 1]
+                let p1 = points[i]
+                let c = MonotoneCubic.controlPoints(
+                    x0: Double(p0.x), y0: Double(p0.y), x1: Double(p1.x), y1: Double(p1.y),
+                    m0: m[i - 1], m1: m[i])
+                path.addCurve(
+                    to: p0, control1: CGPoint(x: c.c2x, y: c.c2y),
+                    control2: CGPoint(x: c.c1x, y: c.c1y))
+                i -= 1
+            }
+        } else {
+            begin(points[0])
+            for i in 1..<points.count {
+                let p0 = points[i - 1]
+                let p1 = points[i]
+                let c = MonotoneCubic.controlPoints(
+                    x0: Double(p0.x), y0: Double(p0.y), x1: Double(p1.x), y1: Double(p1.y),
+                    m0: m[i - 1], m1: m[i])
+                path.addCurve(
+                    to: p1, control1: CGPoint(x: c.c1x, y: c.c1y),
+                    control2: CGPoint(x: c.c2x, y: c.c2y))
+            }
+        }
+    }
+
+    /// The curve through `points` as a fresh path.
+    static func path(_ points: [CGPoint]) -> CGMutablePath {
+        let path = CGMutablePath()
+        add(points, to: path)
+        return path
+    }
+}

--- a/Sources/MacPerfMonitor/Charts/TrendChart.swift
+++ b/Sources/MacPerfMonitor/Charts/TrendChart.swift
@@ -578,11 +578,8 @@ private struct TrendLiveLayer: View {
                     } else {
                         run = rawRun
                     }
-                    var linePath = Path()
-                    for (i, pt) in run.enumerated() {
-                        let q = CGPoint(x: x(pt.date), y: y(pt.value))
-                        if i == 0 { linePath.move(to: q) } else { linePath.addLine(to: q) }
-                    }
+                    let linePath = Path(
+                        MonotoneCurve.path(run.map { CGPoint(x: x($0.date), y: y($0.value)) }))
                     if s.filled, run.count >= 2 {
                         var fill = linePath
                         fill.addLine(to: CGPoint(x: x(run.last!.date), y: plot.maxY))

--- a/Sources/MacPerfMonitor/Charts/TrendSurface.swift
+++ b/Sources/MacPerfMonitor/Charts/TrendSurface.swift
@@ -397,7 +397,12 @@ final class TrendSurfaceView: LiveSurfaceView {
         {
             // Extend: the bucket still filling plus its neighbours, whose
             // joins depend on it, are repainted; everything older is final.
-            dirtyFrom = max(current.drawnThrough - 3, current.home)
+            // The line is a curve whose slope at a point depends on both
+            // neighbours, so a new sample also reshapes the segment before the
+            // previous one: repaint back past two sample spacings (the gap
+            // threshold is three) so that segment gets its final tangent.
+            let reach = Int((2 * gapThreshold / 3 / bucketWidth).rounded(.up))
+            dirtyFrom = max(current.drawnThrough - 3 - reach, current.home)
             current.drawnThrough = live
             strip = current
         } else {
@@ -903,7 +908,8 @@ enum TrendRenderer {
                 bottom.append(CGPoint(x: px, y: y(bucket.minValue)))
             }
             let path = CGMutablePath()
-            path.addLines(between: top + bottom.reversed())
+            MonotoneCurve.add(top, to: path)
+            MonotoneCurve.add(bottom, to: path, reversed: true, move: false)
             path.closeSubpath()
             ctx.addPath(path)
             ctx.setFillColor(color.withAlphaComponent(0.22).cgColor)
@@ -953,14 +959,19 @@ enum TrendRenderer {
         // window itself.
         let smoothing =
             bucketWidth > 0 ? max(1, Int((smoothingSeconds / bucketWidth).rounded())) : 1
+        // Columns of extra history to the left, so a repaint of a few live
+        // columns matches a full one exactly. The first visible curve segment
+        // takes its shape from the two points before it, each at most a gap
+        // threshold back (further and it is a new run), and each of those needs
+        // the full trailing window behind it for its averaged value to agree.
+        let gapColumns = bucketWidth > 0 ? Int((tick.gapThreshold / bucketWidth).rounded(.up)) : 1
+        let context = 2 * gapColumns + smoothing + 2
 
         for s in model.series {
-            // Fetch the extra columns to the left that the trailing average
-            // needs, so a repaint of a few live columns matches a full one.
             let extremes = LiveStripBuckets.buckets(
-                times: s.column.times, values: s.column.values, width: bucketWidth,
-                from: buckets.lowerBound - smoothing, through: buckets.upperBound,
-                gapThreshold: tick.gapThreshold, scale: s.scale)
+                times: s.column.times, values: s.column.values, highs: s.column.highs,
+                width: bucketWidth, from: buckets.lowerBound - context,
+                through: buckets.upperBound, gapThreshold: tick.gapThreshold, scale: s.scale)
             guard !extremes.isEmpty else { continue }
             let color = NSColor(s.color)
 
@@ -1005,8 +1016,7 @@ enum TrendRenderer {
                         in: CGRect(x: first.x - r, y: first.y - r, width: 2 * r, height: 2 * r))
                     continue
                 }
-                let path = CGMutablePath()
-                path.addLines(between: run)
+                let path = MonotoneCurve.path(run)
                 if s.filled, let gradient = gradient(for: color, cache: &gradients) {
                     let fill = path.mutableCopy() ?? CGMutablePath()
                     fill.addLine(to: CGPoint(x: last.x, y: height))

--- a/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
+++ b/Sources/MacPerfMonitor/ViewModels/SamplerModel.swift
@@ -1046,6 +1046,12 @@ final class SamplerModel: ObservableObject {
         // A GPU panel on screen (the GPU tab, an open GPU dropdown) reads the
         // device every tick so it moves at the dial; the icon alone and the
         // history make do with one read a second.
+        // The first tick after launch has nothing to difference against, so
+        // its CPU, network and disk figures are zero by construction. It still
+        // seeds the sampler and drives the first scan, but it is neither
+        // recorded nor charted: a recorded zero starts every run after a gap
+        // with a vertical climb from the axis.
+        let hasBaseline = sampler.hasBaseline
         let (system, cpu, battery, network, disk, gpu) = sampler.tickSystem(
             readGPU: gpuSamplingEnabled || gpuConsumers > 0 || persistenceEnabled,
             gpuReadInterval: gpuConsumers > 0 ? 0 : 1)
@@ -1135,10 +1141,14 @@ final class SamplerModel: ObservableObject {
         if anythingWatching {
             DispatchQueue.main.async {
                 let publishStart = TickDiagnostics.now()
-                self.systemHistory.append(system)
-                self.appendRecentCPU(cpu)
-                self.appendRecentNetwork(network)
-                self.appendRecentDisk(disk)
+                // The delta-based rings skip the baseline tick (see above);
+                // battery and GPU are read directly and are fine to show.
+                if hasBaseline {
+                    self.systemHistory.append(system)
+                    self.appendRecentCPU(cpu)
+                    self.appendRecentNetwork(network)
+                    self.appendRecentDisk(disk)
+                }
                 self.recentBattery = battery
                 // GPU is sampled only while the menubar GPU item is on; smooth it like
                 // CPU so the icon figure settles, and drop the history when it goes off.
@@ -1235,7 +1245,7 @@ final class SamplerModel: ObservableObject {
         // cost. The live charts read the in-memory ring, not the DB, so only
         // the long-range history granularity follows this.
         var persistStore: SampleStore?
-        if scanDue, persistenceEnabled, let store {
+        if scanDue, persistenceEnabled, hasBaseline, let store {
             let now = Date()
             if lastPersistAt.map({ now.timeIntervalSince($0) >= persistMinInterval }) ?? true {
                 lastPersistAt = now

--- a/Sources/MacPerfMonitor/Views/DashboardView.swift
+++ b/Sources/MacPerfMonitor/Views/DashboardView.swift
@@ -388,24 +388,33 @@ struct DashboardView: View {
 
     // MARK: - Loading
 
-    /// Cap for minute/hour history. Raw windows keep their samples so every
-    /// recorded point remains immutable and moves left intact.
-    private static let maxChartPoints = 360
-
+    /// Every range loads at the resolution its tier stores. Nothing is folded
+    /// on the way in: the charts reduce at draw time so the band behind the
+    /// line is made of real extremes (docs/chart-rules.md, rule 1).
     private func reload() {
         guard let model else { return }
         let requested = range
-        let pointLimit = requested.granularity == .raw ? nil : Self.maxChartPoints
-        model.loadSystemHistory(requested, downsampledTo: pointLimit) { pts in
+        model.loadSystemHistory(requested) { pts in
             guard self.range == requested else { return }
             self.timeline.replace(
-                pts, span: requested.seconds, live: model.liveSystem, cpu: model.smoothedCPU,
-                liveCPU: model.liveCPU,
+                pts, span: requested.seconds, storedSpacing: Self.storedSpacing(requested),
+                live: model.liveSystem, cpu: model.smoothedCPU, liveCPU: model.liveCPU,
                 totalRAM: model.liveSystem?.totalRAM ?? model.latest?.system.totalRAM ?? 0)
             self.thermalPoints = pts
             self.loadedRange = requested
         }
         reloadTopConsumers(window: requested)
+    }
+
+    /// The coarsest spacing the loaded rows legitimately have: nothing beyond
+    /// the logging interval for a raw range, the tier's bucket for the rest.
+    /// The minute tier's bucket follows the standard-resolution dial.
+    private static func storedSpacing(_ window: HistoryWindow) -> TimeInterval {
+        var spacing = window.granularity.storedSpacing ?? 0
+        if window.granularity == .minute {
+            spacing = max(spacing, SamplerModel.configuredStandardResInterval())
+        }
+        return spacing
     }
 
     /// The ranking is an aggregation over the whole window's raw rows (at 1 s
@@ -493,10 +502,11 @@ private final class DashboardTimelineStore: ObservableObject {
     var xDomain: ClosedRange<Date>? { window.xDomain }
 
     func replace(
-        _ loaded: [SystemHistoryPoint], span: TimeInterval, live: SystemSample?, cpu: CPUSample?,
-        liveCPU: CPUSample?, totalRAM: UInt64
+        _ loaded: [SystemHistoryPoint], span: TimeInterval, storedSpacing: TimeInterval,
+        live: SystemSample?, cpu: CPUSample?, liveCPU: CPUSample?, totalRAM: UInt64
     ) {
         window.replace(loaded, span: span)
+        self.storedSpacing = storedSpacing
         if let live {
             window.append(Self.point(from: live))
             latestSystem = live
@@ -556,12 +566,19 @@ private final class DashboardTimelineStore: ObservableObject {
         diskYDomain = 0...MenuChart.niceUpperBound(max(diskPeak * 1.25, 100 * 1_048_576))
     }
 
+    /// The spacing of the rows the current range loaded from the database:
+    /// zero for a raw range, a minute or an hour for the stored tiers.
+    private var storedSpacing: TimeInterval = 0
+
     /// What counts as missing data here. The window mixes live samples, one a
-    /// second, with history read back from the database at the logging
-    /// interval, so the coarsest legitimate spacing is the logging interval,
-    /// and anything much beyond it means nothing was recorded.
+    /// second, with history read back from the database: at the logging
+    /// interval for the raw ranges, a row a minute or an hour for the longer
+    /// ones. The coarsest of those is the legitimate spacing; anything much
+    /// beyond it means nothing was recorded. Sizing this to the logging
+    /// interval alone made every stored row its own island on a six hour view.
     private var gapThreshold: TimeInterval {
-        ChartGap.threshold(expectedSpacing: max(1, SamplerModel.configuredHighResInterval()))
+        ChartGap.threshold(
+            expectedSpacing: max(1, SamplerModel.configuredHighResInterval(), storedSpacing))
     }
 
     /// Build every chart's and card's model from the window and hand it to
@@ -624,7 +641,7 @@ private final class DashboardTimelineStore: ObservableObject {
         _ window: SystemHistoryWindow, domain: ClosedRange<Date>?, level: PressureLevel,
         gap: TimeInterval
     ) -> TrendModel {
-        let column = LiveColumn(window, .pressurePercent)
+        let column = LiveColumn(window, .pressurePercent, peak: .pressurePercentPeak)
         var model = TrendModel()
         model.series = [
             TrendSurfaceSeries(column: column, color: level.color, filled: true)
@@ -655,7 +672,7 @@ private final class DashboardTimelineStore: ObservableObject {
         _ window: SystemHistoryWindow, domain: ClosedRange<Date>?, level: CPULevel,
         gap: TimeInterval
     ) -> TrendModel {
-        let column = LiveColumn(window, .cpuLoad)
+        let column = LiveColumn(window, .cpuLoad, peak: .cpuLoadPeak)
         var model = TrendModel()
         model.series = [
             TrendSurfaceSeries(column: column, scale: 100, color: level.color)
@@ -686,8 +703,8 @@ private final class DashboardTimelineStore: ObservableObject {
         _ window: SystemHistoryWindow, domain: ClosedRange<Date>?, yDomain: ClosedRange<Double>,
         gap: TimeInterval
     ) -> TrendModel {
-        let download = LiveColumn(window, .networkInBytesPerSec)
-        let upload = LiveColumn(window, .networkOutBytesPerSec)
+        let download = LiveColumn(window, .networkInBytesPerSec, peak: .networkInPeak)
+        let upload = LiveColumn(window, .networkOutBytesPerSec, peak: .networkOutPeak)
         var model = TrendModel()
         model.series = [
             TrendSurfaceSeries(column: download, color: NetworkStyle.download),
@@ -719,8 +736,8 @@ private final class DashboardTimelineStore: ObservableObject {
         _ window: SystemHistoryWindow, domain: ClosedRange<Date>?, yDomain: ClosedRange<Double>,
         gap: TimeInterval
     ) -> TrendModel {
-        let read = LiveColumn(window, .diskReadBytesPerSec)
-        let write = LiveColumn(window, .diskWriteBytesPerSec)
+        let read = LiveColumn(window, .diskReadBytesPerSec, peak: .diskReadPeak)
+        let write = LiveColumn(window, .diskWriteBytesPerSec, peak: .diskWritePeak)
         var model = TrendModel()
         model.series = [
             TrendSurfaceSeries(column: read, color: DiskStyle.read),

--- a/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/HistoryDownsample.swift
@@ -94,68 +94,74 @@ extension Array where Element == SystemHistoryPoint {
             func omax(_ value: (SystemHistoryPoint) -> Double?) -> Double? {
                 slice.compactMap(value).max()
             }
-            result.append(
-                SystemHistoryPoint(
-                    // Grid-anchored start of the bucket: a fixed point that does
-                    // not move as samples land in this or any other bucket.
-                    date: Date(timeIntervalSince1970: b * width),
-                    pressurePercent: slice.map(\.pressurePercent).max() ?? 0,
-                    appMemory: mean { $0.appMemory },
-                    wired: mean { $0.wired },
-                    compressed: mean { $0.compressed },
-                    cachedFiles: mean { $0.cachedFiles },
-                    swapUsed: mean { $0.swapUsed },
-                    // CPU is inherently spiky, so average rather than peak per
-                    // bucket; a max-collapsed line would read as permanently high.
-                    cpuLoad: dmean { $0.cpuLoad },
-                    // Carry the battery scalars through too: omitting them
-                    // defaulted them to 0, which collapsed the Battery tab's
-                    // charge/power lines to a flat zero on any downsampled range.
-                    batteryCharge: dmean { $0.batteryCharge },
-                    batteryPowerWatts: dmean { $0.batteryPowerWatts },
-                    batteryHealthPercent: dmean { $0.batteryHealthPercent },
-                    batteryTemperatureCelsius: dmean { $0.batteryTemperatureCelsius },
-                    // Network is bursty, so average per bucket (a max-collapsed
-                    // line would read as permanently saturated), like CPU.
-                    networkInBytesPerSec: dmean { $0.networkInBytesPerSec },
-                    networkOutBytesPerSec: dmean { $0.networkOutBytesPerSec },
-                    // Disk throughput is bursty too, so average per bucket like
-                    // network. Carrying these through is the same fix the battery
-                    // and network scalars already got: leaving them out defaulted
-                    // them to 0 and flattened the Disk tab's read/write trend on
-                    // any range whose point count exceeded the chart cap.
-                    diskReadBytesPerSec: dmean { $0.diskReadBytesPerSec },
-                    diskWriteBytesPerSec: dmean { $0.diskWriteBytesPerSec },
-                    diskReadOperationsPerSec: dmean { $0.diskReadOperationsPerSec },
-                    diskWriteOperationsPerSec: dmean { $0.diskWriteOperationsPerSec },
-                    diskReadLatencyMs: omean { $0.diskReadLatencyMs },
-                    diskWriteLatencyMs: omean { $0.diskWriteLatencyMs },
-                    diskUtilizationPercent: omean { $0.diskUtilizationPercent },
-                    // Free space wants its low water mark, not its average: the
-                    // moment the disk nearly filled is the moment that matters.
-                    bootFreeBytes: slice.compactMap(\.bootFreeBytes).min(),
-                    bootTotalBytes: slice.compactMap(\.bootTotalBytes).last,
-                    // Carry the GPU figures through: omitting them defaulted
-                    // them to nil and blanked the GPU tab's history on any
-                    // downsampled range, the same class of drop the battery
-                    // and disk scalars had. Bursty like CPU, so average.
-                    gpuUtilization: omean { $0.gpuUtilization },
-                    gpuPowerWatts: omean { $0.gpuPowerWatts },
-                    anePowerWatts: omean { $0.anePowerWatts },
-                    cpuDieC: omax { $0.cpuDieC },
-                    gpuDieC: omax { $0.gpuDieC },
-                    ssdTemperatureC: omax { $0.ssdTemperatureC },
-                    fanRPM: omax { $0.fanRPM },
-                    // Worst pressure in the bucket, for the same reason.
-                    thermalPressure: slice.compactMap(\.thermalPressure).max(),
-                    cpuPCoreDieC: omax { $0.cpuPCoreDieC },
-                    cpuECoreDieC: omax { $0.cpuECoreDieC },
-                    airflowC: omax { $0.airflowC },
-                    skinC: omax { $0.skinC },
-                    wirelessC: omax { $0.wirelessC },
-                    voltageRailC: omax { $0.voltageRailC },
-                    otherSensorC: omax { $0.otherSensorC }
-                ))
+            var point = SystemHistoryPoint(
+                // Grid-anchored start of the bucket: a fixed point that does
+                // not move as samples land in this or any other bucket.
+                date: Date(timeIntervalSince1970: b * width),
+                pressurePercent: slice.map(\.pressurePercent).max() ?? 0,
+                appMemory: mean { $0.appMemory },
+                wired: mean { $0.wired },
+                compressed: mean { $0.compressed },
+                cachedFiles: mean { $0.cachedFiles },
+                swapUsed: mean { $0.swapUsed },
+                // CPU is inherently spiky, so average rather than peak per
+                // bucket; a max-collapsed line would read as permanently high.
+                cpuLoad: dmean { $0.cpuLoad },
+                // Carry the battery scalars through too: omitting them
+                // defaulted them to 0, which collapsed the Battery tab's
+                // charge/power lines to a flat zero on any downsampled range.
+                batteryCharge: dmean { $0.batteryCharge },
+                batteryPowerWatts: dmean { $0.batteryPowerWatts },
+                batteryHealthPercent: dmean { $0.batteryHealthPercent },
+                batteryTemperatureCelsius: dmean { $0.batteryTemperatureCelsius },
+                // Network is bursty, so average per bucket (a max-collapsed
+                // line would read as permanently saturated), like CPU.
+                networkInBytesPerSec: dmean { $0.networkInBytesPerSec },
+                networkOutBytesPerSec: dmean { $0.networkOutBytesPerSec },
+                // Disk throughput is bursty too, so average per bucket like
+                // network. Carrying these through is the same fix the battery
+                // and network scalars already got: leaving them out defaulted
+                // them to 0 and flattened the Disk tab's read/write trend on
+                // any range whose point count exceeded the chart cap.
+                diskReadBytesPerSec: dmean { $0.diskReadBytesPerSec },
+                diskWriteBytesPerSec: dmean { $0.diskWriteBytesPerSec },
+                diskReadOperationsPerSec: dmean { $0.diskReadOperationsPerSec },
+                diskWriteOperationsPerSec: dmean { $0.diskWriteOperationsPerSec },
+                diskReadLatencyMs: omean { $0.diskReadLatencyMs },
+                diskWriteLatencyMs: omean { $0.diskWriteLatencyMs },
+                diskUtilizationPercent: omean { $0.diskUtilizationPercent },
+                // Free space wants its low water mark, not its average: the
+                // moment the disk nearly filled is the moment that matters.
+                bootFreeBytes: slice.compactMap(\.bootFreeBytes).min(),
+                bootTotalBytes: slice.compactMap(\.bootTotalBytes).last,
+                // Carry the GPU figures through: omitting them defaulted
+                // them to nil and blanked the GPU tab's history on any
+                // downsampled range, the same class of drop the battery
+                // and disk scalars had. Bursty like CPU, so average.
+                gpuUtilization: omean { $0.gpuUtilization },
+                gpuPowerWatts: omean { $0.gpuPowerWatts },
+                anePowerWatts: omean { $0.anePowerWatts },
+                cpuDieC: omax { $0.cpuDieC },
+                gpuDieC: omax { $0.gpuDieC },
+                ssdTemperatureC: omax { $0.ssdTemperatureC },
+                fanRPM: omax { $0.fanRPM },
+                // Worst pressure in the bucket, for the same reason.
+                thermalPressure: slice.compactMap(\.thermalPressure).max(),
+                cpuPCoreDieC: omax { $0.cpuPCoreDieC },
+                cpuECoreDieC: omax { $0.cpuECoreDieC },
+                airflowC: omax { $0.airflowC },
+                skinC: omax { $0.skinC },
+                wirelessC: omax { $0.wirelessC },
+                voltageRailC: omax { $0.voltageRailC },
+                otherSensorC: omax { $0.otherSensorC }
+            )
+            // The bucket's peak is the highest peak among its members (a raw
+            // member's peak being itself), so a band drawn over the result
+            // still reaches the real spike.
+            point.peaks = slice.dropFirst().reduce(slice[i].effectivePeaks) {
+                $0.merged(with: $1.effectivePeaks)
+            }
+            result.append(point)
             i = j
         }
         return result

--- a/Sources/MacPerfMonitorCore/Persistence/HistoryQuery.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/HistoryQuery.swift
@@ -41,7 +41,22 @@ public enum HistoryWindow: String, Sendable, CaseIterable, Identifiable {
 
     /// Which stored tier backs queries for this window. The raw tier only holds
     /// two hours (section 6), so anything longer reads the aggregates.
-    public enum Granularity: Sendable, Equatable { case raw, minute, hour }
+    public enum Granularity: Sendable, Equatable {
+        case raw, minute, hour
+
+        /// How far apart the rows of this tier are, nominally: one a minute,
+        /// one an hour. Nil for the raw tier, whose spacing is whatever the
+        /// logging interval is. A chart's gap threshold has to come from this,
+        /// not from the logging cadence, or every stored row is its own island
+        /// and a six hour view draws dots.
+        public var storedSpacing: TimeInterval? {
+            switch self {
+            case .raw: return nil
+            case .minute: return 60
+            case .hour: return 3600
+            }
+        }
+    }
 
     public var granularity: Granularity {
         switch self {

--- a/Sources/MacPerfMonitorCore/Persistence/SystemHistory.swift
+++ b/Sources/MacPerfMonitorCore/Persistence/SystemHistory.swift
@@ -8,6 +8,14 @@ import GRDB
 /// part of this point; the live stacked bar (which must sum to total RAM) uses
 /// the current `SystemSample` instead.
 public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
+    /// The highest raw value inside the bucket this point summarises. Set for
+    /// points read from the minute and hour tiers, whose value is a mean; nil
+    /// for a raw sample, whose peak is itself. The charts draw the mean as the
+    /// line and the peak as the top of the band behind it, so a long range still
+    /// shows what the spikes reached rather than a flat average. The tiers do
+    /// not store a minimum, so the band's floor is the mean.
+    public var peaks: SystemHistoryPeaks?
+
     public var date: Date
     public var pressurePercent: Double
     public var appMemory: UInt64
@@ -147,11 +155,71 @@ public struct SystemHistoryPoint: Sendable, Identifiable, Equatable {
     }
 }
 
+/// The per-bucket peaks stored alongside the means in the minute and hour
+/// tiers, for the metrics the Dashboard draws as a line inside a band.
+public struct SystemHistoryPeaks: Sendable, Equatable {
+    public var pressurePercent: Double
+    public var cpuLoad: Double
+    public var networkInBytesPerSec: Double
+    public var networkOutBytesPerSec: Double
+    public var diskReadBytesPerSec: Double
+    public var diskWriteBytesPerSec: Double
+    public var gpuUtilization: Double?
+
+    public init(
+        pressurePercent: Double, cpuLoad: Double, networkInBytesPerSec: Double,
+        networkOutBytesPerSec: Double, diskReadBytesPerSec: Double,
+        diskWriteBytesPerSec: Double, gpuUtilization: Double? = nil
+    ) {
+        self.pressurePercent = pressurePercent
+        self.cpuLoad = cpuLoad
+        self.networkInBytesPerSec = networkInBytesPerSec
+        self.networkOutBytesPerSec = networkOutBytesPerSec
+        self.diskReadBytesPerSec = diskReadBytesPerSec
+        self.diskWriteBytesPerSec = diskWriteBytesPerSec
+        self.gpuUtilization = gpuUtilization
+    }
+
+    /// The peaks of a single raw sample: the sample itself.
+    public init(_ point: SystemHistoryPoint) {
+        self.init(
+            pressurePercent: point.pressurePercent, cpuLoad: point.cpuLoad,
+            networkInBytesPerSec: point.networkInBytesPerSec,
+            networkOutBytesPerSec: point.networkOutBytesPerSec,
+            diskReadBytesPerSec: point.diskReadBytesPerSec,
+            diskWriteBytesPerSec: point.diskWriteBytesPerSec,
+            gpuUtilization: point.gpuUtilization)
+    }
+
+    /// The element-wise larger of two peaks.
+    public func merged(with other: SystemHistoryPeaks) -> SystemHistoryPeaks {
+        SystemHistoryPeaks(
+            pressurePercent: max(pressurePercent, other.pressurePercent),
+            cpuLoad: max(cpuLoad, other.cpuLoad),
+            networkInBytesPerSec: max(networkInBytesPerSec, other.networkInBytesPerSec),
+            networkOutBytesPerSec: max(networkOutBytesPerSec, other.networkOutBytesPerSec),
+            diskReadBytesPerSec: max(diskReadBytesPerSec, other.diskReadBytesPerSec),
+            diskWriteBytesPerSec: max(diskWriteBytesPerSec, other.diskWriteBytesPerSec),
+            gpuUtilization: [gpuUtilization, other.gpuUtilization].compactMap { $0 }.max())
+    }
+}
+
+extension SystemHistoryPoint {
+    /// The peaks this point stands for: its stored bucket peaks, or itself.
+    public var effectivePeaks: SystemHistoryPeaks { peaks ?? SystemHistoryPeaks(self) }
+}
+
 extension SampleStore {
     /// System history for a dashboard window, oldest first. Reads from the raw,
     /// minute, or hour table according to `window.granularity`. The whole app
     /// shares one `HistoryWindow` (5m / 30m / 1h / 6h / 24h / 7d) so every page's
     /// history picker offers the same timeframes.
+    ///
+    /// A tier only holds buckets that were complete when retention last ran, so
+    /// on its own it ends up to a minute (or an hour) before now. The result is
+    /// topped up from the finer tiers past each tier's watermark, down to the
+    /// raw rows, so every range runs right up to the last recorded sample and
+    /// the live samples the caller appends join on without a hole.
     public func systemHistory(
         _ window: HistoryWindow, now: Date = Date()
     ) throws -> [SystemHistoryPoint] {
@@ -160,9 +228,26 @@ extension SampleStore {
         case .raw:
             return try rawHistory(since: since)
         case .minute:
-            return try aggregateHistory(table: "system_minute", since: since)
+            return try tieredHistory(since: since, hours: false)
         case .hour:
-            return try aggregateHistory(table: "system_hour", since: since)
+            return try tieredHistory(since: since, hours: true)
+        }
+    }
+
+    private func tieredHistory(since: Double, hours: Bool) throws -> [SystemHistoryPoint] {
+        try databasePool.read { db in
+            var points: [SystemHistoryPoint] = []
+            var coveredThrough = since
+            if hours {
+                points = try Self.aggregateHistory(db, table: "system_hour", since: since)
+                let watermark = try Retention.meta(db, "hour_watermark") ?? 0
+                coveredThrough = max(coveredThrough, watermark)
+            }
+            points += try Self.aggregateHistory(db, table: "system_minute", since: coveredThrough)
+            let watermark = try Retention.meta(db, "minute_watermark") ?? 0
+            coveredThrough = max(coveredThrough, watermark)
+            points += try Self.rawHistory(db, since: coveredThrough)
+            return points
         }
     }
 
@@ -179,47 +264,62 @@ extension SampleStore {
     }
 
     private func rawHistory(since: Double) throws -> [SystemHistoryPoint] {
-        try databasePool.read { db in
-            try Row.fetchAll(
-                db,
-                sql: """
-                    SELECT timestamp, pressure_percent, app_memory, wired, compressed, cached_files, swap_used, cpu_load,
-                           battery_charge, battery_power, battery_health, battery_temp, net_in, net_out,
-                           disk_read, disk_write, disk_read_iops, disk_write_iops,
-                           disk_read_latency, disk_write_latency, disk_util, boot_free, boot_total,
-                           gpu_util, gpu_power, ane_power,
-                           cpu_die, gpu_die, ssd_temp, fan_rpm, thermal_state,
-                           cpu_p_die, cpu_e_die, airflow_temp, skin_temp, wireless_temp,
-                           vrail_temp, other_temp
-                    FROM system_samples
-                    WHERE timestamp >= ?
-                    ORDER BY timestamp ASC
-                    """, arguments: [since]
-            ).map(Self.decodeHistoryPoint)
-        }
+        try databasePool.read { db in try Self.rawHistory(db, since: since) }
     }
 
-    private func aggregateHistory(table: String, since: Double) throws -> [SystemHistoryPoint] {
-        try databasePool.read { db in
-            try Row.fetchAll(
-                db,
-                sql: """
-                    SELECT bucket, pressure_avg, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg,
-                           battery_charge_avg, battery_power_avg, battery_health_avg, battery_temp_avg,
-                           net_in_avg, net_out_avg,
-                           disk_read_avg, disk_write_avg, disk_read_iops_avg, disk_write_iops_avg,
-                           disk_read_latency_avg, disk_write_latency_avg, disk_util_avg,
-                           boot_free_min, boot_total,
-                           gpu_util_avg, gpu_power_avg, ane_power_avg,
-                           cpu_die_max, gpu_die_max, ssd_temp_max, fan_rpm_max, thermal_state_max,
-                           cpu_p_die_max, cpu_e_die_max, airflow_temp_max, skin_temp_max,
-                           wireless_temp_max, vrail_temp_max, other_temp_max
-                    FROM \(table)
-                    WHERE bucket >= ?
-                    ORDER BY bucket ASC
-                    """, arguments: [since]
-            ).map(Self.decodeHistoryPoint)
-        }
+    private static func rawHistory(_ db: Database, since: Double) throws -> [SystemHistoryPoint] {
+        try Row.fetchAll(
+            db,
+            sql: """
+                SELECT timestamp, pressure_percent, app_memory, wired, compressed, cached_files, swap_used, cpu_load,
+                       battery_charge, battery_power, battery_health, battery_temp, net_in, net_out,
+                       disk_read, disk_write, disk_read_iops, disk_write_iops,
+                       disk_read_latency, disk_write_latency, disk_util, boot_free, boot_total,
+                       gpu_util, gpu_power, ane_power,
+                       cpu_die, gpu_die, ssd_temp, fan_rpm, thermal_state,
+                       cpu_p_die, cpu_e_die, airflow_temp, skin_temp, wireless_temp,
+                       vrail_temp, other_temp
+                FROM system_samples
+                WHERE timestamp >= ?
+                ORDER BY timestamp ASC
+                """, arguments: [since]
+        ).map(Self.decodeHistoryPoint)
+    }
+
+    private static func aggregateHistory(
+        _ db: Database, table: String, since: Double
+    ) throws -> [SystemHistoryPoint] {
+        try Row.fetchAll(
+            db,
+            sql: """
+                SELECT bucket, pressure_avg, app_avg, wired_avg, compressed_avg, cached_avg, swap_used_avg, cpu_avg,
+                       battery_charge_avg, battery_power_avg, battery_health_avg, battery_temp_avg,
+                       net_in_avg, net_out_avg,
+                       disk_read_avg, disk_write_avg, disk_read_iops_avg, disk_write_iops_avg,
+                       disk_read_latency_avg, disk_write_latency_avg, disk_util_avg,
+                       boot_free_min, boot_total,
+                       gpu_util_avg, gpu_power_avg, ane_power_avg,
+                       cpu_die_max, gpu_die_max, ssd_temp_max, fan_rpm_max, thermal_state_max,
+                       cpu_p_die_max, cpu_e_die_max, airflow_temp_max, skin_temp_max,
+                       wireless_temp_max, vrail_temp_max, other_temp_max,
+                       pressure_max, cpu_max, net_in_max, net_out_max,
+                       disk_read_max, disk_write_max, gpu_util_max
+                FROM \(table)
+                WHERE bucket >= ?
+                ORDER BY bucket ASC
+                """, arguments: [since]
+        ).map(Self.decodeAggregatePoint)
+    }
+
+    /// The shared decode plus the peak columns only the tiers have (38 on).
+    private static func decodeAggregatePoint(_ row: Row) -> SystemHistoryPoint {
+        var point = decodeHistoryPoint(row)
+        point.peaks = SystemHistoryPeaks(
+            pressurePercent: row[38], cpuLoad: row[39],
+            networkInBytesPerSec: row[40], networkOutBytesPerSec: row[41],
+            diskReadBytesPerSec: row[42], diskWriteBytesPerSec: row[43],
+            gpuUtilization: row[44])
+        return point
     }
 
     /// Positional decode shared by the raw and aggregate queries, which list the

--- a/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
+++ b/Sources/MacPerfMonitorCore/Sampling/Sampler.swift
@@ -257,6 +257,15 @@ public final class Sampler {
             battery: battery, network: network, disk: disk)
     }
 
+    /// Whether the next `tickSystem` has a previous tick to difference against.
+    ///
+    /// The first tick after launch or `reset()` has none, so its CPU, network
+    /// and disk figures are zero by construction rather than measured. Anything
+    /// that records or charts samples should skip that tick: recorded, it puts a
+    /// zero at the start of every run, and the line climbs vertically out of it
+    /// when the chart resumes after the gap.
+    public var hasBaseline: Bool { lastSystemTime != nil }
+
     /// The cheap system-wide sample: total/per-core CPU and the memory/pressure
     /// figures. It does no per-process enumeration, so it is safe to call at a
     /// fast (sub-second) cadence to keep the menubar live without the cost of

--- a/Sources/MacPerfMonitorCore/Util/LiveStripBuckets.swift
+++ b/Sources/MacPerfMonitorCore/Util/LiveStripBuckets.swift
@@ -64,9 +64,9 @@ public enum LiveStripBuckets {
         /// follow. Falls back to the single value when there is only one.
         public var mean: Double { count > 0 ? sum / Double(count) : minValue }
 
-        /// Whether this bucket holds more than the one sample a column can show
-        /// directly, and so has a band worth drawing.
-        public var isAggregate: Bool { count > 1 && maxValue > minValue }
+        /// Whether this bucket has a spread worth drawing as a band: more than
+        /// one distinct sample, or a stored peak above a stored mean.
+        public var isAggregate: Bool { maxValue > minValue }
 
         /// The bucket's one or two points in chronological order: a single
         /// point when both extremes are the same sample, else the earlier
@@ -89,16 +89,23 @@ public enum LiveStripBuckets {
     /// multiplies every value. The sample just before the range (if any) is
     /// consulted so the first bucket's `gapBefore` is right.
     ///
+    /// `highs`, when given, holds each sample's own peak (a stored tier row is
+    /// a mean with the bucket's maximum beside it); it can only raise a
+    /// bucket's maximum, never move its mean, so the band reaches the real
+    /// spike while the line still follows the average.
+    ///
     /// Cost is a binary search plus one pass over the samples inside the
     /// range, so a live edge of a few buckets costs a few dozen samples however
     /// long the window is.
     public static func buckets(
-        times: ArraySlice<Double>, values: ArraySlice<Double>, width: Double,
-        from first: Int, through last: Int, gapThreshold: Double, scale: Double = 1
+        times: ArraySlice<Double>, values: ArraySlice<Double>, highs: ArraySlice<Double>? = nil,
+        width: Double, from first: Int, through last: Int, gapThreshold: Double,
+        scale: Double = 1
     ) -> [Bucket] {
         guard width > 0, first <= last, !times.isEmpty, times.count == values.count else {
             return []
         }
+        let highs = highs.flatMap { $0.count == times.count ? $0 : nil }
         let rangeStart = Double(first) * width
         let rangeEnd = Double(last + 1) * width
 
@@ -115,6 +122,7 @@ public enum LiveStripBuckets {
         // a trimmed slice, a derived column a fresh array), so index `values`
         // by offset from `times`.
         let valueOffset = values.startIndex - times.startIndex
+        let highOffset = highs.map { $0.startIndex - times.startIndex } ?? 0
         var out: [Bucket] = []
         var current: Bucket?
         var i = lo
@@ -122,14 +130,15 @@ public enum LiveStripBuckets {
             let t = times[i]
             if t >= rangeEnd { break }
             let v = values[i + valueOffset] * scale
+            let h = highs.map { max(v, $0[i + highOffset] * scale) } ?? v
             let b = index(of: t, width: width)
             if var bucket = current, bucket.index == b {
                 if v < bucket.minValue {
                     bucket.minValue = v
                     bucket.minTime = t
                 }
-                if v > bucket.maxValue {
-                    bucket.maxValue = v
+                if h > bucket.maxValue {
+                    bucket.maxValue = h
                     bucket.maxTime = t
                 }
                 bucket.sum += v
@@ -139,7 +148,8 @@ public enum LiveStripBuckets {
                 if let bucket = current { out.append(bucket) }
                 let gap = previousTime.map { t - $0 > gapThreshold } ?? false
                 current = Bucket(
-                    index: b, minTime: t, minValue: v, maxTime: t, maxValue: v, gapBefore: gap)
+                    index: b, minTime: t, minValue: v, maxTime: t, maxValue: h, gapBefore: gap,
+                    sum: v)
             }
             previousTime = t
             i += 1

--- a/Sources/MacPerfMonitorCore/Util/MonotoneCubic.swift
+++ b/Sources/MacPerfMonitorCore/Util/MonotoneCubic.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Tangents for a monotone cubic Hermite spline: the curve beszel, and d3's
+/// `curveMonotoneX` beneath it, draw through chart points.
+///
+/// A polyline through 120 reduced points reads as jagged. A Catmull-Rom or
+/// natural cubic spline reads as smooth but overshoots, inventing a bump
+/// between two real points. The monotone construction (Fritsch and Carlson's
+/// tangent limits, with d3's three-point rule at the ends) is the one that is
+/// both: between any two points the curve stays inside their vertical range,
+/// so on a monitoring chart every peak is one that was measured.
+public enum MonotoneCubic {
+    /// One tangent (dy/dx) per point. `xs` should be increasing; a repeated x
+    /// gets a flat tangent rather than an infinite one. Fewer than two points
+    /// yield zeros, two yield the chord slope at both ends.
+    public static func tangents(xs: [Double], ys: [Double]) -> [Double] {
+        let n = min(xs.count, ys.count)
+        guard n > 1 else { return Array(repeating: 0, count: n) }
+        if n == 2 {
+            let h = xs[1] - xs[0]
+            let s = h > 0 ? (ys[1] - ys[0]) / h : 0
+            return [s, s]
+        }
+        var m = Array(repeating: 0.0, count: n)
+        for i in 1..<(n - 1) {
+            m[i] = slope3(
+                xs[i - 1], ys[i - 1], xs[i], ys[i], xs[i + 1], ys[i + 1])
+        }
+        m[0] = slope2(xs[0], ys[0], xs[1], ys[1], m[1])
+        m[n - 1] = slope2(xs[n - 2], ys[n - 2], xs[n - 1], ys[n - 1], m[n - 2])
+        return m
+    }
+
+    /// The cubic Bezier control points that realise the Hermite segment from
+    /// (x0, y0) with tangent m0 to (x1, y1) with tangent m1.
+    public static func controlPoints(
+        x0: Double, y0: Double, x1: Double, y1: Double, m0: Double, m1: Double
+    ) -> (c1x: Double, c1y: Double, c2x: Double, c2y: Double) {
+        let dx = (x1 - x0) / 3
+        return (x0 + dx, y0 + dx * m0, x1 - dx, y1 - dx * m1)
+    }
+
+    /// An interior tangent: zero at a local extremum or a flat, otherwise the
+    /// smaller of twice each secant slope and the weighted mean of the two,
+    /// which keeps the segment either side monotone.
+    static func slope3(
+        _ x0: Double, _ y0: Double, _ x1: Double, _ y1: Double, _ x2: Double, _ y2: Double
+    ) -> Double {
+        let h0 = x1 - x0
+        let h1 = x2 - x1
+        guard h0 > 0, h1 > 0 else { return 0 }
+        let s0 = (y1 - y0) / h0
+        let s1 = (y2 - y1) / h1
+        guard s0 != 0, s1 != 0, (s0 < 0) == (s1 < 0) else { return 0 }
+        let p = (s0 * h1 + s1 * h0) / (h0 + h1)
+        let magnitude = 2 * min(abs(s0), abs(s1), 0.5 * abs(p))
+        return s0 < 0 ? -magnitude : magnitude
+    }
+
+    /// An end tangent, from the end segment's chord and the tangent already
+    /// fixed at its other end.
+    static func slope2(
+        _ x0: Double, _ y0: Double, _ x1: Double, _ y1: Double, _ t: Double
+    ) -> Double {
+        let h = x1 - x0
+        return h > 0 ? (3 * (y1 - y0) / h - t) / 2 : t
+    }
+}

--- a/Sources/MacPerfMonitorCore/Util/SystemHistoryWindow.swift
+++ b/Sources/MacPerfMonitorCore/Util/SystemHistoryWindow.swift
@@ -37,6 +37,19 @@ public struct SystemHistoryWindow {
         /// 0 (the columnar store is non-optional); consumers with a floored
         /// y-domain should treat near-zero as "not sampled".
         case cpuDieC
+        /// The bucket peaks behind the metrics above, for points read from
+        /// the stored minute and hour tiers (`SystemHistoryPoint.peaks`). A raw
+        /// sample's peak is the sample itself, so for live data these columns
+        /// equal their metric and cost nothing to read alongside it. A chart
+        /// pairs a metric with its peak column and the band rises to the peak
+        /// where the line is a mean.
+        case pressurePercentPeak
+        case cpuLoadPeak
+        case networkInPeak
+        case networkOutPeak
+        case diskReadPeak
+        case diskWritePeak
+        case gpuUtilizationPeak
     }
 
     /// Timestamps as `timeIntervalSinceReferenceDate`, oldest first.
@@ -157,6 +170,15 @@ public struct SystemHistoryWindow {
         columns[Column.gpuPowerWatts.rawValue].append(point.gpuPowerWatts ?? 0)
         columns[Column.anePowerWatts.rawValue].append(point.anePowerWatts ?? 0)
         columns[Column.cpuDieC.rawValue].append(point.cpuDieC ?? 0)
+        let peaks = point.effectivePeaks
+        columns[Column.pressurePercentPeak.rawValue].append(peaks.pressurePercent)
+        columns[Column.cpuLoadPeak.rawValue].append(peaks.cpuLoad)
+        columns[Column.networkInPeak.rawValue].append(peaks.networkInBytesPerSec)
+        columns[Column.networkOutPeak.rawValue].append(peaks.networkOutBytesPerSec)
+        columns[Column.diskReadPeak.rawValue].append(peaks.diskReadBytesPerSec)
+        columns[Column.diskWritePeak.rawValue].append(peaks.diskWriteBytesPerSec)
+        columns[Column.gpuUtilizationPeak.rawValue].append(
+            peaks.gpuUtilization ?? point.gpuUtilization ?? 0)
         latest = point
     }
 

--- a/Tests/MacPerfMonitorCoreTests/HistoryDownsampleTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/HistoryDownsampleTests.swift
@@ -119,4 +119,26 @@ final class HistoryDownsampleTests: XCTestCase {
         XCTAssertEqual(frees, frees.sorted(by: >))
         XCTAssertEqual(downsampled.last?.bootTotalBytes, 2_000_000)
     }
+
+    func testDownsampleCarriesTheHighestPeakOfTheBucket() {
+        func point(_ seconds: Double, cpu: Double, peak: Double? = nil) -> SystemHistoryPoint {
+            var p = SystemHistoryPoint(
+                date: Date(timeIntervalSince1970: seconds), pressurePercent: cpu * 100,
+                appMemory: 1, wired: 1, compressed: 1, cachedFiles: 1, swapUsed: 0, cpuLoad: cpu)
+            if let peak {
+                p.peaks = SystemHistoryPeaks(
+                    pressurePercent: peak * 100, cpuLoad: peak, networkInBytesPerSec: 0,
+                    networkOutBytesPerSec: 0, diskReadBytesPerSec: 0, diskWriteBytesPerSec: 0)
+            }
+            return p
+        }
+        let points = [point(0, cpu: 0.2), point(10, cpu: 0.4, peak: 0.9), point(20, cpu: 0.3)]
+        let reduced = points.chartDownsampled(span: 60, to: 1)
+        XCTAssertEqual(reduced.count, 1)
+        XCTAssertEqual(reduced[0].cpuLoad, 0.3, accuracy: 1e-9, "the value stays a mean")
+        XCTAssertEqual(reduced[0].peaks?.cpuLoad ?? 0, 0.9, accuracy: 1e-9)
+        XCTAssertEqual(
+            reduced[0].peaks?.pressurePercent ?? 0, 90, accuracy: 1e-9,
+            "a raw member's peak is itself, so the stored peak wins here too")
+    }
 }

--- a/Tests/MacPerfMonitorCoreTests/LiveStripBucketsTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/LiveStripBucketsTests.swift
@@ -219,4 +219,50 @@ final class LiveStripBucketsTests: XCTestCase {
         XCTAssertEqual(ChartGap.threshold(expectedSpacing: 3600), 10800)
     }
 
+    // MARK: - Stored peaks
+
+    func testHighsRaiseTheMaximumButNotTheMean() {
+        let times: [Double] = [100, 101, 102]
+        let values: [Double] = [0.2, 0.4, 0.3]
+        let highs: [Double] = [0.2, 0.9, 0.3]
+        let buckets = LiveStripBuckets.buckets(
+            times: times[...], values: values[...], highs: highs[...], width: 10, from: 10,
+            through: 10, gapThreshold: 5)
+        XCTAssertEqual(buckets.count, 1)
+        XCTAssertEqual(buckets[0].maxValue, 0.9)
+        XCTAssertEqual(buckets[0].maxTime, 101)
+        XCTAssertEqual(buckets[0].minValue, 0.2)
+        XCTAssertEqual(buckets[0].mean, 0.3, accuracy: 1e-9, "the line still follows the means")
+        XCTAssertEqual(buckets[0].count, 3)
+    }
+
+    func testAStoredMeanWithAPeakIsAggregateOnItsOwn() {
+        // One minute-tier row per column: a mean with the bucket peak beside it
+        // has a spread worth a band even though it is a single sample.
+        let times: [Double] = [100]
+        let values: [Double] = [0.2]
+        let highs: [Double] = [0.6]
+        let buckets = LiveStripBuckets.buckets(
+            times: times[...], values: values[...], highs: highs[...], width: 10, from: 10,
+            through: 10, gapThreshold: 5)
+        XCTAssertEqual(buckets.count, 1)
+        XCTAssertEqual(buckets[0].count, 1)
+        XCTAssertEqual(buckets[0].maxValue, 0.6)
+        XCTAssertEqual(buckets[0].minValue, 0.2)
+        XCTAssertTrue(buckets[0].isAggregate)
+        XCTAssertEqual(buckets[0].mean, 0.2)
+    }
+
+    func testHighsScaleWithTheValuesAndMismatchedHighsAreIgnored() {
+        let times: [Double] = [100, 101]
+        let values: [Double] = [0.2, 0.4]
+        let scaled = LiveStripBuckets.buckets(
+            times: times[...], values: values[...], highs: [0.5, 0.5][...], width: 10, from: 10,
+            through: 10, gapThreshold: 5, scale: 100)
+        XCTAssertEqual(scaled[0].maxValue, 50)
+        let mismatched = LiveStripBuckets.buckets(
+            times: times[...], values: values[...], highs: [0.9][...], width: 10, from: 10,
+            through: 10, gapThreshold: 5)
+        XCTAssertEqual(mismatched[0].maxValue, 0.4, "a highs slice of the wrong length is dropped")
+    }
 }

--- a/Tests/MacPerfMonitorCoreTests/MonotoneCubicTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/MonotoneCubicTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+@testable import MacPerfMonitorCore
+
+/// The chart curve must pass through every point and never overshoot between
+/// two of them: a bump on a monitoring chart has to be something measured.
+final class MonotoneCubicTests: XCTestCase {
+    /// The Hermite segment, evaluated through its Bezier form at `t`.
+    private func bezier(
+        _ p0: Double, _ c1: Double, _ c2: Double, _ p1: Double, _ t: Double
+    )
+        -> Double
+    {
+        let u = 1 - t
+        return u * u * u * p0 + 3 * u * u * t * c1 + 3 * u * t * t * c2 + t * t * t * p1
+    }
+
+    /// Every segment of the curve through (xs, ys), sampled finely.
+    private func samples(xs: [Double], ys: [Double]) -> [[Double]] {
+        let m = MonotoneCubic.tangents(xs: xs, ys: ys)
+        return (0..<(xs.count - 1)).map { i in
+            let c = MonotoneCubic.controlPoints(
+                x0: xs[i], y0: ys[i], x1: xs[i + 1], y1: ys[i + 1], m0: m[i], m1: m[i + 1])
+            return (0...40).map { k in
+                bezier(ys[i], c.c1y, c.c2y, ys[i + 1], Double(k) / 40)
+            }
+        }
+    }
+
+    func testMonotoneDataGivesAMonotoneCurve() {
+        let xs = (0..<8).map(Double.init)
+        let ys: [Double] = [0, 1, 1.2, 5, 5.1, 9, 9.5, 10]
+        let m = MonotoneCubic.tangents(xs: xs, ys: ys)
+        XCTAssertEqual(m.count, 8)
+        XCTAssertTrue(m.allSatisfy { $0 >= 0 }, "rising data never gets a falling tangent")
+        for segment in samples(xs: xs, ys: ys) {
+            for (a, b) in zip(segment, segment.dropFirst()) {
+                XCTAssertGreaterThanOrEqual(b, a - 1e-9)
+            }
+        }
+    }
+
+    func testNoOvershootAroundASpike() {
+        let xs = (0..<5).map(Double.init)
+        let ys: [Double] = [0, 0, 10, 0, 0]
+        let m = MonotoneCubic.tangents(xs: xs, ys: ys)
+        XCTAssertEqual(m[2], 0, "a local maximum is flat, so the curve peaks exactly there")
+        for (i, segment) in samples(xs: xs, ys: ys).enumerated() {
+            let lo = min(ys[i], ys[i + 1])
+            let hi = max(ys[i], ys[i + 1])
+            for y in segment {
+                XCTAssertGreaterThanOrEqual(y, lo - 1e-9)
+                XCTAssertLessThanOrEqual(y, hi + 1e-9)
+            }
+        }
+    }
+
+    func testTwoPointsUseTheChordSlope() {
+        XCTAssertEqual(MonotoneCubic.tangents(xs: [0, 2], ys: [0, 6]), [3, 3])
+    }
+
+    func testDegenerateInputsStayFinite() {
+        XCTAssertEqual(MonotoneCubic.tangents(xs: [], ys: []), [])
+        XCTAssertEqual(MonotoneCubic.tangents(xs: [1], ys: [4]), [0])
+        let repeated = MonotoneCubic.tangents(xs: [0, 1, 1, 2], ys: [0, 1, 5, 6])
+        XCTAssertTrue(repeated.allSatisfy(\.isFinite), "a repeated x is flat, not infinite")
+    }
+
+    func testControlPointsSitAThirdOfTheWayAlong() {
+        let c = MonotoneCubic.controlPoints(x0: 0, y0: 0, x1: 3, y1: 3, m0: 1, m1: 1)
+        XCTAssertEqual(c.c1x, 1)
+        XCTAssertEqual(c.c1y, 1)
+        XCTAssertEqual(c.c2x, 2)
+        XCTAssertEqual(c.c2y, 2)
+    }
+}

--- a/Tests/MacPerfMonitorCoreTests/SamplerLiveTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/SamplerLiveTests.swift
@@ -102,4 +102,13 @@ final class SamplerLiveTests: XCTestCase {
         let after = try XCTUnwrap(reader.fdCount(pid, scratch: scratch))
         XCTAssertLessThan(after, baseline + 50)
     }
+
+    func testHasBaselineOnlyAfterAFirstTick() {
+        let sampler = Sampler()
+        XCTAssertFalse(sampler.hasBaseline, "nothing to difference against before the first tick")
+        _ = sampler.tickSystem()
+        XCTAssertTrue(sampler.hasBaseline)
+        sampler.reset()
+        XCTAssertFalse(sampler.hasBaseline, "a reset drops the baseline with the deltas")
+    }
 }

--- a/Tests/MacPerfMonitorCoreTests/SystemHistoryTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/SystemHistoryTests.swift
@@ -103,4 +103,59 @@ final class SystemHistoryTests: XCTestCase {
         XCTAssertEqual(HistoryWindow.oneDay.granularity, .minute)
         XCTAssertEqual(HistoryWindow.sevenDays.granularity, .hour)
     }
+
+    // MARK: - Tiers carry their peaks and run up to the last raw row
+
+    func testMinuteAggregatesCarryTheBucketPeak() throws {
+        try insert(at: anchor.addingTimeInterval(6), pressure: 10)
+        try insert(at: anchor.addingTimeInterval(12), pressure: 50)
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(600))
+
+        let points = try store.systemHistory(.oneDay, now: anchor.addingTimeInterval(600))
+        let minute = try XCTUnwrap(points.first)
+        XCTAssertEqual(minute.pressurePercent, 30, accuracy: 0.001, "the line gets the mean")
+        XCTAssertEqual(minute.peaks?.pressurePercent ?? 0, 50, accuracy: 0.001)
+        XCTAssertEqual(minute.effectivePeaks.pressurePercent, 50, accuracy: 0.001)
+    }
+
+    func testLongRangesTopUpFromTheRawRowsPastTheWatermark() throws {
+        // Two complete minutes, rolled into the minute tier...
+        for i in 0..<20 {
+            try insert(at: anchor.addingTimeInterval(Double(i) * 6), pressure: 30)
+        }
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(120))
+        // ...then raw samples retention has not seen yet.
+        try insert(at: anchor.addingTimeInterval(130), pressure: 70)
+        try insert(at: anchor.addingTimeInterval(140), pressure: 80)
+
+        let points = try store.systemHistory(.sixHours, now: anchor.addingTimeInterval(150))
+        let dates = points.map(\.date)
+        XCTAssertEqual(dates, dates.sorted())
+        XCTAssertEqual(Set(dates).count, dates.count, "no row is served twice")
+        XCTAssertEqual(points.count, 4, "two minute rows, then the two raw rows after them")
+        XCTAssertNotNil(points[0].peaks)
+        XCTAssertNotNil(points[1].peaks)
+        XCTAssertNil(points[2].peaks, "a raw row has no stored peak")
+        XCTAssertEqual(points[2].pressurePercent, 70)
+        XCTAssertEqual(points[3].pressurePercent, 80)
+        XCTAssertEqual(
+            points[2].date.timeIntervalSince(points[1].date), 70, accuracy: 0.001,
+            "the raw tail starts at the minute watermark, not inside a rolled minute")
+    }
+
+    func testRawSamplesAlreadyRolledUpAreNotServedTwice() throws {
+        for i in 0..<10 {
+            try insert(at: anchor.addingTimeInterval(Double(i) * 6), pressure: 30)
+        }
+        try Retention.run(store.databasePool, now: anchor.addingTimeInterval(60))
+        let points = try store.systemHistory(.sixHours, now: anchor.addingTimeInterval(70))
+        XCTAssertEqual(points.count, 1, "the minute row stands in for its ten raw samples")
+    }
+
+    func testStoredSpacingPerTier() {
+        XCTAssertNil(HistoryWindow.oneHour.granularity.storedSpacing)
+        XCTAssertEqual(HistoryWindow.sixHours.granularity.storedSpacing, 60)
+        XCTAssertEqual(HistoryWindow.oneDay.granularity.storedSpacing, 60)
+        XCTAssertEqual(HistoryWindow.sevenDays.granularity.storedSpacing, 3600)
+    }
 }

--- a/Tests/MacPerfMonitorCoreTests/SystemHistoryWindowTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/SystemHistoryWindowTests.swift
@@ -84,4 +84,31 @@ final class SystemHistoryWindowTests: XCTestCase {
         }
         XCTAssertLessThanOrEqual(columnar.count, 1440)
     }
+
+    // MARK: - Peak columns
+
+    func testPeakColumnsMirrorRawSamplesAndCarryStoredPeaks() {
+        var window = SystemHistoryWindow(span: 3600)
+        let base = Date(timeIntervalSinceReferenceDate: 1000)
+        let raw = SystemHistoryPoint(
+            date: base, pressurePercent: 20, appMemory: 1, wired: 1, compressed: 1, cachedFiles: 1,
+            swapUsed: 0, cpuLoad: 0.3, networkInBytesPerSec: 10, diskWriteBytesPerSec: 4)
+        window.append(raw)
+        var stored = SystemHistoryPoint(
+            date: base.addingTimeInterval(60), pressurePercent: 30, appMemory: 1, wired: 1,
+            compressed: 1, cachedFiles: 1, swapUsed: 0, cpuLoad: 0.2, networkInBytesPerSec: 2)
+        stored.peaks = SystemHistoryPeaks(
+            pressurePercent: 80, cpuLoad: 0.9, networkInBytesPerSec: 50, networkOutBytesPerSec: 6,
+            diskReadBytesPerSec: 7, diskWriteBytesPerSec: 8)
+        window.append(stored)
+
+        XCTAssertEqual(Array(window.values(.cpuLoad)), [0.3, 0.2], "the line column is the mean")
+        XCTAssertEqual(
+            Array(window.values(.cpuLoadPeak)), [0.3, 0.9],
+            "a raw sample's peak is itself; a stored row's is its bucket peak")
+        XCTAssertEqual(Array(window.values(.pressurePercentPeak)), [20, 80])
+        XCTAssertEqual(Array(window.values(.networkInPeak)), [10, 50])
+        XCTAssertEqual(Array(window.values(.diskWritePeak)), [4, 8])
+        XCTAssertEqual(Array(window.values(.gpuUtilizationPeak)), [0, 0])
+    }
 }

--- a/docs/chart-rules.md
+++ b/docs/chart-rules.md
@@ -65,6 +65,15 @@ database, because rule 3 needs the real minimum and maximum of each bucket and
 an average taken earlier has thrown them away. Keeping full resolution in memory
 is the cheap part: an hour at one second is 3,600 doubles per metric.
 
+The line through those points is a monotone cubic curve, the same construction
+beszel draws with (d3's `curveMonotoneX`). A polyline through 120 points reads
+as jagged, and an ordinary spline smooths it by overshooting, which on a
+monitoring chart invents a peak between two real ones. The monotone curve stays
+inside the vertical range of each pair of points it joins, so every bump is one
+that was measured. `MonotoneCubic` in Core holds the tangent rule and its tests;
+`MonotoneCurve` turns it into a path for both the layer-backed strips and the
+Canvas charts.
+
 **2. How a bucket is reduced belongs to the metric, and is decided once.**
 
 | Kind of metric | Reduction | Why |
@@ -84,9 +93,14 @@ this is a drawing change rather than a data change.
 is the plot width that decides how much reduction happens. Five minutes at one
 second is 300 samples and most of them survive; an hour is 3,600 and most do
 not. Nothing is special-cased by name. Ranges long enough to be served by the
-stored minute and hour tiers arrive pre-averaged, so their bands are flat: giving
-those tiers a stored minimum and maximum is the one piece of this that is not
-done.
+stored minute and hour tiers arrive as means, but each row carries its bucket's
+peak (`SystemHistoryPoint.peaks`, from the `_max` columns the tiers already
+kept), and the band rises to it: at six hours and beyond the line is the mean
+and the shading above it reaches what the spikes hit. The tiers store no
+minimum, so the band's floor there is the mean itself. Those ranges also run
+right up to the present: a tier only holds buckets that were complete when
+retention last ran, so the query tops up from the finer tiers past each
+watermark down to the raw rows, and the live samples join on without a hole.
 
 **5. The y axis fits the data, with a floor on the span.** A fixed wide axis
 wastes the plot: a die sensor pinned to 0 to 110 draws a flat ribbon through the
@@ -101,7 +115,15 @@ each second makes a steady signal look alive.
 
 **7. Gaps are gaps.** A missing sample breaks the line. Never interpolate across
 a hole, because on a monitoring chart a straight line means "we measured this"
-and a gap means "we were not looking".
+and a gap means "we were not looking". The threshold comes from the spacing the
+data legitimately has (`ChartGap.threshold`: three times the coarsest expected
+spacing, floored at fifteen seconds), never from the span. For a live range that
+is the logging interval; for a range served by a stored tier it is the tier's
+row spacing, a minute or an hour, or every stored row is its own island and the
+chart draws dots. A run resumes from its first real sample: the sampler's first
+tick after launch has nothing to difference against and reports zeros, so it is
+neither recorded nor charted, otherwise every run after a gap begins with a
+vertical climb from the axis.
 
 **8. Every chart says what it is showing against.** Where there is room, a
 labelled y axis, a time axis, and a caption. On a card strip there is not room,
@@ -120,11 +142,11 @@ be raw data is a lie the user cannot see.
 
 | Rule | Where it lives |
 | --- | --- |
-| 1, 4 | `TrendRenderer.smoothingColumns` sets the window from the span; `LiveStripBuckets` supplies the per-column extremes behind it. The history window keeps every sample on purpose |
-| 2 | one table in Core, keyed by `SystemHistoryWindow.Column` |
+| 1, 4 | `TrendRenderer.smoothingSeconds` sets the window from the span; `LiveStripBuckets` supplies the per-column extremes behind it, raised to the stored peaks where a row carries them; `MonotoneCurve` draws the line. The history window keeps every sample on purpose |
+| 2 | `TrendSurfaceSeries.reduction`, declared per series where the model is built |
 | 3 | `TrendSurface` band drawing, fed by the decimator's existing min and max |
 | 5, 6 | `ChartDomain.fitted`, called by each chart with its own minimum span |
-| 7 | `TrendModel.gapThreshold` |
+| 7 | `TrendModel.gapThreshold`, sized by `ChartGap.threshold` from the loaded tier's spacing; `Sampler.hasBaseline` keeps the zero tick out |
 | 8 | `TrendChartGeometry` for full charts, `ScaledSparkline` for strips |
 | 9, 10 | review, and the captions each panel already carries |
 
@@ -164,8 +186,9 @@ one at a time.
    fixed domains.
 3. **Annotation** (rules 8 and 10): peak labels on every card strip, captions
    that name the reduction. Done for the Processes header only.
-4. **Stored tiers** (rule 4's exception): keep a minimum and maximum alongside
-   the mean in the minute and hour tiers, so ranges of six hours and longer get
-   a band too.
+4. **Stored tiers** (rule 4's exception): the tiers' stored maxima now ride
+   along with the means, so ranges of six hours and longer get a band from the
+   mean up to the peak. Storing a minimum as well, so the band has a floor
+   below the mean, is the remaining piece.
 
 Rules 7 and 9 are met everywhere the audit does not list an exception.


### PR DESCRIPTION
Fixes the two chart bugs reported on build 215 and brings the beszel-style display Neil asked for to every chart.

**Resuming from zero.** The sampler's first tick after launch has nothing to difference against, so its CPU, network and disk figures are zero by construction. That tick was both recorded and drawn, which left a zero at the start of every run and a vertical climb out of the axis whenever a chart resumed after a gap. `Sampler.hasBaseline` now says whether a tick is measured, and the model neither records nor charts the one that is not. It still seeds the sampler and drives the first process scan.

**Dots on 6 hr, 24 hr and 7 day.** The gap threshold was sized to the logging interval, but those ranges are served by rows a minute or an hour apart, so every row counted as an island and drew as a dot. The Dashboard now sizes the threshold to the spacing of the tier the range loaded from.

**Average and peaks at long ranges.** Those ranges load every stored row (the renderer reduces at draw time, per the rules doc) and each row carries its bucket's peak from the `_max` columns the tiers already keep. New peak columns in `SystemHistoryWindow` and `LiveColumn.highs` lift the band to the real spike while the line follows the mean. The query also tops up from the finer tiers and the raw rows past each retention watermark, so a long range runs to the present instead of stopping at the last complete minute or hour.

**Curves.** Lines and band edges are monotone cubic curves (`MonotoneCubic` in Core, d3's `curveMonotoneX` as beszel draws), which are smooth and cannot overshoot, so every bump was measured. The sliding strip renderer fetches enough context to the left and repaints far enough back that a live-edge repaint matches a full one.

Tests: baseline flag, tier peaks and tail fill, peak columns, highs in buckets, downsampled peaks, curve monotonicity. Full suite passes (590 tests). `docs/chart-rules.md` and the changelog updated.

Offscreen renders at 1 hr and 6 hr show a smooth curve inside its band; 5 min keeps its detail. The real test is the installed app's stored ranges, which needs a new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
