### PR TITLE
Show the 5 and 15 minute load averages on the load card, as beszel does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ Notable changes to Mac Performance Monitor. This project follows
   process and group detail charts, and the battery charge chart, which moves
   off Swift Charts. Those tabs now load every stored row rather than thinning
   the history to 360 points before drawing it, and the menu bar panels draw the
-  same curve.
+  same curve. The load average card on the Processes tab shows the 1, 5 and 15
+  minute averages together, as beszel does: the 1 minute figure as the line,
+  the slower two as fainter lines behind it, with their values in the corner.
 
 ### Security
 

--- a/Localizations/Localizable.xcstrings
+++ b/Localizations/Localizable.xcstrings
@@ -5881,6 +5881,36 @@
         }
       }
     },
+    "5 min %1$@ · 15 min %2$@" : {
+      "comment" : "Processes header: the load average card's corner label, the 5 and 15 minute averages beside the 1 minute line",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 Min. %1$@ · 15 Min. %2$@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 min %1$@ · 15 min %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 min %1$@ · 15 min %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 分钟 %1$@ · 15 分钟 %2$@"
+          }
+        }
+      }
+    },
     "6 hr" : {
       "comment" : "Identity entries: English renders the key verbatim. Present so the two tables mirror each other and English copy stays auditable in one place; check-localization.py enforces the parity.",
       "extractionState" : "manual",
@@ -45181,32 +45211,32 @@
         }
       }
     },
-    "Read straight from the kernel's load averages (the same numbers `uptime` reports). The bar shows the 1-minute load relative to your logical core count, full at one process per core." : {
+    "Read straight from the kernel's load averages (the same numbers `uptime` reports). The chart draws the 1-minute load as the line and the 5 and 15-minute averages as fainter lines behind it, with full height at one process per core." : {
       "comment" : "Metric Cards & Explanations",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Direkt aus der durchschnittlichen Auslastung des Kernels gelesen (dieselben Zahlen, die `uptime` meldet). Der Balken zeigt die 1-Minuten-Last im Verhältnis zur Zahl deiner logischen Kerne, voll bei einem Prozess pro Kern."
+            "value" : "Direkt aus der durchschnittlichen Auslastung des Kernels gelesen (dieselben Zahlen, die `uptime` meldet). Das Diagramm zeichnet die 1-Minuten-Last als Linie und die 5- und 15-Minuten-Durchschnitte als blassere Linien dahinter, wobei die volle Höhe einem Prozess pro Kern entspricht."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Read straight from the kernel's load averages (the same numbers `uptime` reports). The bar shows the 1-minute load relative to your logical core count, full at one process per core."
+            "value" : "Read straight from the kernel's load averages (the same numbers `uptime` reports). The chart draws the 1-minute load as the line and the 5 and 15-minute averages as fainter lines behind it, with full height at one process per core."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lu directement dans la charge moyenne du noyau (les mêmes chiffres que rapporte `uptime`). La barre montre la charge sur 1 minute par rapport à votre nombre de cœurs logiques, pleine à un processus par cœur."
+            "value" : "Lu directement dans la charge moyenne du noyau (les mêmes chiffres que rapporte `uptime`). Le graphique trace la charge sur 1 minute en ligne principale et les moyennes sur 5 et 15 minutes en lignes plus pâles derrière elle, la pleine hauteur correspondant à un processus par cœur."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "直接从内核的平均负载中读取（与 uptime 命令报告的数值相同）。柱状条显示相对于逻辑核心数的 1 分钟负载，每个核心对应一个进程时为满格。"
+            "value" : "直接从内核的平均负载中读取（与 uptime 命令报告的数值相同）。图表以主线绘制 1 分钟负载，并在其后以较淡的线条绘制 5 分钟和 15 分钟平均值，满高度对应每个核心一个进程。"
           }
         }
       }

--- a/Scripts/check-string-coverage.py
+++ b/Scripts/check-string-coverage.py
@@ -44,14 +44,14 @@ NOT_TRANSLATED = {
     # Units and identifiers that read the same in every language. PID, MAC and
     # the protocol names are the same list check-localization.py keeps in
     # KEEP_IN_ENGLISH.
-    "%lld ms", "± %lld ms", "80%", "fd %d · %@", "PID %d", "PID %d · UID %u",
+    "%lld ms", "± %lld ms", "fd %d · %@", "PID %d", "PID %d · UID %u",
     "%@ · PID %d", "PID %d · %@%@",
     "MTU", "MAC", "DNS", "SMB", "mDNS", "IPv4", "RAM",
     # Sample values shown as a text field's placeholder, not as copy.
     "1", "1024", "192.168.1.1", "192.168.1.254", "ABCDE12345",
     # Swift Charts series and axis identifiers: named for the code that reads
     # them back, never drawn on screen.
-    "t", "u", "c", "Segment", "Value", "Full",
+    "t", "u", "c", "Value",
 }
 
 

--- a/Sources/MacPerfMonitor/Charts/SparklineSurface.swift
+++ b/Sources/MacPerfMonitor/Charts/SparklineSurface.swift
@@ -9,6 +9,15 @@ import SwiftUI
 /// The sparkline is a bare `TrendSurfaceView` (no axes, no padding) driven
 /// through `trend`, so it scrolls by sliding pixels like the page's charts
 /// instead of restroking its whole path four times a second.
+/// A secondary line drawn on a card strip in the strip's own tint, fainter and
+/// thinner than the main one: the 5 and 15 minute load averages beside the
+/// 1 minute line, the way beszel shows load.
+struct MetricCardCompanion {
+    var column: LiveColumn
+    var alpha: CGFloat
+    var lineWidth: CGFloat = 1.2
+}
+
 final class MetricCardFeed {
     private(set) var value: String?
 
@@ -28,7 +37,7 @@ final class MetricCardFeed {
     func publish(
         value: String?, tint: NSColor, column: LiveColumn?, scale: Double = 1,
         xDomain: ClosedRange<Date>?, yDomain: ClosedRange<Double>?, peak: String? = nil,
-        reduction: TrendSurfaceSeries.Reduction = .mean
+        reduction: TrendSurfaceSeries.Reduction = .mean, companions: [MetricCardCompanion] = []
     ) {
         self.value = value
         self.peak = peak
@@ -40,11 +49,17 @@ final class MetricCardFeed {
         var model = TrendModel()
         model.bare = true
         if let column {
-            model.series = [
+            // Companions go first so the main line is drawn over them.
+            model.series = companions.map { companion in
+                TrendSurfaceSeries(
+                    column: companion.column, scale: scale,
+                    color: Color(nsColor: tint.withAlphaComponent(companion.alpha)),
+                    lineWidth: companion.lineWidth, reduction: reduction, band: false)
+            }
+            model.series.append(
                 TrendSurfaceSeries(
                     column: column, scale: scale, color: Color(nsColor: tint), lineWidth: 1.5,
-                    reduction: reduction)
-            ]
+                    reduction: reduction))
         }
         model.xDomain = xDomain
         model.yDomain = yDomain

--- a/Sources/MacPerfMonitor/Charts/TrendSurface.swift
+++ b/Sources/MacPerfMonitor/Charts/TrendSurface.swift
@@ -24,6 +24,10 @@ struct TrendSurfaceSeries {
     var filled = false
     var lineWidth: CGFloat = 2
     var reduction: Reduction = .mean
+    /// Whether the spread of each bucket is drawn behind the line. Off for a
+    /// companion line (the 5 and 15 minute load averages beside the 1 minute
+    /// one), where three overlapping bands would only muddy the strip.
+    var band = true
 }
 
 /// What a live chart surface draws: the same inputs as `TrendChart`, as a
@@ -1000,7 +1004,7 @@ enum TrendRenderer {
         // and the spread goes behind it as a band, instead of a spike per
         // column that turns a busy metric into a solid block.
         let aggregated = extremes.contains(where: \.isAggregate) || smoothing > 1
-        if aggregated {
+        if aggregated, s.band {
             drawBand(extremes, width: bucketWidth, color: color, x: x, y: y, context: ctx)
         }
         let line = TrendRenderer.smoothed(

--- a/Sources/MacPerfMonitor/Views/MetricCard.swift
+++ b/Sources/MacPerfMonitor/Views/MetricCard.swift
@@ -856,7 +856,9 @@ enum CPUMetrics {
 
                 unit: .percent,
                 detail: cpu.map {
-                    String(format: "%.2f · %.2f", $0.loadAverage5, $0.loadAverage15)
+                    t(
+                        "5 min %1$@ · 15 min %2$@", String(format: "%.2f", $0.loadAverage5),
+                        String(format: "%.2f", $0.loadAverage15))
                 },
                 help:
                     "Processes competing to run, averaged over 1 minute (5 and 15-minute alongside). Click for details.",
@@ -864,7 +866,7 @@ enum CPUMetrics {
                     meaning:
                         "The run-queue length (roughly how many processes are competing to run) averaged over the last minute, with the 5 and 15-minute figures beside it. A load near your core count (\(coreCount > 0 ? String(coreCount) : "the number of cores")) means the CPU is fully subscribed; well above it means work is queuing.",
                     calculation:
-                        "Read straight from the kernel's load averages (the same numbers `uptime` reports). The bar shows the 1-minute load relative to your logical core count, full at one process per core."
+                        "Read straight from the kernel's load averages (the same numbers `uptime` reports). The chart draws the 1-minute load as the line and the 5 and 15-minute averages as fainter lines behind it, with full height at one process per core."
                 )
             ),
         ]

--- a/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
+++ b/Sources/MacPerfMonitor/Views/SystemHeaderView.swift
@@ -208,10 +208,15 @@ final class ProcessHeaderStore: ObservableObject {
     static let headerSpan: TimeInterval = 10 * 60
 
     /// Load average has no column in the history window, so the header keeps its
-    /// own ring of samples over the same span. That is what lets the load card
-    /// be a chart like its neighbours instead of the odd bar out.
+    /// own rings of samples over the same span. That is what lets the load card
+    /// be a chart like its neighbours instead of the odd bar out. All three
+    /// averages are kept: the 1 minute figure is the line, and the 5 and 15
+    /// minute figures ride behind it as fainter companions, the way beszel
+    /// draws load, so a spike and the trend it sits on read together.
     private var loadTimes: [Double] = []
     private var loadValues: [Double] = []
+    private var load5Values: [Double] = []
+    private var load15Values: [Double] = []
     let usageFeed = MetricCardFeed()
     let loadFeed = MetricCardFeed()
     let coreFeed = CoreGridFeed()
@@ -248,21 +253,35 @@ final class ProcessHeaderStore: ObservableObject {
             let now = Date().timeIntervalSinceReferenceDate
             loadTimes.append(now)
             loadValues.append(cpu.loadAverage1)
+            load5Values.append(cpu.loadAverage5)
+            load15Values.append(cpu.loadAverage15)
             let cutoff = now - Self.headerSpan
             if let keep = loadTimes.firstIndex(where: { $0 >= cutoff }), keep > 0 {
                 loadTimes.removeFirst(keep)
                 loadValues.removeFirst(keep)
+                load5Values.removeFirst(keep)
+                load15Values.removeFirst(keep)
             }
         }
         let loadColumn = LiveColumn(times: loadTimes[...], values: loadValues[...])
+        let load5Column = LiveColumn(times: loadTimes[...], values: load5Values[...])
+        let load15Column = LiveColumn(times: loadTimes[...], values: load15Values[...])
         // Full height is one process per core, so the chart reads as "how close
         // to fully subscribed", and it stretches when load goes past that.
-        let loadTop = max(Double(cpu?.cores.count ?? 0), loadColumn.range?.max ?? 0, 1)
+        let loadTop = max(
+            Double(cpu?.cores.count ?? 0), loadColumn.range?.max ?? 0,
+            load5Column.range?.max ?? 0, load15Column.range?.max ?? 0, 1)
         loadFeed.publish(
             value: cpu.map { String(format: "%.2f", $0.loadAverage1) },
             tint: NSColor(CPUMetrics.loadColor(cpu)), column: loadColumn, scale: 1,
             xDomain: window.xDomain, yDomain: 0...loadTop,
-            peak: loadColumn.range.map { t("peak %@", String(format: "%.2f", $0.max)) })
+            peak: loadColumn.range.map { t("peak %@", String(format: "%.2f", $0.max)) },
+            // The card's second line labels these two, so the fainter lines
+            // read without a legend the strip has no room for.
+            companions: [
+                MetricCardCompanion(column: load5Column, alpha: 0.6, lineWidth: 1.2),
+                MetricCardCompanion(column: load15Column, alpha: 0.35, lineWidth: 1),
+            ])
         // The bars show the sample as measured. The cards above them stay
         // smoothed: a jittering percentage is unreadable, a still core grid is
         // uninformative.


### PR DESCRIPTION
The Processes header's load average card drew the 1 minute average alone. Neil asked for all three, the way beszel shows load.

- `MetricCardFeed` takes companion lines: extra columns drawn in the strip's own tint, fainter and thinner, under the main line and without a band of their own (`TrendSurfaceSeries.band`), so three overlapping spreads do not muddy a strip a few dozen points tall.
- The header keeps rings for the 5 and 15 minute averages beside the 1 minute one and publishes them as companions at 60 and 35 percent opacity. The axis top follows the highest of the three.
- The card's second line already carried the 5 and 15 minute values with no label; it now says which is which, and the card's explanation describes the chart rather than the bar it replaced. New catalog entries in German, French and Simplified Chinese; the coverage check passes with nothing uncarried.
- The string coverage allowlist drops three keys the compiler stopped emitting when the battery chart left Swift Charts in #110.

Verified: `swift build`, lint clean, `Scripts/check-string-coverage.py` clean. The offscreen harness has no header history, so the three lines need the installed build to judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
