### PR TITLE
Build 219: the installed test build records load averages and has the new detail sheets

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>218</string>
+	<string>219</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSMultipleInstancesProhibited</key>


### PR DESCRIPTION
Records the build number the install script produced for the copy now in /Applications (#113 included), so the branch matches the installed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3VXPHeapBsngrkjxvsQAQ
