### PR TITLE
Draw every chart through the one series routine, and load the tabs at full resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,12 @@ Notable changes to Mac Performance Monitor. This project follows
   to the present rather than stopping at the last complete minute or hour.
   Temperature axes fit the data with a floor on their span, the area fills are
   gone from the volatile series, the Processes header cards state their peak,
-  and the load average is a chart.
+  and the load average is a chart. The same drawing runs on every chart in the
+  app, not only the Dashboard: the GPU, Energy, Disk and Network tabs, the
+  process and group detail charts, and the battery charge chart, which moves
+  off Swift Charts. Those tabs now load every stored row rather than thinning
+  the history to 360 points before drawing it, and the menu bar panels draw the
+  same curve.
 
 ### Security
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>215</string>
+	<string>217</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>

--- a/Sources/MacPerfMonitor/Charts/BatteryChart.swift
+++ b/Sources/MacPerfMonitor/Charts/BatteryChart.swift
@@ -1,16 +1,21 @@
-import Charts
 import MacPerfMonitorCore
 import SwiftUI
 
-/// The battery charge timeline: a 0–100% area chart, with the "low" (20%) and
-/// "full" (80%) bands marked, tinted by the current `BatteryLevel`. A direct
-/// sibling of `CPUChart`/`PressureChart` so the dashboards read the same way.
-/// Plots `SystemHistoryPoint.batteryCharge`; the line's slope already shows
-/// whether the battery was charging or discharging.
+/// The battery charge timeline: a 0 to 100 percent area chart with the "low"
+/// (20 percent) and "full" (80 percent) marks, tinted by the current
+/// `BatteryLevel`. A direct sibling of `CPUChart` and `PressureChart`, drawn
+/// with the same `TrendChart` so it follows the chart rules with the rest of
+/// the app. Plots `SystemHistoryPoint.batteryCharge`; the line's slope already
+/// shows whether the battery was charging or discharging. Charge is a calm,
+/// slow series, so it keeps its fill (docs/chart-rules.md, rule 9).
 struct BatteryChart: View {
     let points: [SystemHistoryPoint]
     let currentLevel: BatteryLevel
     var xDomain: ClosedRange<Date>? = nil
+
+    private var chargePoints: [TrendPoint] {
+        points.map { TrendPoint(date: $0.date, value: $0.batteryCharge) }
+    }
 
     private var accessibilitySummary: String {
         guard let latest = points.last?.batteryCharge else { return t("No data yet.") }
@@ -23,70 +28,20 @@ struct BatteryChart: View {
     }
 
     var body: some View {
-        Chart {
-            RuleMark(y: .value("Low", 20))
-                .foregroundStyle(.red.opacity(0.35))
-                .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
-                .annotation(position: .top, alignment: .leading) {
-                    Text("Low").font(.caption2).foregroundStyle(.red)
-                }
-            RuleMark(y: .value("Full", 80))
-                .foregroundStyle(.green.opacity(0.3))
-                .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
-                .annotation(position: .top, alignment: .leading) {
-                    Text("80%").font(.caption2).foregroundStyle(.green)
-                }
-
-            ForEach(Array(points.splitIntoSegments().enumerated()), id: \.offset) {
-                segIdx, segment in
-                ForEach(segment) { point in
-                    AreaMark(
-                        x: .value("Time", point.date),
-                        y: .value("Charge", point.batteryCharge),
-                        series: .value("Segment", segIdx)
-                    )
-                    .interpolationMethod(.linear)
-                    .foregroundStyle(
-                        .linearGradient(
-                            colors: [
-                                currentLevel.color.opacity(0.45), currentLevel.color.opacity(0.04),
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-
-                    LineMark(
-                        x: .value("Time", point.date),
-                        y: .value("Charge", point.batteryCharge),
-                        series: .value("Segment", segIdx)
-                    )
-                    .interpolationMethod(.linear)
-                    .foregroundStyle(currentLevel.color)
-                    .lineStyle(StrokeStyle(lineWidth: 2))
-                }
-            }
-        }
-        .chartXScale(domain: resolvedXDomain)
-        .chartYScale(domain: 0...100)
-        .chartYAxis {
-            AxisMarks(values: [0, 20, 50, 80, 100]) { value in
-                AxisGridLine()
-                AxisValueLabel {
-                    if let v = value.as(Int.self) { Text("\(v)") }
-                }
-            }
-        }
-        .chartLegend(.hidden)
+        TrendChart(
+            series: [
+                TrendSeries(points: chargePoints, color: currentLevel.color, filled: true)
+            ],
+            xDomain: xDomain,
+            yDomain: 0...100,
+            yTicks: [0, 20, 50, 80, 100],
+            rules: [
+                TrendRule(value: 20, label: "Low", color: .red),
+                TrendRule(value: 80, label: "80%", color: .green),
+            ],
+            showsTimeAxis: true
+        )
         .accessibilityLabel("Battery charge timeline")
         .accessibilityValue(accessibilitySummary)
-        .reducedMotionAware()
-    }
-
-    private var resolvedXDomain: ClosedRange<Date> {
-        if let xDomain { return xDomain }
-        let first = points.first?.date ?? .distantPast
-        let last = points.last?.date ?? first.addingTimeInterval(1)
-        return first < last ? first...last : first.addingTimeInterval(-1)...last
     }
 }

--- a/Sources/MacPerfMonitor/Charts/CPUChart.swift
+++ b/Sources/MacPerfMonitor/Charts/CPUChart.swift
@@ -60,10 +60,14 @@ struct CPUChart: View {
         TrendChart(
             series: [
                 TrendSeries(
-                    points: LiveTrend.points(cpu, xDomain: xDomain).map {
-                        scale == 1 ? $0 : TrendPoint(date: $0.date, value: $0.value * scale)
+                    points: LiveTrend.allPoints(cpu).map {
+                        scale == 1
+                            ? $0
+                            : TrendPoint(
+                                date: $0.date, value: $0.value * scale,
+                                high: $0.high.map { $0 * scale })
                     },
-                    color: currentLevel.color, filled: true)
+                    color: currentLevel.color)
             ],
             xDomain: xDomain,
             yDomain: 0...100,

--- a/Sources/MacPerfMonitor/Charts/DiskChart.swift
+++ b/Sources/MacPerfMonitor/Charts/DiskChart.swift
@@ -13,8 +13,12 @@ struct DiskChart: View {
         yDomain: ClosedRange<Double>? = nil, showsTimeAxis: Bool = false
     ) {
         self.init(
-            read: LiveColumn(points) { $0.diskReadBytesPerSec },
-            write: LiveColumn(points) { $0.diskWriteBytesPerSec },
+            read: LiveColumn(
+                points, value: { $0.diskReadBytesPerSec },
+                high: { $0.effectivePeaks.diskReadBytesPerSec }),
+            write: LiveColumn(
+                points, value: { $0.diskWriteBytesPerSec },
+                high: { $0.effectivePeaks.diskWriteBytesPerSec }),
             xDomain: xDomain, yDomain: yDomain, showsTimeAxis: showsTimeAxis)
     }
 
@@ -24,8 +28,8 @@ struct DiskChart: View {
         yDomain: ClosedRange<Double>? = nil, showsTimeAxis: Bool = false
     ) {
         self.init(
-            read: LiveColumn(window, .diskReadBytesPerSec),
-            write: LiveColumn(window, .diskWriteBytesPerSec),
+            read: LiveColumn(window, .diskReadBytesPerSec, peak: .diskReadPeak),
+            write: LiveColumn(window, .diskWriteBytesPerSec, peak: .diskWritePeak),
             xDomain: xDomain, yDomain: yDomain, showsTimeAxis: showsTimeAxis)
     }
 
@@ -54,12 +58,9 @@ struct DiskChart: View {
     var body: some View {
         TrendChart(
             series: [
+                TrendSeries(points: LiveTrend.allPoints(read), color: DiskStyle.read),
                 TrendSeries(
-                    points: LiveTrend.points(read, xDomain: xDomain),
-                    color: DiskStyle.read, filled: true),
-                TrendSeries(
-                    points: LiveTrend.points(write, xDomain: xDomain),
-                    color: DiskStyle.write, filled: false, lineWidth: 1.8),
+                    points: LiveTrend.allPoints(write), color: DiskStyle.write, lineWidth: 1.8),
             ],
             xDomain: xDomain,
             yDomain: yDomain,

--- a/Sources/MacPerfMonitor/Charts/LiveTrend.swift
+++ b/Sources/MacPerfMonitor/Charts/LiveTrend.swift
@@ -30,17 +30,44 @@ struct LiveColumn {
         highs = peak.map { window.values($0) }
     }
 
-    init(_ points: [SystemHistoryPoint], value: (SystemHistoryPoint) -> Double) {
+    /// `high`, when given, reads each point's stored peak (see
+    /// `SystemHistoryPoint.effectivePeaks`) so the band reaches it.
+    init(
+        _ points: [SystemHistoryPoint], value: (SystemHistoryPoint) -> Double,
+        high: ((SystemHistoryPoint) -> Double)? = nil
+    ) {
+        var t: [Double] = []
+        var v: [Double] = []
+        var h: [Double] = []
+        t.reserveCapacity(points.count)
+        v.reserveCapacity(points.count)
+        if high != nil { h.reserveCapacity(points.count) }
+        for point in points {
+            t.append(point.date.timeIntervalSinceReferenceDate)
+            v.append(value(point))
+            if let high { h.append(high(point)) }
+        }
+        times = t[...]
+        values = v[...]
+        highs = high == nil ? nil : h[...]
+    }
+
+    /// The Canvas charts' input, as a column. Highs are carried only when some
+    /// point has one; a series of raw samples has none.
+    init(_ points: [TrendPoint]) {
         var t: [Double] = []
         var v: [Double] = []
         t.reserveCapacity(points.count)
         v.reserveCapacity(points.count)
         for point in points {
             t.append(point.date.timeIntervalSinceReferenceDate)
-            v.append(value(point))
+            v.append(point.value)
         }
         times = t[...]
         values = v[...]
+        if points.contains(where: { $0.high != nil }) {
+            highs = points.map { $0.high ?? $0.value }[...]
+        }
     }
 
     var count: Int { times.count }
@@ -74,8 +101,34 @@ enum LiveTrend {
     /// this is about one bucket per point, so nothing visible is lost.
     static let buckets = 720
 
+    /// Every sample of a column as chart points, peaks included. The chart
+    /// reduces at draw time (docs/chart-rules.md, rule 1), so nothing is
+    /// thinned here.
+    static func allPoints(_ column: LiveColumn) -> [TrendPoint] {
+        var out: [TrendPoint] = []
+        out.reserveCapacity(column.count)
+        var ti = column.times.startIndex
+        var vi = column.values.startIndex
+        var hi = column.highs?.startIndex
+        while ti < column.times.endIndex {
+            var point = TrendPoint(
+                date: Date(timeIntervalSinceReferenceDate: column.times[ti]),
+                value: column.values[vi])
+            if let highs = column.highs, let h = hi {
+                point.high = highs[h]
+                hi = h + 1
+            }
+            out.append(point)
+            ti += 1
+            vi += 1
+        }
+        return out
+    }
+
     /// Decimated points for one metric. `xDomain` anchors the buckets; without
-    /// one (a static chart) the data's own extent is used.
+    /// one (a static chart) the data's own extent is used. Used by the card
+    /// strips' fallback path; the charts take `allPoints` and reduce at draw
+    /// time.
     static func points(
         _ column: LiveColumn, xDomain: ClosedRange<Date>?, buckets: Int = LiveTrend.buckets
     ) -> [TrendPoint] {

--- a/Sources/MacPerfMonitor/Charts/MenuTrendChart.swift
+++ b/Sources/MacPerfMonitor/Charts/MenuTrendChart.swift
@@ -59,11 +59,14 @@ enum MenuChart {
             return
         }
 
-        var area = Path()
-        area.move(to: CGPoint(x: first.x, y: baselineY))
-        for point in points { area.addLine(to: point) }
-        area.addLine(to: CGPoint(x: points[points.count - 1].x, y: baselineY))
-        area.closeSubpath()
+        // The same monotone curve the main charts draw (docs/chart-rules.md):
+        // smooth, and it cannot overshoot a sample.
+        let outline = CGMutablePath()
+        outline.move(to: CGPoint(x: first.x, y: baselineY))
+        MonotoneCurve.add(points, to: outline, move: false)
+        outline.addLine(to: CGPoint(x: points[points.count - 1].x, y: baselineY))
+        outline.closeSubpath()
+        let area = Path(outline)
         // A light fill gives the line body without becoming a solid block: it
         // fades to fully transparent, so even a steady high line reads as a line
         // with a soft glow under it rather than a filled rectangle.
@@ -74,9 +77,7 @@ enum MenuChart {
                 startPoint: CGPoint(x: 0, y: gradientTop),
                 endPoint: CGPoint(x: 0, y: gradientBottom)))
 
-        var line = Path()
-        line.move(to: first)
-        for point in points.dropFirst() { line.addLine(to: point) }
+        let line = Path(MonotoneCurve.path(points))
         ctx.stroke(
             line, with: .color(color),
             style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))

--- a/Sources/MacPerfMonitor/Charts/MetricChart.swift
+++ b/Sources/MacPerfMonitor/Charts/MetricChart.swift
@@ -49,28 +49,13 @@ struct MetricChart: View, Equatable {
             && lhs.samples.last == rhs.samples.last
     }
 
-    /// Cap on the number of points actually drawn. A dense window (a 30-minute
-    /// or longer span holds hundreds to thousands of 1-second samples) is
-    /// collapsed to at most this many points, so the line stays a crisp trend
-    /// instead of smearing into noise and the live edge does not shimmer.
-    private static let maxPoints = 160
-
-    /// Width of one downsampling bucket, fixed by the span and the point cap so
-    /// it does not move as data accrues. Because it is anchored to the clock,
-    /// past buckets are settled the moment they fall behind the live edge.
-    private var bucketWidth: TimeInterval { windowSeconds / Double(Self.maxPoints) }
-
     /// The raw samples split into contiguous runs, broken wherever two samples
     /// are far enough apart to mean data is missing (the app was asleep, the
-    /// process was briefly unreadable, or it was relaunched). Splitting the RAW
-    /// series, before downsampling, is deliberate: the downsampled points sit
-    /// at each bucket's peak, whose timestamps jitter within the bucket, so
-    /// judging gaps on them would invent breaks in spiky metrics like CPU and
-    /// disk I/O. Each run is then downsampled on its own, so a real gap is left
-    /// blank rather than bridged by a misleading straight diagonal.
+    /// process was briefly unreadable, or it was relaunched). The chart then
+    /// reduces each run at draw time, a mean line inside a band of the
+    /// extremes (docs/chart-rules.md), so nothing is thinned here.
     private var segments: [[MetricSample]] {
         Self.split(samples, gapThreshold: gapThreshold)
-            .map { Self.stableDownsample($0, bucketWidth: bucketWidth) }
     }
 
     /// A gap is a jump well beyond the normal sampling cadence. Raw rows are
@@ -144,45 +129,6 @@ struct MetricChart: View, Equatable {
         .accessibilityLabel(t(accessibilityTitle))
         .accessibilityValue(accessibilitySummary)
         .reducedMotionAware()
-    }
-
-    /// Collapse a dense series to one point per fixed time bucket by keeping the
-    /// bucket's peak sample. The bucket width is fixed by the caller (derived
-    /// from the span, not the data), and the buckets are anchored to absolute
-    /// time (epoch / bucketWidth), not to the array index, so they stay put as
-    /// the live window advances: appending the newest sample only ever changes
-    /// the rightmost bucket while the rest of the line holds perfectly still
-    /// instead of changing shape. Keeping each bucket's maximum preserves spikes
-    /// (a climbing leak, a CPU burst) rather than averaging them away. A series
-    /// already coarser than the bucket width passes straight through untouched.
-    private static func stableDownsample(
-        _ samples: [MetricSample], bucketWidth: TimeInterval
-    )
-        -> [MetricSample]
-    {
-        guard bucketWidth > 0, samples.count > 2 else { return samples }
-        func bucketIndex(_ d: Date) -> Int {
-            Int((d.timeIntervalSince1970 / bucketWidth).rounded(.down))
-        }
-        var result: [MetricSample] = []
-        result.reserveCapacity(samples.count)
-        var currentBucket = bucketIndex(samples[0].date)
-        var peak = samples[0]
-        for sample in samples.dropFirst() {
-            let bucket = bucketIndex(sample.date)
-            if bucket == currentBucket {
-                if sample.value > peak.value { peak = sample }
-            } else {
-                result.append(peak)
-                currentBucket = bucket
-                peak = sample
-            }
-        }
-        result.append(peak)
-        if let latest = samples.last, latest.date > peak.date {
-            result.append(latest)
-        }
-        return result
     }
 
     /// Break a series into contiguous runs wherever two consecutive points are

--- a/Sources/MacPerfMonitor/Charts/NetworkChart.swift
+++ b/Sources/MacPerfMonitor/Charts/NetworkChart.swift
@@ -16,8 +16,12 @@ struct NetworkChart: View {
         yDomain: ClosedRange<Double>? = nil, showsTimeAxis: Bool = false
     ) {
         self.init(
-            download: LiveColumn(points) { $0.networkInBytesPerSec },
-            upload: LiveColumn(points) { $0.networkOutBytesPerSec },
+            download: LiveColumn(
+                points, value: { $0.networkInBytesPerSec },
+                high: { $0.effectivePeaks.networkInBytesPerSec }),
+            upload: LiveColumn(
+                points, value: { $0.networkOutBytesPerSec },
+                high: { $0.effectivePeaks.networkOutBytesPerSec }),
             xDomain: xDomain, yDomain: yDomain, showsTimeAxis: showsTimeAxis)
     }
 
@@ -27,8 +31,8 @@ struct NetworkChart: View {
         yDomain: ClosedRange<Double>? = nil, showsTimeAxis: Bool = false
     ) {
         self.init(
-            download: LiveColumn(window, .networkInBytesPerSec),
-            upload: LiveColumn(window, .networkOutBytesPerSec),
+            download: LiveColumn(window, .networkInBytesPerSec, peak: .networkInPeak),
+            upload: LiveColumn(window, .networkOutBytesPerSec, peak: .networkOutPeak),
             xDomain: xDomain, yDomain: yDomain, showsTimeAxis: showsTimeAxis)
     }
 
@@ -57,12 +61,10 @@ struct NetworkChart: View {
     var body: some View {
         TrendChart(
             series: [
+                TrendSeries(points: LiveTrend.allPoints(download), color: NetworkStyle.download),
                 TrendSeries(
-                    points: LiveTrend.points(download, xDomain: xDomain),
-                    color: NetworkStyle.download, filled: true),
-                TrendSeries(
-                    points: LiveTrend.points(upload, xDomain: xDomain),
-                    color: NetworkStyle.upload, filled: false, lineWidth: 1.8),
+                    points: LiveTrend.allPoints(upload), color: NetworkStyle.upload,
+                    lineWidth: 1.8),
             ],
             xDomain: xDomain,
             yDomain: yDomain,

--- a/Sources/MacPerfMonitor/Charts/PressureChart.swift
+++ b/Sources/MacPerfMonitor/Charts/PressureChart.swift
@@ -53,8 +53,8 @@ struct PressureChart: View {
         TrendChart(
             series: [
                 TrendSeries(
-                    points: LiveTrend.points(pressure, xDomain: xDomain),
-                    color: currentLevel.color, filled: true)
+                    points: LiveTrend.allPoints(pressure), color: currentLevel.color,
+                    filled: true)
             ],
             xDomain: xDomain,
             yDomain: 0...100,

--- a/Sources/MacPerfMonitor/Charts/SwapChart.swift
+++ b/Sources/MacPerfMonitor/Charts/SwapChart.swift
@@ -41,9 +41,7 @@ struct SwapChart: View {
     var body: some View {
         TrendChart(
             series: [
-                TrendSeries(
-                    points: LiveTrend.points(swap, xDomain: xDomain),
-                    color: .indigo, filled: true)
+                TrendSeries(points: LiveTrend.allPoints(swap), color: .indigo, filled: true)
             ],
             xDomain: xDomain,
             yDomain: yDomain,

--- a/Sources/MacPerfMonitor/Charts/TemperatureChart.swift
+++ b/Sources/MacPerfMonitor/Charts/TemperatureChart.swift
@@ -25,65 +25,33 @@ extension ThermalPressureState {
 
 /// CPU and GPU die temperature over the selected window. The thermal fields
 /// are optional (nil marks a tick that did not read the SMC), so each series
-/// carries only the points that have a value: `TrendChart`'s gap splitting
+/// carries only the points that have a value: the chart's gap splitting
 /// leaves unsampled stretches blank instead of drawing a misleading 0 degree
-/// floor. On aggregate ranges the points already carry the bucket max, so the
-/// line is "how hot did it get", never a smoothed average.
+/// floor. The line follows each bucket's maximum, never a mean, because a
+/// thermal spike is the event worth seeing, and the band behind it shows how
+/// far the readings ranged below that (docs/chart-rules.md, rule 2). On the
+/// stored ranges the rows already carry the bucket maximum.
 struct TemperatureChart: View {
     let points: [SystemHistoryPoint]
     var xDomain: ClosedRange<Date>? = nil
     var showsTimeAxis = false
 
     private var cpuPoints: [TrendPoint] {
-        Self.reduced(
-            points.compactMap { p in p.cpuDieC.map { TrendPoint(date: p.date, value: $0) } },
-            width: bucketWidth)
+        points.compactMap { p in p.cpuDieC.map { TrendPoint(date: p.date, value: $0) } }
     }
 
     private var gpuPoints: [TrendPoint] {
-        Self.reduced(
-            points.compactMap { p in p.gpuDieC.map { TrendPoint(date: p.date, value: $0) } },
-            width: bucketWidth)
+        points.compactMap { p in p.gpuDieC.map { TrendPoint(date: p.date, value: $0) } }
     }
 
-    /// Bucket width in seconds, taken from the range being shown rather than
-    /// from the data. Taking it from the data was a bug: each new sample
-    /// stretched the span slightly, every bucket boundary moved with it, and the
-    /// whole line changed shape on each tick instead of simply extending. A
-    /// width fixed by the range, with buckets anchored to absolute time, means
-    /// an old bucket always holds exactly the samples it always held.
-    private var bucketWidth: Double {
+    /// The spacing of one drawn point, taken from the range being shown rather
+    /// than from the data (which would move with every sample). It sizes the
+    /// gap threshold: on the stored ranges a row a minute or an hour apart is
+    /// still one series.
+    private var pointSpacing: Double {
         guard let xDomain else { return 0 }
         let span = xDomain.upperBound.timeIntervalSince(xDomain.lowerBound)
         return span > 0 ? span / 120 : 0
-    }
-
-    /// About 120 points across the window, each the hottest reading in its
-    /// bucket. An hour of one second samples is 3,600 readings in a panel a few
-    /// hundred points wide; drawn raw they stack into a solid block whose
-    /// height is the spread rather than the temperature. The maximum is the
-    /// right reduction here, not the mean: a thermal spike is the event worth
-    /// seeing. See docs/chart-rules.md.
-    private static func reduced(_ series: [TrendPoint], width: Double) -> [TrendPoint] {
-        guard width > 0, series.count > 240 else { return series }
-        var out: [TrendPoint] = []
-        out.reserveCapacity(series.count / 2 + 1)
-        var bucket = Int.min
-        var hottest: TrendPoint?
-        for point in series {
-            let index = Int(
-                (point.date.timeIntervalSinceReferenceDate
-                    / width).rounded(.down))
-            if index != bucket {
-                if let hottest { out.append(hottest) }
-                bucket = index
-                hottest = point
-            } else if let current = hottest, point.value > current.value {
-                hottest = point
-            }
-        }
-        if let hottest { out.append(hottest) }
-        return out
     }
 
     private var accessibilitySummary: String {
@@ -104,16 +72,17 @@ struct TemperatureChart: View {
     var body: some View {
         TrendChart(
             series: [
-                TrendSeries(points: cpuPoints, color: ThermalStyle.cpu),
+                TrendSeries(points: cpuPoints, color: ThermalStyle.cpu, reduction: .maximum),
                 TrendSeries(
-                    points: gpuPoints, color: ThermalStyle.gpu, filled: false, lineWidth: 1.8),
+                    points: gpuPoints, color: ThermalStyle.gpu, lineWidth: 1.8,
+                    reduction: .maximum),
             ],
             xDomain: xDomain,
             yDomain: temperatureDomain,
             yFormat: { String(format: "%.0f°C", $0) },
             showsTimeAxis: showsTimeAxis,
             gapThreshold: ChartGap.threshold(
-                expectedSpacing: max(bucketWidth, SamplerModel.configuredHighResInterval()))
+                expectedSpacing: max(pointSpacing, SamplerModel.configuredHighResInterval()))
         )
         .accessibilityLabel("Die temperature trend")
         .accessibilityValue(accessibilitySummary)
@@ -155,7 +124,7 @@ struct FanChart: View {
     var body: some View {
         TrendChart(
             series: [
-                TrendSeries(points: fanPoints, color: ThermalStyle.fan, filled: true)
+                TrendSeries(points: fanPoints, color: ThermalStyle.fan, reduction: .maximum)
             ],
             xDomain: xDomain,
             yFormat: { t("%@ rpm", String(format: "%.0f", max($0, 0))) },

--- a/Sources/MacPerfMonitor/Charts/TrendChart.swift
+++ b/Sources/MacPerfMonitor/Charts/TrendChart.swift
@@ -5,6 +5,9 @@ import SwiftUI
 struct TrendPoint: Equatable {
     var date: Date
     var value: Double
+    /// The peak behind a stored mean (a minute or hour row's bucket maximum),
+    /// which the band rises to. Nil for a raw sample, whose peak is itself.
+    var high: Double? = nil
 }
 
 /// One line (with optional area fill) on a `TrendChart`.
@@ -13,6 +16,10 @@ struct TrendSeries: Equatable {
     var color: Color
     var filled: Bool = false
     var lineWidth: CGFloat = 2
+    /// What the line through a bucket of samples follows: the mean for
+    /// utilisation and rates, the maximum for temperatures and fan speeds
+    /// (docs/chart-rules.md, rule 2).
+    var reduction: TrendSurfaceSeries.Reduction = .mean
 }
 
 /// A dashed horizontal threshold line with a small leading label (e.g. "Busy").
@@ -70,8 +77,9 @@ struct TrendChart: View {
     var showsTimeAxis: Bool = false
     var timeAxis: TimeAxis = .clock
     /// Two consecutive points further apart than this are not joined. Nil
-    /// derives a threshold from the window (or the median spacing); pass
-    /// `.infinity` for a series the caller has already split.
+    /// derives a threshold from the series' own spacing
+    /// (`ChartGap.expectedSpacing`); pass `.infinity` for a series the caller
+    /// has already split.
     var gapThreshold: TimeInterval? = nil
     /// Draw a hairline frame around the plot.
     var plotBorder: Bool = false
@@ -115,7 +123,7 @@ struct TrendChart: View {
                 domain: domain,
                 tMin: tMin,
                 tMax: tMax,
-                gapThreshold: resolvedGapThreshold(span: span),
+                gapThreshold: gapThreshold,
                 clockTickFractions: clockTicks.map(\.fraction),
                 scrub: scrub
             )
@@ -176,14 +184,6 @@ struct TrendChart: View {
         return lo <= hi ? (lo, hi) : (0, 0)
     }
 
-    /// A jump beyond the window's spacing × 15 (floored at 30 s) is treated as
-    /// missing data, matching the previous Swift Charts behaviour. Nil asks the
-    /// live layer to derive one from the median spacing instead.
-    private func resolvedGapThreshold(span: Double) -> TimeInterval? {
-        if let gapThreshold { return gapThreshold }
-        return xDomain.map { _ in max(span / 360 * 15, 30) }
-    }
-
     /// The point of any series nearest the scrubbed time.
     private func nearestPoint(fraction: CGFloat, tMin: Double, span: Double) -> TrendScrubPoint? {
         let target = tMin + Double(fraction) * span
@@ -202,49 +202,6 @@ struct TrendChart: View {
         return TrendScrubPoint(
             fraction: CGFloat((best.date.timeIntervalSinceReferenceDate - tMin) / span),
             date: best.date, value: best.value)
-    }
-
-    // MARK: - Gap runs
-
-    /// Split a series into gap-free runs. Live charts pass a fixed threshold
-    /// derived from the window so the split never needs a sort; static charts
-    /// use the median spacing × 15 (floored at 30 s).
-    static func runs(
-        _ points: [TrendPoint], gapThreshold fixedThreshold: TimeInterval?
-    ) -> [[TrendPoint]] {
-        guard points.count > 1 else { return points.isEmpty ? [] : [points] }
-        let threshold: TimeInterval
-        if let fixedThreshold {
-            threshold = fixedThreshold
-        } else {
-            var deltas: [TimeInterval] = []
-            deltas.reserveCapacity(points.count - 1)
-            for i in 1..<points.count {
-                deltas.append(points[i].date.timeIntervalSince(points[i - 1].date))
-            }
-            deltas.sort()
-            threshold = max(deltas[deltas.count / 2] * 15, 30)
-        }
-        // Fast path: no gaps, the whole series is one run and needs no copy.
-        var hasGap = false
-        for i in 1..<points.count
-        where points[i].date.timeIntervalSince(points[i - 1].date) > threshold {
-            hasGap = true
-            break
-        }
-        if !hasGap { return [points] }
-        var result: [[TrendPoint]] = []
-        var current: [TrendPoint] = [points[0]]
-        for pt in points.dropFirst() {
-            if let last = current.last, pt.date.timeIntervalSince(last.date) > threshold {
-                result.append(current)
-                current = [pt]
-            } else {
-                current.append(pt)
-            }
-        }
-        result.append(current)
-        return result
     }
 
     // MARK: - Time axis ticks
@@ -551,61 +508,38 @@ private struct TrendLiveLayer: View {
 
             guard tMax > tMin else { return }
 
-            // A series denser than the plot is reduced to per-pixel extremes so
-            // the stroked path never has more segments than there are columns.
-            let columns = max(1, Int(plot.width.rounded(.up)))
-            let plotDomain =
-                Date(
-                    timeIntervalSinceReferenceDate: tMin)...Date(
-                    timeIntervalSinceReferenceDate: tMax)
-
             // Series stay inside the plot: callers retain samples slightly
             // older than the window (so the line enters from the left edge),
             // and unclipped those points stroke through the axis gutter.
             var seriesCtx = ctx
             seriesCtx.clip(to: Path(plot))
 
-            // Each series: gap-aware runs, optional area fill, then the line.
-            for s in series {
-                for rawRun in TrendChart.runs(s.points, gapThreshold: gapThreshold)
-                where !rawRun.isEmpty {
-                    let run: [TrendPoint]
-                    if rawRun.count > 2 * columns {
-                        run = LiveSeriesDecimator.decimate(
-                            rawRun, buckets: columns, domain: plotDomain,
-                            date: { $0.date }, value: { $0.value }
-                        ).map { TrendPoint(date: $0.date, value: $0.value) }
-                    } else {
-                        run = rawRun
-                    }
-                    let linePath = Path(
-                        MonotoneCurve.path(run.map { CGPoint(x: x($0.date), y: y($0.value)) }))
-                    if s.filled, run.count >= 2 {
-                        var fill = linePath
-                        fill.addLine(to: CGPoint(x: x(run.last!.date), y: plot.maxY))
-                        fill.addLine(to: CGPoint(x: x(run.first!.date), y: plot.maxY))
-                        fill.closeSubpath()
-                        seriesCtx.fill(
-                            fill,
-                            with: .linearGradient(
-                                Gradient(colors: [s.color.opacity(0.42), s.color.opacity(0.04)]),
-                                startPoint: CGPoint(x: 0, y: plot.minY),
-                                endPoint: CGPoint(x: 0, y: plot.maxY)))
-                    }
-                    if run.count >= 2 {
-                        seriesCtx.stroke(
-                            linePath, with: .color(s.color),
-                            style: StrokeStyle(
-                                lineWidth: s.lineWidth, lineCap: .round, lineJoin: .round))
-                    } else if let only = run.first {
-                        // A lone point draws a dot so an isolated reading is visible.
-                        let r: CGFloat = 1.6
-                        let dot = Path(
-                            ellipseIn: CGRect(
-                                x: x(only.date) - r, y: y(only.value) - r, width: 2 * r,
-                                height: 2 * r))
-                        seriesCtx.fill(dot, with: .color(s.color))
-                    }
+            // The same drawing as the live strips (`TrendRenderer.drawSeries`):
+            // one bucket per pixel column, the mean of each as a curve inside
+            // a band of the extremes, gaps left open. Only the gap threshold
+            // is decided here, from the series' own spacing when the caller
+            // did not say.
+            let columns = max(1, Int(plot.width.rounded(.up)))
+            let bucketWidth = tSpan / Double(columns)
+            let first = LiveStripBuckets.index(of: tMin, width: bucketWidth)
+            let last = LiveStripBuckets.index(of: tMax, width: bucketWidth)
+            seriesCtx.withCGContext { cg in
+                var gradients: [String: CGGradient] = [:]
+                for s in series where !s.points.isEmpty {
+                    let column = LiveColumn(s.points)
+                    let threshold =
+                        gapThreshold
+                        ?? ChartGap.threshold(
+                            expectedSpacing: ChartGap.expectedSpacing(times: column.times))
+                    TrendRenderer.drawSeries(
+                        TrendSurfaceSeries(
+                            column: column, color: s.color, filled: s.filled,
+                            lineWidth: s.lineWidth, reduction: s.reduction),
+                        span: tSpan, bucketWidth: bucketWidth, buckets: first...last,
+                        gapThreshold: threshold,
+                        x: { t in plot.minX + CGFloat((t - tMin) / tSpan) * plot.width },
+                        y: y, fillTop: plot.minY, fillBaseline: plot.maxY, context: cg,
+                        gradients: &gradients)
                 }
             }
 

--- a/Sources/MacPerfMonitor/Charts/TrendSurface.swift
+++ b/Sources/MacPerfMonitor/Charts/TrendSurface.swift
@@ -946,97 +946,115 @@ enum TrendRenderer {
             ctx.strokePath()
         }
 
-        // How many columns of history the line averages over. One column holds
-        // two or three samples at an hour's span, and the mean of three noisy
-        // samples is still noisy, so bucketing to pixels barely smooths at all.
-        // Averaging over a window sized from the span does: a target of about
-        // 120 points across the plot puts thirty seconds behind each point at an
-        // hour, three minutes at six hours, and two seconds at five minutes,
-        // where the detail is still the point. See docs/chart-rules.md.
-        let smoothingSeconds = TrendRenderer.smoothingSeconds(span: tick.span)
-        // Columns of extra history to fetch, so a repaint of the live edge sees
-        // the same window as a full repaint. Expressed in the same units as the
-        // window itself.
-        let smoothing =
-            bucketWidth > 0 ? max(1, Int((smoothingSeconds / bucketWidth).rounded())) : 1
         // Columns of extra history to the left, so a repaint of a few live
         // columns matches a full one exactly. The first visible curve segment
         // takes its shape from the two points before it, each at most a gap
         // threshold back (further and it is a new run), and each of those needs
         // the full trailing window behind it for its averaged value to agree.
+        let smoothing = smoothingColumns(span: tick.span, bucketWidth: bucketWidth)
         let gapColumns = bucketWidth > 0 ? Int((tick.gapThreshold / bucketWidth).rounded(.up)) : 1
         let context = 2 * gapColumns + smoothing + 2
 
         for s in model.series {
-            let extremes = LiveStripBuckets.buckets(
-                times: s.column.times, values: s.column.values, highs: s.column.highs,
-                width: bucketWidth, from: buckets.lowerBound - context,
-                through: buckets.upperBound, gapThreshold: tick.gapThreshold, scale: s.scale)
-            guard !extremes.isEmpty else { continue }
-            let color = NSColor(s.color)
+            drawSeries(
+                s, span: tick.span, bucketWidth: bucketWidth,
+                buckets: (buckets.lowerBound - context)...buckets.upperBound,
+                gapThreshold: tick.gapThreshold, x: x, y: y, fillTop: 0, fillBaseline: height,
+                context: ctx, gradients: &gradients)
+        }
+    }
 
-            // More than one sample per column means the samples cannot all be
-            // drawn honestly. Rule 3: the line becomes the bucket's reduction
-            // and the spread goes behind it as a band, instead of a spike per
-            // column that turns a busy metric into a solid block.
-            let aggregated = extremes.contains(where: \.isAggregate) || smoothing > 1
+    /// How many columns of history the line averages over. One column holds
+    /// two or three samples at an hour's span, and the mean of three noisy
+    /// samples is still noisy, so bucketing to pixels barely smooths at all.
+    /// Averaging over a window sized from the span does: a target of about
+    /// 120 points across the plot puts thirty seconds behind each point at an
+    /// hour, three minutes at six hours, and two seconds at five minutes,
+    /// where the detail is still the point. See docs/chart-rules.md.
+    static func smoothingColumns(span: Double, bucketWidth: Double) -> Int {
+        bucketWidth > 0 ? max(1, Int((smoothingSeconds(span: span) / bucketWidth).rounded())) : 1
+    }
+
+    /// One series over `buckets`: the band of each column's spread, the
+    /// smoothed line as a monotone curve, the optional fill, and a dot for an
+    /// isolated reading. This is the whole of how a series is drawn, shared by
+    /// the strip (which widens `buckets` to the left so a partial repaint
+    /// agrees with a full one) and the Canvas charts (a full redraw of the
+    /// visible buckets), so every chart in the app follows the same rules.
+    static func drawSeries(
+        _ s: TrendSurfaceSeries, span: Double, bucketWidth: Double, buckets: ClosedRange<Int>,
+        gapThreshold: Double, x: (Double) -> CGFloat, y: (Double) -> CGFloat, fillTop: CGFloat,
+        fillBaseline: CGFloat, context ctx: CGContext, gradients: inout [String: CGGradient]
+    ) {
+        let smoothingSeconds = smoothingSeconds(span: span)
+        let smoothing = smoothingColumns(span: span, bucketWidth: bucketWidth)
+        let extremes = LiveStripBuckets.buckets(
+            times: s.column.times, values: s.column.values, highs: s.column.highs,
+            width: bucketWidth, from: buckets.lowerBound, through: buckets.upperBound,
+            gapThreshold: gapThreshold, scale: s.scale)
+        guard !extremes.isEmpty else { return }
+        let color = NSColor(s.color)
+
+        // More than one sample per column means the samples cannot all be
+        // drawn honestly. Rule 3: the line becomes the bucket's reduction
+        // and the spread goes behind it as a band, instead of a spike per
+        // column that turns a busy metric into a solid block.
+        let aggregated = extremes.contains(where: \.isAggregate) || smoothing > 1
+        if aggregated {
+            drawBand(extremes, width: bucketWidth, color: color, x: x, y: y, context: ctx)
+        }
+        let line = TrendRenderer.smoothed(
+            extremes, seconds: smoothingSeconds, width: bucketWidth,
+            value: { s.reduction == .maximum ? $0.maxValue : $0.mean })
+
+        // Gap-free runs of points in time order.
+        var runs: [[CGPoint]] = []
+        var current: [CGPoint] = []
+        for (bucket, value) in zip(extremes, line) {
+            if bucket.gapBefore, !current.isEmpty {
+                runs.append(current)
+                current = []
+            }
             if aggregated {
-                drawBand(
-                    extremes, width: bucketWidth, color: color, x: x, y: y, context: ctx)
+                current.append(
+                    CGPoint(x: x(bucketMidTime(bucket, width: bucketWidth)), y: y(value)))
+            } else {
+                for point in bucket.orderedPoints {
+                    current.append(CGPoint(x: x(point.time), y: y(point.value)))
+                }
             }
-            let line = TrendRenderer.smoothed(
-                extremes, seconds: smoothingSeconds, width: bucketWidth,
-                value: { s.reduction == .maximum ? $0.maxValue : $0.mean })
+        }
+        if !current.isEmpty { runs.append(current) }
 
-            // Gap-free runs of points in time order.
-            var runs: [[CGPoint]] = []
-            var current: [CGPoint] = []
-            for (bucket, value) in zip(extremes, line) {
-                if bucket.gapBefore, !current.isEmpty {
-                    runs.append(current)
-                    current = []
-                }
-                if aggregated {
-                    current.append(
-                        CGPoint(x: x(bucketMidTime(bucket, width: bucketWidth)), y: y(value)))
-                } else {
-                    for point in bucket.orderedPoints {
-                        current.append(CGPoint(x: x(point.time), y: y(point.value)))
-                    }
-                }
+        for run in runs {
+            guard let first = run.first, let last = run.last else { continue }
+            if run.count == 1 {
+                ctx.setFillColor(color.cgColor)
+                let r: CGFloat = 1.6
+                ctx.fillEllipse(
+                    in: CGRect(x: first.x - r, y: first.y - r, width: 2 * r, height: 2 * r))
+                continue
             }
-            if !current.isEmpty { runs.append(current) }
-
-            for run in runs {
-                guard let first = run.first, let last = run.last else { continue }
-                if run.count == 1 {
-                    ctx.setFillColor(color.cgColor)
-                    let r: CGFloat = 1.6
-                    ctx.fillEllipse(
-                        in: CGRect(x: first.x - r, y: first.y - r, width: 2 * r, height: 2 * r))
-                    continue
-                }
-                let path = MonotoneCurve.path(run)
-                if s.filled, let gradient = gradient(for: color, cache: &gradients) {
-                    let fill = path.mutableCopy() ?? CGMutablePath()
-                    fill.addLine(to: CGPoint(x: last.x, y: height))
-                    fill.addLine(to: CGPoint(x: first.x, y: height))
-                    fill.closeSubpath()
-                    ctx.saveGState()
-                    ctx.addPath(fill)
-                    ctx.clip()
-                    ctx.drawLinearGradient(
-                        gradient, start: CGPoint(x: 0, y: 0), end: CGPoint(x: 0, y: height),
-                        options: [])
-                    ctx.restoreGState()
-                }
-                ctx.addPath(path)
-                ctx.setStrokeColor(color.cgColor)
-                ctx.setLineWidth(s.lineWidth)
-                ctx.setLineCap(.butt)
-                ctx.setLineJoin(.bevel)
-                ctx.strokePath()
+            let path = MonotoneCurve.path(run)
+            if s.filled, let gradient = gradient(for: color, cache: &gradients) {
+                let fill = path.mutableCopy() ?? CGMutablePath()
+                fill.addLine(to: CGPoint(x: last.x, y: fillBaseline))
+                fill.addLine(to: CGPoint(x: first.x, y: fillBaseline))
+                fill.closeSubpath()
+                ctx.saveGState()
+                ctx.addPath(fill)
+                ctx.clip()
+                ctx.drawLinearGradient(
+                    gradient, start: CGPoint(x: 0, y: fillTop),
+                    end: CGPoint(x: 0, y: fillBaseline), options: [])
+                ctx.restoreGState()
             }
+            ctx.addPath(path)
+            ctx.setStrokeColor(color.cgColor)
+            ctx.setLineWidth(s.lineWidth)
+            ctx.setLineCap(.butt)
+            ctx.setLineJoin(.bevel)
+            ctx.strokePath()
         }
     }
 

--- a/Sources/MacPerfMonitor/Views/BatteryView.swift
+++ b/Sources/MacPerfMonitor/Views/BatteryView.swift
@@ -615,13 +615,11 @@ struct BatteryView: View {
 
     // MARK: - Derived
 
-    private static let maxChartPoints = 360
-
-    /// Recompute the memoized `points`: the pre-thinned loaded history plus the
-    /// latest live sample on the right edge so the timelines track the current
-    /// tick. The downsampling itself happens on the model's read queue
-    /// (`downsampledTo:`), so this per-tick step is O(chart points). Called only
-    /// when `history` reloads or a new sample lands — never during a layout pass.
+    /// Recompute the memoized `points`: the loaded history plus the latest live
+    /// sample on the right edge so the timelines track the current tick. The
+    /// charts reduce at draw time, so the history is loaded at the resolution
+    /// its tier stores. Called only when `history` reloads or a new sample
+    /// lands, never during a layout pass.
     private func rebuildPoints() {
         var pts = history
         if let system = model.liveSystem, system.batteryPresent {
@@ -659,7 +657,7 @@ struct BatteryView: View {
 
     private func reload() {
         let requested = range
-        model.loadSystemHistory(requested, downsampledTo: Self.maxChartPoints) { pts in
+        model.loadSystemHistory(requested) { pts in
             self.history = pts
             self.loadedRange = requested
             self.rebuildPoints()

--- a/Sources/MacPerfMonitor/Views/DiskUsageView.swift
+++ b/Sources/MacPerfMonitor/Views/DiskUsageView.swift
@@ -566,8 +566,6 @@ struct DiskUsageView: View {
         }
     }
 
-    private static let maxChartPoints = 360
-
     private func rebuildPoints() {
         var pts = history
         if let system = model.liveSystem {
@@ -600,7 +598,7 @@ struct DiskUsageView: View {
 
     private func reload() {
         let requested = range
-        model.loadSystemHistory(requested, downsampledTo: Self.maxChartPoints) { pts in
+        model.loadSystemHistory(requested) { pts in
             self.history = pts
             self.loadedRange = requested
             self.rebuildPoints()

--- a/Sources/MacPerfMonitor/Views/GPUView.swift
+++ b/Sources/MacPerfMonitor/Views/GPUView.swift
@@ -92,8 +92,7 @@ struct GPUView: View {
     private func reload() {
         guard let model else { return }
         let requested = range
-        let pointLimit = requested.granularity == .raw ? nil : 720
-        model.loadSystemHistory(requested, downsampledTo: pointLimit) { points in
+        model.loadSystemHistory(requested) { points in
             guard range == requested else { return }
             timeline.replace(
                 points, span: requested.seconds, live: model.liveSystem, gpu: model.latestGPU)

--- a/Sources/MacPerfMonitorCore/Util/LiveStripBuckets.swift
+++ b/Sources/MacPerfMonitorCore/Util/LiveStripBuckets.swift
@@ -25,6 +25,26 @@ public enum ChartGap {
     public static func threshold(expectedSpacing: TimeInterval) -> TimeInterval {
         max(expectedSpacing * 3, 15)
     }
+
+    /// The coarsest spacing a series legitimately has, read from the series
+    /// itself: the 90th percentile of the intervals between consecutive
+    /// samples. A series can mix tiers (hour rows topped up with minute rows
+    /// and then raw ones), and the median would follow whichever is more
+    /// numerous and turn the coarse rows into islands; a high percentile
+    /// follows the coarse rows, and the few real holes above it are what the
+    /// threshold exists to find. Zero with fewer than two samples.
+    public static func expectedSpacing(times: ArraySlice<Double>) -> Double {
+        guard times.count > 1 else { return 0 }
+        var deltas: [Double] = []
+        deltas.reserveCapacity(times.count - 1)
+        var previous = times[times.startIndex]
+        for t in times.dropFirst() {
+            deltas.append(t - previous)
+            previous = t
+        }
+        deltas.sort()
+        return deltas[min(deltas.count - 1, (deltas.count * 9) / 10)]
+    }
 }
 
 public enum LiveStripBuckets {

--- a/Tests/MacPerfMonitorCoreTests/LiveStripBucketsTests.swift
+++ b/Tests/MacPerfMonitorCoreTests/LiveStripBucketsTests.swift
@@ -265,4 +265,50 @@ final class LiveStripBucketsTests: XCTestCase {
             through: 10, gapThreshold: 5)
         XCTAssertEqual(mismatched[0].maxValue, 0.4, "a highs slice of the wrong length is dropped")
     }
+
+    // MARK: - Expected spacing
+
+    func testExpectedSpacingOfAUniformSeriesIsItsCadence() {
+        let times = (0..<100).map { Double($0) * 10 }
+        XCTAssertEqual(ChartGap.expectedSpacing(times: times[...]), 10)
+    }
+
+    func testExpectedSpacingFollowsTheCoarseTierWhenTiersMix() {
+        // A week of hour rows, topped up with an hour of minute rows and two
+        // minutes of one second rows: the fine tail outnumbers the hour rows,
+        // so a median would break the hour rows into islands.
+        var times: [Double] = []
+        var t = 0.0
+        for _ in 0..<168 {
+            times.append(t)
+            t += 3600
+        }
+        for _ in 0..<60 {
+            times.append(t)
+            t += 60
+        }
+        for _ in 0..<120 {
+            times.append(t)
+            t += 1
+        }
+        XCTAssertEqual(ChartGap.expectedSpacing(times: times[...]), 3600)
+    }
+
+    func testExpectedSpacingIgnoresAFewRealHoles() {
+        var times: [Double] = []
+        var t = 0.0
+        for i in 0..<200 {
+            times.append(t)
+            t += i == 100 ? 1800 : 60
+        }
+        XCTAssertEqual(ChartGap.expectedSpacing(times: times[...]), 60)
+        XCTAssertLessThan(
+            ChartGap.threshold(expectedSpacing: ChartGap.expectedSpacing(times: times[...])),
+            1800, "the hole is still a gap")
+    }
+
+    func testExpectedSpacingOfTooFewSamplesIsZero() {
+        XCTAssertEqual(ChartGap.expectedSpacing(times: [][...]), 0)
+        XCTAssertEqual(ChartGap.expectedSpacing(times: [5][...]), 0)
+    }
 }

--- a/docs/chart-rules.md
+++ b/docs/chart-rules.md
@@ -144,9 +144,9 @@ be raw data is a lie the user cannot see.
 | --- | --- |
 | 1, 4 | `TrendRenderer.smoothingSeconds` sets the window from the span; `LiveStripBuckets` supplies the per-column extremes behind it, raised to the stored peaks where a row carries them; `MonotoneCurve` draws the line. The history window keeps every sample on purpose |
 | 2 | `TrendSurfaceSeries.reduction`, declared per series where the model is built |
-| 3 | `TrendSurface` band drawing, fed by the decimator's existing min and max |
+| 3 | `TrendRenderer.drawSeries`, the one routine every series is drawn with: the layer-backed strips call it for their live columns, the Canvas `TrendChart` (every tab chart, the detail charts, the battery chart) calls it for its points |
 | 5, 6 | `ChartDomain.fitted`, called by each chart with its own minimum span |
-| 7 | `TrendModel.gapThreshold`, sized by `ChartGap.threshold` from the loaded tier's spacing; `Sampler.hasBaseline` keeps the zero tick out |
+| 7 | `TrendModel.gapThreshold`, sized by `ChartGap.threshold` from the loaded tier's spacing; a `TrendChart` given no threshold reads its series' own spacing with `ChartGap.expectedSpacing`; `Sampler.hasBaseline` keeps the zero tick out |
 | 8 | `TrendChartGeometry` for full charts, `ScaledSparkline` for strips |
 | 9, 10 | review, and the captions each panel already carries |
 
@@ -158,14 +158,16 @@ met today; everything else is work.
 | Surface | Rules met | Work needed |
 | --- | --- | --- |
 | Dashboard: pressure, processor, network, disk, swap | 1, 2, 3, 4, 7, 9 | none |
-| Dashboard: thermals | 1, 2, 4, 5, 7, 9 | 3: `TrendChart` has no band, so this shows the bucket maximum as a line with no spread behind it |
+| Dashboard: thermals | 1, 2, 3, 4, 5, 7, 9 | none |
 | Dashboard: metric cards | 1, 2, 3, 4, 5, 7, 9 | 8: no peak label, unlike the Processes header |
 | Processes header: CPU, load, die | 1, 2, 3, 4, 5, 8, 9 | none |
-| GPU tab | 7 | 1, 3, 5: fixed 0 to 100 and 0 to peak domains |
-| Energy and battery | 7, 9 | 1, 3, 5 |
-| Disk tab | 7 | 1, 3, 5 |
-| Network tab | 7 | 1, 3, 5 |
-| Menu bar panels | 8, 9 | 3, 5 |
+| GPU tab: utilisation, power, temperature | 1, 2, 3, 4, 7, 9 | 5 for power, which still runs from zero to a rounded peak; utilisation keeps 0 to 100 on purpose |
+| Energy tab: thermals, fan, charge | 1, 2, 3, 4, 5, 7, 9 | none |
+| Disk tab: throughput, operations, latency, free space | 1, 2, 3, 4, 7, 9 | 5 for latency; free space keeps 0 to capacity on purpose |
+| Network tab and adapter detail | 1, 2, 3, 4, 7, 9 | 5 |
+| Process and group detail charts | 1, 2, 3, 4, 7, 9 | 5 |
+| Menu bar panels | 8, 9 | 1, 3, 5: the curve is shared, the reduction and band are not |
+| Process performance chart (Processes tab, trace viewer) | 7 | to audit: a separate Canvas with its own scrubber |
 | Insights and Analytics | to audit | to audit |
 
 ## Rollout
@@ -174,12 +176,15 @@ One pull request per rule group, applied across every surface at once rather
 than per tab, because the point of writing this down is to stop fixing charts
 one at a time.
 
-1. **Resolution and reduction** (rules 1 to 4, 9): done for every live surface.
-   `LiveStripBuckets` carries each bucket's mean alongside its extremes, and
-   `TrendSurface` draws the mean as the line inside a translucent band of the
-   spread. Series declare their reduction, so temperature follows the maximum
-   while everything else follows the mean, and the area fills are gone from the
-   volatile series.
+1. **Resolution and reduction** (rules 1 to 4, 9): done for every chart but
+   the menu bar panels and the process performance chart. `LiveStripBuckets`
+   carries each bucket's mean alongside its extremes, and
+   `TrendRenderer.drawSeries` draws the mean as a monotone curve inside a
+   translucent band of the spread, for the live strips and the Canvas charts
+   alike. Series declare their reduction, so temperature and fan speed follow
+   the maximum while everything else follows the mean, the area fills are gone
+   from the volatile series, and the tabs load every stored row instead of
+   thinning to 360 points on the way in.
 2. **Axes** (rules 5 and 6): `ChartDomain.fitted` everywhere, with a stated
    minimum span per metric, and hysteresis on live recomputation. Done for the
    two temperature surfaces; the GPU, Energy, Disk and Network tabs still carry


### PR DESCRIPTION
Neil asked for the GPU and Energy tab temperature charts, and the rest of the tabs, to look like the Dashboard's memory and processor charts. Those two were the only surfaces drawn by the layer-backed strip renderer; everything else went through the Canvas `TrendChart`, which still reduced a series to per-pixel extremes and stroked a polyline through them.

**One routine for every series.** The per-series body of the strip renderer is now `TrendRenderer.drawSeries`: one bucket per pixel column, the mean (or maximum) of each as a monotone curve inside a band of the extremes, fills where declared, gaps left open, a dot for an isolated reading. The strip calls it with extra columns of context for its partial repaints; `TrendChart` calls it from its Canvas through a `CGContext` for a full redraw. The GPU tab's temperature, the Energy tab's thermals, fan and charge charts, the Disk and Network tabs, the adapter detail and the process and group detail charts all draw exactly as the Dashboard does.

**Reduction and peaks.** `TrendSeries` declares its reduction (temperature and fan speed follow the maximum) and `TrendPoint` can carry a stored peak, so the tab charts get the same mean-plus-peak band on the stored ranges the Dashboard got in #109.

**Gap threshold from the data.** A `TrendChart` with no explicit threshold reads its series' own spacing. `ChartGap.expectedSpacing` is the 90th percentile of the intervals, which follows the coarse rows when tiers mix (hour rows topped up with minute and raw rows), where a median would turn the hour rows into dots. Tests cover uniform, mixed and holed series.

**Full resolution in.** The GPU, Disk and Energy tabs load every stored row instead of thinning the history to 360 or 720 points before drawing (rule 1). `TemperatureChart` and `MetricChart` drop their own peak-per-bucket thinning, the wrapper charts hand every sample to the chart instead of the 720-bucket decimation, and the now unused `TrendChart.runs` is gone.

**Also:** `BatteryChart` moves off Swift Charts onto `TrendChart`; the menu bar panels draw the same curve; `Info.plist` carries build 217, which is the build installed for testing.

Not touched: the process performance chart (Processes tab and trace viewer), which is a separate Canvas with its own scrubber, and the fitted-axis work for power, latency and network (rule 5), listed in the audit.

Verified: `swift build`, lint clean, full suite 594 tests with no failures, and an offscreen render of the Canvas pressure chart shows the curve inside its band. The GPU page cannot be rendered offscreen (no GPU data in the harness), so the temperature chart needs the installed build to judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
